### PR TITLE
fix: Make commands to use server flag set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ embed-frontend:
 
 # Run the backend locally
 run:
-	$(GOCMD) run $(BINARY_PATH)/main.go -config config.toml
+	$(GOCMD) run $(BINARY_PATH)/main.go server -config config.toml
 
 # Run with migrations
 run-migrate:
-	$(GOCMD) run $(BINARY_PATH)/main.go -config config.toml -migrate
+	$(GOCMD) run $(BINARY_PATH)/main.go server -config config.toml -migrate
 
 # Run tests
 test:
@@ -85,7 +85,7 @@ docker-restart:
 
 # Database migrations
 migrate:
-	$(GOCMD) run $(BINARY_PATH)/main.go -config config.toml -migrate
+	$(GOCMD) run $(BINARY_PATH)/main.go server -config config.toml -migrate
 
 # Frontend commands
 frontend-install:


### PR DESCRIPTION
This pull request adjusts the make commands to the `server` flag set. 