### PR TITLE
Fix webhook checkbox events not being captured

### DIFF
--- a/frontend/src/components/ui/checkbox/Checkbox.vue
+++ b/frontend/src/components/ui/checkbox/Checkbox.vue
@@ -1,22 +1,41 @@
 <script setup lang="ts">
-import type { CheckboxRootEmits, CheckboxRootProps } from "reka-ui"
 import type { HTMLAttributes } from "vue"
-import { reactiveOmit } from "@vueuse/core"
 import { CheckIcon } from '@radix-icons/vue'
-import { CheckboxIndicator, CheckboxRoot, useForwardPropsEmits } from "reka-ui"
+import { CheckboxIndicator, CheckboxRoot } from "reka-ui"
 import { cn } from "@/lib/utils"
 
-const props = defineProps<CheckboxRootProps & { class?: HTMLAttributes["class"] }>()
-const emits = defineEmits<CheckboxRootEmits>()
+type CheckedState = boolean | 'indeterminate'
 
-const delegatedProps = reactiveOmit(props, "class")
+const props = defineProps<{
+  checked?: CheckedState
+  defaultChecked?: CheckedState
+  disabled?: boolean
+  required?: boolean
+  name?: string
+  value?: string
+  id?: string
+  class?: HTMLAttributes["class"]
+}>()
 
-const forwarded = useForwardPropsEmits(delegatedProps, emits)
+const emits = defineEmits<{
+  'update:checked': [value: CheckedState]
+}>()
+
+function handleChange(value: CheckedState) {
+  emits('update:checked', value)
+}
 </script>
 
 <template>
   <CheckboxRoot
-    v-bind="forwarded"
+    :model-value="props.checked"
+    :default-value="props.defaultChecked"
+    :disabled="props.disabled"
+    :required="props.required"
+    :name="props.name"
+    :value="props.value"
+    :id="props.id"
+    @update:model-value="handleChange"
     :class="
       cn('grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
          props.class)"

--- a/frontend/src/views/settings/WebhooksView.vue
+++ b/frontend/src/views/settings/WebhooksView.vue
@@ -206,12 +206,16 @@ function removeHeader(key: string) {
   delete formData.value.headers[key]
 }
 
-function toggleEvent(eventValue: string) {
-  const index = formData.value.events.indexOf(eventValue)
-  if (index > -1) {
-    formData.value.events.splice(index, 1)
+function toggleEvent(eventValue: string, checked: boolean | 'indeterminate') {
+  if (checked === true) {
+    if (!formData.value.events.includes(eventValue)) {
+      formData.value.events.push(eventValue)
+    }
   } else {
-    formData.value.events.push(eventValue)
+    const index = formData.value.events.indexOf(eventValue)
+    if (index > -1) {
+      formData.value.events.splice(index, 1)
+    }
   }
 }
 
@@ -388,7 +392,7 @@ onMounted(() => {
                 <Checkbox
                   :id="event.value"
                   :checked="formData.events.includes(event.value)"
-                  @update:checked="toggleEvent(event.value)"
+                  @update:checked="(checked) => toggleEvent(event.value, checked)"
                 />
                 <div class="grid gap-0.5">
                   <Label :for="event.value" class="cursor-pointer">{{ event.label }}</Label>


### PR DESCRIPTION
## Summary
- Fixes the Checkbox component to properly emit `update:checked` events instead of using `useForwardPropsEmits` which wasn't capturing state correctly
- Updates WebhooksView to pass the checked state directly to `toggleEvent` for reliable event selection

Fixes #23

## Test plan
- [x] Navigate to Settings > Webhooks
- [x] Click "Add Webhook"
- [x] Fill in name and URL, select event checkboxes
- [x] Verify webhook is created successfully with selected events
- [x] Verify editing existing webhooks preserves checkbox state