### PR TITLE
fix: Address code scanning security alerts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/frontend/e2e/pages/DialogPage.ts
+++ b/frontend/e2e/pages/DialogPage.ts
@@ -1,6 +1,11 @@
 import { Page, Locator, expect } from '@playwright/test'
 import { BasePage } from './BasePage'
 
+// Escape special characters in CSS selectors (backslashes must be escaped first)
+function escapeCssSelector(id: string): string {
+  return id.replace(/\\/g, '\\\\').replace(/\./g, '\\.')
+}
+
 export class DialogPage extends BasePage {
   readonly dialog: Locator
   readonly cancelButton: Locator
@@ -100,7 +105,7 @@ export class DialogPage extends BasePage {
     if (labelFor) {
       // Checkbox has id matching label's for attribute
       // Need to escape dots in ID for CSS selector
-      const escapedId = labelFor.replace(/\./g, '\\.')
+      const escapedId = escapeCssSelector(labelFor)
       checkbox = this.dialog.locator(`#${escapedId}`)
     } else {
       // Checkbox is sibling of label in same container
@@ -120,7 +125,7 @@ export class DialogPage extends BasePage {
 
     let checkbox: Locator
     if (labelFor) {
-      const escapedId = labelFor.replace(/\./g, '\\.')
+      const escapedId = escapeCssSelector(labelFor)
       checkbox = this.dialog.locator(`#${escapedId}`)
     } else {
       checkbox = labelLocator.locator('..').locator('button[role="checkbox"], input[type="checkbox"]')


### PR DESCRIPTION
- sso.go: Add sanitizeRedirectPath() to prevent open redirect attacks by stripping dangerous characters (// and /\) from redirect paths

- DialogPage.ts: Fix incomplete CSS selector escaping by also escaping backslash characters (not just dots)

- GitHub Actions: Add explicit permissions (contents: read) to test.yml and e2e-tests.yml workflows for security best practices