### PR TITLE
[docs] fix env variables names

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -61,11 +61,11 @@ Configuration values can be overridden using environment variables:
 | Variable | Description |
 |----------|-------------|
 | `WHATOMATE_ENV` | Environment (development/production) |
-| `WHATOMATE_DB_HOST` | Database host |
-| `WHATOMATE_DB_PORT` | Database port |
-| `WHATOMATE_DB_USER` | Database user |
-| `WHATOMATE_DB_PASSWORD` | Database password |
-| `WHATOMATE_DB_NAME` | Database name |
+| `WHATOMATE_DATABASE_HOST` | Database host |
+| `WHATOMATE_DATABASE_PORT` | Database port |
+| `WHATOMATE_DATABASE_USER` | Database user |
+| `WHATOMATE_DATABASE_PASSWORD` | Database password |
+| `WHATOMATE_DATABASE_NAME` | Database name |
 | `WHATOMATE_REDIS_HOST` | Redis host |
 | `WHATOMATE_REDIS_PORT` | Redis port |
 | `WHATOMATE_JWT_SECRET` | JWT signing secret |


### PR DESCRIPTION
Currently variables names within the docs don't match with toml defined ones.