### PR TITLE
feat: make default admin credentials configurable via config.toml

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -131,7 +131,7 @@ func runServer(args []string) {
 
 	// Run migrations if requested
 	if *migrate {
-		if err := database.RunMigrationWithProgress(db); err != nil {
+		if err := database.RunMigrationWithProgress(db, &cfg.DefaultAdmin); err != nil {
 			lo.Fatal("Migration failed", "error", err)
 		}
 	}

--- a/config.example.toml
+++ b/config.example.toml
@@ -45,3 +45,9 @@ s3_bucket = ""
 s3_region = ""
 s3_key = ""
 s3_secret = ""
+
+# Default admin credentials (only used during initial setup when no users exist)
+[default_admin]
+email = "admin@admin.com"
+password = "admin"
+full_name = "Admin"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,14 +11,15 @@ import (
 
 // Config holds all configuration for the application
 type Config struct {
-	App      AppConfig      `koanf:"app"`
-	Server   ServerConfig   `koanf:"server"`
-	Database DatabaseConfig `koanf:"database"`
-	Redis    RedisConfig    `koanf:"redis"`
-	JWT      JWTConfig      `koanf:"jwt"`
-	WhatsApp WhatsAppConfig `koanf:"whatsapp"`
-	AI       AIConfig       `koanf:"ai"`
-	Storage  StorageConfig  `koanf:"storage"`
+	App           AppConfig           `koanf:"app"`
+	Server        ServerConfig        `koanf:"server"`
+	Database      DatabaseConfig      `koanf:"database"`
+	Redis         RedisConfig         `koanf:"redis"`
+	JWT           JWTConfig           `koanf:"jwt"`
+	WhatsApp      WhatsAppConfig      `koanf:"whatsapp"`
+	AI            AIConfig            `koanf:"ai"`
+	Storage       StorageConfig       `koanf:"storage"`
+	DefaultAdmin  DefaultAdminConfig  `koanf:"default_admin"`
 }
 
 type AppConfig struct {
@@ -79,6 +80,12 @@ type StorageConfig struct {
 	S3Region  string `koanf:"s3_region"`
 	S3Key     string `koanf:"s3_key"`
 	S3Secret  string `koanf:"s3_secret"`
+}
+
+type DefaultAdminConfig struct {
+	Email    string `koanf:"email"`
+	Password string `koanf:"password"`
+	FullName string `koanf:"full_name"`
 }
 
 // Load loads configuration from file and environment variables
@@ -165,5 +172,15 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Storage.LocalPath == "" {
 		cfg.Storage.LocalPath = "./uploads"
+	}
+	// Default admin credentials (only used during initial setup)
+	if cfg.DefaultAdmin.Email == "" {
+		cfg.DefaultAdmin.Email = "admin@admin.com"
+	}
+	if cfg.DefaultAdmin.Password == "" {
+		cfg.DefaultAdmin.Password = "admin"
+	}
+	if cfg.DefaultAdmin.FullName == "" {
+		cfg.DefaultAdmin.FullName = "Admin"
 	}
 }


### PR DESCRIPTION
## Summary                                                                                                                              
  This PR makes the default admin user credentials configurable via `config.toml` or environment variables, instead of being hardcoded in 
  the application code.                                                                                                                   
                                                                                                                                          
## Motivation                                                                                                                           
  Previously, default admin credentials (`admin@admin.com` / `admin`) were hardcoded in `internal/database/postgres.go`. This made it     
  difficult to customize credentials for different deployments and increased the risk of forgetting to change default passwords in        
  production.                                                                                                                             
                                                                                                                                          
## Changes                                                                                                                              
  - **`internal/config/config.go`**: Added `DefaultAdminConfig` struct with defaults                                                      
  - **`internal/database/postgres.go`**: Updated `RunMigrationWithProgress` and `CreateDefaultAdmin` to accept config parameter           
  - **`cmd/whatomate/main.go`**: Pass admin config to migration function                                                                  
  - **`config.example.toml`**: Added `[default_admin]` section documentation                                                               
                                                                                                                                          
  ## Usage                                                                                                                                
                                                                                                                                          
  Add to `config.toml`:                                                                                                                   
  ```toml                                                                                                                                 
  [default_admin]                                                                                                                         
  email = "admin@mycompany.com"                                                                                                           
  password = "secure-password"                                                                                                            
  full_name = "Administrator"                                                                                                             
                                                                                                                                          
  Or via environment variables:                                                                                                           
  WHATOMATE_DEFAULT_ADMIN_EMAIL=admin@mycompany.com                                                                                       
  WHATOMATE_DEFAULT_ADMIN_PASSWORD=secure-password                                                                                        
  WHATOMATE_DEFAULT_ADMIN_FULL_NAME="Administrator"                                                                                       
                                                                                                                                    