### PR TITLE
WhatsApp Business Profile Implementation

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -483,6 +483,7 @@ func setupRoutes(g *fastglue.Fastglue, app *handlers.App, lo logf.Logger, basePa
 	g.POST("/api/accounts/{id}/test", app.TestAccountConnection)
 	g.GET("/api/accounts/{id}/business_profile", app.GetBusinessProfile)
 	g.PUT("/api/accounts/{id}/business_profile", app.UpdateBusinessProfile)
+	g.POST("/api/accounts/{id}/business_profile/photo", app.UpdateProfilePicture)
 
 	// Contacts
 	g.GET("/api/contacts", app.ListContacts)

--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -481,6 +481,8 @@ func setupRoutes(g *fastglue.Fastglue, app *handlers.App, lo logf.Logger, basePa
 	g.PUT("/api/accounts/{id}", app.UpdateAccount)
 	g.DELETE("/api/accounts/{id}", app.DeleteAccount)
 	g.POST("/api/accounts/{id}/test", app.TestAccountConnection)
+	g.GET("/api/accounts/{id}/business_profile", app.GetBusinessProfile)
+	g.PUT("/api/accounts/{id}/business_profile", app.UpdateBusinessProfile)
 
 	// Contacts
 	g.GET("/api/contacts", app.ListContacts)

--- a/frontend/e2e/pages/AccountsPage.ts
+++ b/frontend/e2e/pages/AccountsPage.ts
@@ -62,7 +62,7 @@ export class AccountsPage extends BasePage {
 
   // Card helpers
   getAccountCard(name: string): Locator {
-    return this.page.locator('.rounded-lg.border').filter({ hasText: name })
+    return this.page.locator('.account-card').filter({ hasText: name })
   }
 
   async editAccount(name: string) {

--- a/frontend/e2e/pages/AccountsPage.ts
+++ b/frontend/e2e/pages/AccountsPage.ts
@@ -18,6 +18,10 @@ export class AccountsPage extends BasePage {
     this.alertDialog = page.locator('[role="alertdialog"]')
   }
 
+  get profileDialog() {
+    return this.page.locator('[role="dialog"][data-state="open"]').filter({ hasText: 'Business Profile' })
+  }
+
   async goto() {
     await this.page.goto('/settings/accounts')
     await this.page.waitForLoadState('networkidle')
@@ -78,6 +82,14 @@ export class AccountsPage extends BasePage {
     await this.alertDialog.waitFor({ state: 'visible' })
   }
 
+  async openBusinessProfile(name: string) {
+    const card = this.getAccountCard(name)
+    await expect(card).toBeVisible({ timeout: 10000 })
+    // Profile button has svg with text-emerald-500 class
+    await card.locator('button').filter({ has: this.page.locator('svg.text-emerald-500') }).click()
+    await this.profileDialog.waitFor({ state: 'visible' })
+  }
+
   async testConnection(name: string) {
     const card = this.getAccountCard(name)
     await card.getByRole('button', { name: /Test/i }).click()
@@ -121,6 +133,12 @@ export class AccountsPage extends BasePage {
 
   async expectDialogVisible() {
     await expect(this.dialog).toBeVisible()
+  }
+
+  async expectProfileDialogVisible() {
+    await expect(this.profileDialog).toBeVisible()
+    await expect(this.profileDialog.locator('input#about')).toBeVisible()
+    await expect(this.profileDialog.locator('textarea#description')).toBeVisible()
   }
 
   async expectDialogHidden() {

--- a/frontend/e2e/tests/settings/whatsapp-business-profile.spec.ts
+++ b/frontend/e2e/tests/settings/whatsapp-business-profile.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('WhatsApp Business Profile', () => {
+    test.beforeEach(async ({ page }) => {
+        // Login as admin
+        await page.goto('/login');
+        await page.fill('input[type="email"]', 'admin@example.com');
+        await page.fill('input[type="password"]', 'password');
+        await page.click('button[type="submit"]');
+        await expect(page).toHaveURL('/dashboard');
+    });
+
+    test('should view business profile', async ({ page }) => {
+        await page.goto('/settings/accounts');
+        
+        // Wait for accounts to load
+        await expect(page.locator('h1')).toContainText('WhatsApp Accounts');
+        
+        // Find the "Store" button (Business Profile) and click it
+        // Assuming at least one account exists
+        const profileButton = page.locator('button:has(svg.text-emerald-500)').first();
+        await expect(profileButton).toBeVisible();
+        await profileButton.click();
+        
+        // Check if dialog opens
+        await expect(page.locator('div[role="dialog"]')).toBeVisible();
+        await expect(page.locator('h2')).toContainText('Business Profile');
+        
+        // Check if fields are present
+        await expect(page.locator('input#about')).toBeVisible();
+        await expect(page.locator('textarea#description')).toBeVisible();
+        await expect(page.locator('input#email')).toBeVisible();
+        await expect(page.locator('input#address')).toBeVisible();
+    });
+});

--- a/frontend/e2e/tests/settings/whatsapp-business-profile.spec.ts
+++ b/frontend/e2e/tests/settings/whatsapp-business-profile.spec.ts
@@ -1,35 +1,88 @@
 import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../../helpers';
+import { AccountsPage } from '../../pages';
 
 test.describe('WhatsApp Business Profile', () => {
+    let accountsPage: AccountsPage;
+
     test.beforeEach(async ({ page }) => {
-        // Login as admin
-        await page.goto('/login');
-        await page.fill('input[type="email"]', 'admin@example.com');
-        await page.fill('input[type="password"]', 'password');
-        await page.click('button[type="submit"]');
-        await expect(page).toHaveURL('/dashboard');
+        await loginAsAdmin(page);
+        accountsPage = new AccountsPage(page);
+
+        // Mock the GET /accounts to ensure we have a test subject
+        await page.route('**/api/accounts', async route => {
+            if (route.request().method() === 'GET') {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        data: {
+                            accounts: [{
+                                id: 'test-acc-id',
+                                name: 'Test Account',
+                                phone_id: '123456',
+                                business_id: '789012',
+                                status: 'active'
+                            }]
+                        }
+                    })
+                });
+            } else {
+                await route.continue();
+            }
+        });
+
+        // Mock GET profile
+        await page.route('**/api/accounts/*/business_profile*', async route => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    data: [{
+                        about: 'Available',
+                        address: '123 Test St',
+                        description: 'Test Business',
+                        email: 'test@example.com',
+                        vertical: 'PROF_SERVICES',
+                        websites: ['https://example.com'],
+                        profile_picture_url: ''
+                    }]
+                })
+            });
+        });
+
+        await accountsPage.goto();
     });
 
-    test('should view business profile', async ({ page }) => {
-        await page.goto('/settings/accounts');
-        
-        // Wait for accounts to load
-        await expect(page.locator('h1')).toContainText('WhatsApp Accounts');
-        
-        // Find the "Store" button (Business Profile) and click it
-        // Assuming at least one account exists
-        const profileButton = page.locator('button:has(svg.text-emerald-500)').first();
-        await expect(profileButton).toBeVisible();
-        await profileButton.click();
-        
-        // Check if dialog opens
-        await expect(page.locator('div[role="dialog"]')).toBeVisible();
-        await expect(page.locator('h2')).toContainText('Business Profile');
-        
-        // Check if fields are present
-        await expect(page.locator('input#about')).toBeVisible();
-        await expect(page.locator('textarea#description')).toBeVisible();
-        await expect(page.locator('input#email')).toBeVisible();
-        await expect(page.locator('input#address')).toBeVisible();
+    test('should view business profile dialog', async () => {
+        await accountsPage.expectPageVisible();
+        await accountsPage.openBusinessProfile('Test Account');
+        await accountsPage.expectProfileDialogVisible();
+
+        // Verify fields contain mocked data
+        await expect(accountsPage.profileDialog.locator('input#about')).toHaveValue('Available');
+        await expect(accountsPage.profileDialog.locator('input#email')).toHaveValue('test@example.com');
+    });
+
+    test('should update business profile', async ({ page }) => {
+        await accountsPage.openBusinessProfile('Test Account');
+
+        // Mock PUT request
+        await page.route('**/api/accounts/*/business_profile', async route => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    data: { success: true }
+                })
+            });
+        });
+
+        // Change value
+        await accountsPage.profileDialog.locator('input#about').fill('Busy');
+        await accountsPage.profileDialog.getByRole('button', { name: 'Save Changes' }).click();
+
+        // Verify success toast
+        await accountsPage.expectToast(/updated successfully/i);
     });
 });

--- a/frontend/e2e/tests/settings/whatsapp-business-profile.spec.ts
+++ b/frontend/e2e/tests/settings/whatsapp-business-profile.spec.ts
@@ -38,7 +38,7 @@ test.describe('WhatsApp Business Profile', () => {
                 status: 200,
                 contentType: 'application/json',
                 body: JSON.stringify({
-                    data: [{
+                    data: {
                         about: 'Available',
                         address: '123 Test St',
                         description: 'Test Business',
@@ -46,7 +46,7 @@ test.describe('WhatsApp Business Profile', () => {
                         vertical: 'PROF_SERVICES',
                         websites: ['https://example.com'],
                         profile_picture_url: ''
-                    }]
+                    }
                 })
             });
         });

--- a/frontend/src/components/shared/CrudFormDialog.vue
+++ b/frontend/src/components/shared/CrudFormDialog.vue
@@ -78,7 +78,7 @@ import { computed } from 'vue'
 
 <template>
   <Dialog v-model:open="open">
-    <DialogContent :class="maxWidth">
+    <DialogContent :class="[maxWidth, 'max-h-[90vh] overflow-y-auto']">
       <DialogHeader>
         <DialogTitle>{{ computedTitle }}</DialogTitle>
         <DialogDescription>{{ computedDescription }}</DialogDescription>

--- a/frontend/src/views/settings/AccountsView.vue
+++ b/frontend/src/views/settings/AccountsView.vue
@@ -51,7 +51,8 @@ import {
   AlertCircle,
   CheckCircle2,
   Settings2,
-  TestTube2
+  TestTube2,
+  Store
 } from 'lucide-vue-next'
 
 interface WhatsAppAccount {

--- a/frontend/src/views/settings/AccountsView.vue
+++ b/frontend/src/views/settings/AccountsView.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+w<script setup lang="ts">
 import { ref, onMounted, watch } from 'vue'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -82,10 +82,6 @@ interface TestResult {
   verified_name?: string
   quality_rating?: string
   messaging_limit_tier?: string
-  code_verification_status?: string
-  account_mode?: string
-  is_test_number?: boolean
-  warning?: string
 }
 
 import BusinessProfileDialog from './BusinessProfileDialog.vue'
@@ -369,15 +365,10 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                     <span :class="['px-2 py-0.5 text-xs font-medium rounded-full', getStatusBadgeClass(account.status)]">
                       {{ account.status }}
                     </span>
-                    <!-- Test Number Badge -->
-                    <Badge v-if="testResults[account.id]?.is_test_number" variant="outline" class="border-amber-600 text-amber-600 light:border-amber-500 light:text-amber-700">
-                      <TestTube2 class="h-3 w-3 mr-1" />
-                      Test Number
-                    </Badge>
                   </div>
 
                   <!-- Test Result -->
-                  <div v-if="testResults[account.id]" class="mt-2 space-y-2">
+                  <div v-if="testResults[account.id]" class="mt-2">
                     <div v-if="testResults[account.id].success" class="flex items-center gap-2 text-green-400 light:text-green-600">
                       <CheckCircle2 class="h-4 w-4" />
                       <span class="text-sm font-medium">Connected</span>
@@ -388,11 +379,6 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                     <div v-else class="flex items-center gap-2 text-red-400 light:text-red-600">
                       <X class="h-4 w-4" />
                       <span class="text-sm">{{ testResults[account.id].error }}</span>
-                    </div>
-                    <!-- Warning Message for Test Numbers -->
-                    <div v-if="testResults[account.id].warning" class="flex items-start gap-2 p-2 rounded-lg bg-amber-950/50 light:bg-amber-50 border border-amber-800 light:border-amber-200">
-                      <AlertCircle class="h-4 w-4 text-amber-400 light:text-amber-600 mt-0.5 flex-shrink-0" />
-                      <span class="text-sm text-amber-300 light:text-amber-700">{{ testResults[account.id].warning }}</span>
                     </div>
                   </div>
 

--- a/frontend/src/views/settings/AccountsView.vue
+++ b/frontend/src/views/settings/AccountsView.vue
@@ -352,7 +352,7 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
         </Card>
 
         <!-- Account Cards -->
-        <div v-for="account in accounts" :key="account.id" class="card-interactive rounded-xl border border-white/[0.08] bg-white/[0.02] light:bg-white light:border-gray-200">
+        <div v-for="account in accounts" :key="account.id" class="account-card card-interactive rounded-xl border border-white/[0.08] bg-white/[0.02] light:bg-white light:border-gray-200">
           <div class="p-6">
             <div class="flex items-start justify-between">
               <div class="flex items-start gap-4">

--- a/frontend/src/views/settings/AccountsView.vue
+++ b/frontend/src/views/settings/AccountsView.vue
@@ -1,4 +1,4 @@
-w<script setup lang="ts">
+<script setup lang="ts">
 import { ref, onMounted, watch } from 'vue'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'

--- a/frontend/src/views/settings/AccountsView.vue
+++ b/frontend/src/views/settings/AccountsView.vue
@@ -50,7 +50,8 @@ import {
   ExternalLink,
   AlertCircle,
   CheckCircle2,
-  Settings2
+  Settings2,
+  TestTube2
 } from 'lucide-vue-next'
 
 interface WhatsAppAccount {
@@ -80,7 +81,13 @@ interface TestResult {
   verified_name?: string
   quality_rating?: string
   messaging_limit_tier?: string
+  code_verification_status?: string
+  account_mode?: string
+  is_test_number?: boolean
+  warning?: string
 }
+
+import BusinessProfileDialog from './BusinessProfileDialog.vue'
 
 const organizationsStore = useOrganizationsStore()
 
@@ -93,6 +100,15 @@ const testingAccountId = ref<string | null>(null)
 const testResults = ref<Record<string, TestResult>>({})
 const deleteDialogOpen = ref(false)
 const accountToDelete = ref<WhatsAppAccount | null>(null)
+
+// Business Profile Dialog State
+const isProfileDialogOpen = ref(false)
+const profileAccount = ref<WhatsAppAccount | null>(null)
+
+function openProfileDialog(account: WhatsAppAccount) {
+  profileAccount.value = account
+  isProfileDialogOpen.value = true
+}
 
 const formData = ref({
   name: '',
@@ -308,7 +324,7 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
             </div>
           </div>
         </div>
-        </div>
+      </div>
       </div>
     </ScrollArea>
 
@@ -352,10 +368,15 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                     <span :class="['px-2 py-0.5 text-xs font-medium rounded-full', getStatusBadgeClass(account.status)]">
                       {{ account.status }}
                     </span>
+                    <!-- Test Number Badge -->
+                    <Badge v-if="testResults[account.id]?.is_test_number" variant="outline" class="border-amber-600 text-amber-600 light:border-amber-500 light:text-amber-700">
+                      <TestTube2 class="h-3 w-3 mr-1" />
+                      Test Number
+                    </Badge>
                   </div>
 
                   <!-- Test Result -->
-                  <div v-if="testResults[account.id]" class="mt-2">
+                  <div v-if="testResults[account.id]" class="mt-2 space-y-2">
                     <div v-if="testResults[account.id].success" class="flex items-center gap-2 text-green-400 light:text-green-600">
                       <CheckCircle2 class="h-4 w-4" />
                       <span class="text-sm font-medium">Connected</span>
@@ -366,6 +387,11 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                     <div v-else class="flex items-center gap-2 text-red-400 light:text-red-600">
                       <X class="h-4 w-4" />
                       <span class="text-sm">{{ testResults[account.id].error }}</span>
+                    </div>
+                    <!-- Warning Message for Test Numbers -->
+                    <div v-if="testResults[account.id].warning" class="flex items-start gap-2 p-2 rounded-lg bg-amber-950/50 light:bg-amber-50 border border-amber-800 light:border-amber-200">
+                      <AlertCircle class="h-4 w-4 text-amber-400 light:text-amber-600 mt-0.5 flex-shrink-0" />
+                      <span class="text-sm text-amber-300 light:text-amber-700">{{ testResults[account.id].warning }}</span>
                     </div>
                   </div>
 
@@ -393,8 +419,8 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                     <div class="flex items-center gap-2">
                       <span class="text-white/50 light:text-gray-500">Access Token:</span>
                       <Badge
-                        variant="outline"
-                        :class="account.has_access_token ? 'border-green-600 text-green-600' : 'border-destructive text-destructive'"
+                          variant="outline"
+                          :class="account.has_access_token ? 'border-green-600 text-green-600' : 'border-destructive text-destructive'"
                       >
                         {{ account.has_access_token ? 'Configured' : 'Missing' }}
                       </Badge>
@@ -402,8 +428,8 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                     <div class="flex items-center gap-2">
                       <span class="text-white/50 light:text-gray-500">App Secret:</span>
                       <Badge
-                        variant="outline"
-                        :class="account.has_app_secret ? 'border-green-600 text-green-600' : 'border-yellow-600 text-yellow-600'"
+                          variant="outline"
+                          :class="account.has_app_secret ? 'border-green-600 text-green-600' : 'border-yellow-600 text-yellow-600'"
                       >
                         {{ account.has_app_secret ? 'Configured' : 'Not Set' }}
                       </Badge>
@@ -442,10 +468,10 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
               <!-- Actions -->
               <div class="flex items-center gap-1">
                 <Button
-                  variant="ghost"
-                  size="sm"
-                  @click="testConnection(account)"
-                  :disabled="testingAccountId === account.id"
+                    variant="ghost"
+                    size="sm"
+                    @click="testConnection(account)"
+                    :disabled="testingAccountId === account.id"
                 >
                   <Loader2 v-if="testingAccountId === account.id" class="h-4 w-4 animate-spin" />
                   <RefreshCw v-else class="h-4 w-4" />
@@ -458,6 +484,14 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>Edit account</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <Button variant="ghost" size="icon" @click="openProfileDialog(account)">
+                      <Store class="h-4 w-4 text-emerald-500" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Business Profile</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger as-child>
@@ -497,22 +531,22 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
             <ol class="list-decimal list-inside space-y-3 text-sm text-muted-foreground">
               <li>
                 Go to <a href="https://developers.facebook.com" target="_blank" class="text-primary hover:underline inline-flex items-center gap-1">
-                  Meta Developer Console <ExternalLink class="h-3 w-3" />
-                </a> and create or select your app
+                Meta Developer Console <ExternalLink class="h-3 w-3" />
+              </a> and create or select your app
               </li>
               <li>Add WhatsApp product to your app and complete the setup</li>
               <li>In WhatsApp &gt; API Setup, copy your <strong>Phone Number ID</strong> and <strong>WhatsApp Business Account ID</strong></li>
               <li>
                 Create a permanent access token in <a href="https://business.facebook.com/settings/system-users" target="_blank" class="text-primary hover:underline inline-flex items-center gap-1">
-                  Business Settings &gt; System Users <ExternalLink class="h-3 w-3" />
-                </a>
+                Business Settings &gt; System Users <ExternalLink class="h-3 w-3" />
+              </a>
               </li>
               <li>Configure the webhook URL and verify token in your Meta app settings</li>
               <li>Subscribe to messages webhook field</li>
             </ol>
           </CardContent>
         </Card>
-        </div>
+      </div>
       </div>
     </ScrollArea>
 
@@ -530,9 +564,9 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
           <div class="space-y-2">
             <Label for="name">Account Name <span class="text-destructive">*</span></Label>
             <Input
-              id="name"
-              v-model="formData.name"
-              placeholder="e.g., Main Business Line"
+                id="name"
+                v-model="formData.name"
+                placeholder="e.g., Main Business Line"
             />
           </div>
 
@@ -541,9 +575,9 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
           <div class="space-y-2">
             <Label for="app_id">Meta App ID</Label>
             <Input
-              id="app_id"
-              v-model="formData.app_id"
-              placeholder="e.g., 123456789012345"
+                id="app_id"
+                v-model="formData.app_id"
+                placeholder="e.g., 123456789012345"
             />
             <p class="text-xs text-muted-foreground">
               Found in Meta Developer Console &gt; App Dashboard
@@ -553,9 +587,9 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
           <div class="space-y-2">
             <Label for="phone_id">Phone Number ID <span class="text-destructive">*</span></Label>
             <Input
-              id="phone_id"
-              v-model="formData.phone_id"
-              placeholder="e.g., 123456789012345"
+                id="phone_id"
+                v-model="formData.phone_id"
+                placeholder="e.g., 123456789012345"
             />
             <p class="text-xs text-muted-foreground">
               Found in Meta Developer Console &gt; WhatsApp &gt; API Setup
@@ -565,9 +599,9 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
           <div class="space-y-2">
             <Label for="business_id">WhatsApp Business Account ID <span class="text-destructive">*</span></Label>
             <Input
-              id="business_id"
-              v-model="formData.business_id"
-              placeholder="e.g., 987654321098765"
+                id="business_id"
+                v-model="formData.business_id"
+                placeholder="e.g., 987654321098765"
             />
           </div>
 
@@ -578,10 +612,10 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
               <span v-else class="text-muted-foreground">(leave blank to keep existing)</span>
             </Label>
             <Input
-              id="access_token"
-              v-model="formData.access_token"
-              type="password"
-              placeholder="Permanent access token from System User"
+                id="access_token"
+                v-model="formData.access_token"
+                type="password"
+                placeholder="Permanent access token from System User"
             />
             <p class="text-xs text-muted-foreground">
               Generate in Business Settings &gt; System Users &gt; Generate Token
@@ -594,10 +628,10 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
               <span v-if="editingAccount" class="text-muted-foreground">(leave blank to keep existing)</span>
             </Label>
             <Input
-              id="app_secret"
-              v-model="formData.app_secret"
-              type="password"
-              placeholder="Meta App Secret for webhook verification"
+                id="app_secret"
+                v-model="formData.app_secret"
+                type="password"
+                placeholder="Meta App Secret for webhook verification"
             />
             <p class="text-xs text-muted-foreground">
               Found in Meta Developer Console &gt; App Settings &gt; Basic &gt; App Secret. Used to verify webhook signatures.
@@ -609,18 +643,18 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
           <div class="space-y-2">
             <Label for="api_version">API Version</Label>
             <Input
-              id="api_version"
-              v-model="formData.api_version"
-              placeholder="v21.0"
+                id="api_version"
+                v-model="formData.api_version"
+                placeholder="v21.0"
             />
           </div>
 
           <div class="space-y-2">
             <Label for="webhook_verify_token">Webhook Verify Token</Label>
             <Input
-              id="webhook_verify_token"
-              v-model="formData.webhook_verify_token"
-              placeholder="Auto-generated if empty"
+                id="webhook_verify_token"
+                v-model="formData.webhook_verify_token"
+                placeholder="Auto-generated if empty"
             />
             <p class="text-xs text-muted-foreground">
               Used to verify webhook requests from Meta
@@ -636,9 +670,9 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                 Default for incoming messages
               </Label>
               <Switch
-                id="is_default_incoming"
-                :checked="formData.is_default_incoming"
-                @update:checked="formData.is_default_incoming = $event"
+                  id="is_default_incoming"
+                  :checked="formData.is_default_incoming"
+                  @update:checked="formData.is_default_incoming = $event"
               />
             </div>
             <div class="flex items-center justify-between">
@@ -646,9 +680,9 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                 Default for outgoing messages
               </Label>
               <Switch
-                id="is_default_outgoing"
-                :checked="formData.is_default_outgoing"
-                @update:checked="formData.is_default_outgoing = $event"
+                  id="is_default_outgoing"
+                  :checked="formData.is_default_outgoing"
+                  @update:checked="formData.is_default_outgoing = $event"
               />
             </div>
             <div class="flex items-center justify-between">
@@ -656,9 +690,9 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
                 Automatically send read receipts
               </Label>
               <Switch
-                id="auto_read_receipt"
-                :checked="formData.auto_read_receipt"
-                @update:checked="formData.auto_read_receipt = $event"
+                  id="auto_read_receipt"
+                  :checked="formData.auto_read_receipt"
+                  @update:checked="formData.auto_read_receipt = $event"
               />
             </div>
           </div>
@@ -691,5 +725,11 @@ const webhookUrl = window.location.origin + basePath + '/api/webhook'
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+
+    <BusinessProfileDialog
+        v-model:open="isProfileDialogOpen"
+        :account-id="profileAccount?.id || null"
+        :account-name="profileAccount?.name || ''"
+    />
   </div>
 </template>

--- a/frontend/src/views/settings/BusinessProfileDialog.vue
+++ b/frontend/src/views/settings/BusinessProfileDialog.vue
@@ -1,23 +1,15 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { api } from '@/services/api'
 import { toast } from 'vue-sonner'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
+import { CrudFormDialog } from '@/components/shared'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   Loader2,
-  Save,
-  Store,
   Globe,
   Mail,
   MapPin,
@@ -25,11 +17,6 @@ import {
   AlertTriangle,
   Pencil
 } from 'lucide-vue-next'
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from '@/components/ui/alert'
 
 interface Props {
   open: boolean
@@ -39,6 +26,11 @@ interface Props {
 
 const props = defineProps<Props>()
 const emit = defineEmits(['update:open'])
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: (value) => emit('update:open', value)
+})
 
 interface BusinessProfile {
   messaging_product: string
@@ -88,6 +80,11 @@ const verticals = [
   { value: 'TRAVEL', label: 'Travel & Transportation' }
 ]
 
+const selectedVerticalLabel = computed(() => {
+  const found = verticals.find(v => v.value === profile.value.vertical)
+  return found?.label || ''
+})
+
 watch(() => props.open, async (isOpen) => {
   if (isOpen && props.accountId) {
     await fetchProfile()
@@ -101,7 +98,7 @@ async function fetchProfile() {
   try {
     const response = await api.get(`/accounts/${props.accountId}/business_profile`)
     const data = response.data.data
-    
+
     // Fill the form, ensure arrays have data
     profile.value = {
       messaging_product: data.messaging_product || 'whatsapp',
@@ -113,14 +110,14 @@ async function fetchProfile() {
       profile_picture_url: data.profile_picture_url || '',
       about: data.about || ''
     }
-    
+
     // Ensure at least two slots for websites
     if (profile.value.websites.length < 2) {
       profile.value.websites.push('')
     }
     // Trim to max 2
     profile.value.websites = profile.value.websites.slice(0, 2)
-    
+
   } catch (error: any) {
     console.error('Failed to fetch business profile:', error)
     toast.error('Failed to load business profile')
@@ -128,7 +125,6 @@ async function fetchProfile() {
     isLoading.value = false
   }
 }
-
 
 async function saveProfile() {
   if (!props.accountId) return
@@ -177,7 +173,7 @@ async function handleFileChange(event: Event) {
     toast.error('Please select an image file (JPEG, PNG)')
     return
   }
-  
+
   // Validate size (Meta limit is usually 5MB for profile generic, strict on square)
   if (file.size > 5 * 1024 * 1024) {
     toast.error('Image must be less than 5MB')
@@ -209,134 +205,125 @@ async function handleFileChange(event: Event) {
 </script>
 
 <template>
-  <Dialog :open="open" @update:open="$emit('update:open', $event)">
-    <DialogContent class="max-w-2xl max-h-[90vh] overflow-y-auto">
-      <DialogHeader>
-        <DialogTitle class="flex items-center gap-2">
-          <Store class="h-5 w-5 text-emerald-500" />
-          Business Profile: {{ accountName }}
-        </DialogTitle>
-        <DialogDescription>
-          Update your WhatsApp Business profile details. These are visible to your customers.
-        </DialogDescription>
-      </DialogHeader>
+  <CrudFormDialog
+    v-model:open="dialogOpen"
+    :is-editing="true"
+    :is-submitting="isSubmitting || isLoading"
+    :title="`Business Profile: ${accountName}`"
+    description="Update your WhatsApp Business profile details. These are visible to your customers."
+    submit-label="Save Changes"
+    max-width="max-w-2xl"
+    @submit="saveProfile"
+  >
+    <div v-if="isLoading" class="py-12 flex justify-center">
+      <Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
 
-      <div v-if="isLoading" class="py-12 flex justify-center">
-        <Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
+    <div v-else class="space-y-6">
+      <Alert variant="warning">
+        <AlertTriangle class="h-4 w-4" />
+        <AlertTitle>Profile Updates</AlertTitle>
+        <AlertDescription>
+          Changes to your address, description, email, and websites usually update immediately.
+          <br/>Note: Updating the Business Display Name (not available here) triggers a Meta review process.
+        </AlertDescription>
+      </Alert>
 
-      <div v-else class="space-y-6 py-4">
-        <!-- Warning about Name Review (Static for now as name update isn't directly exposed here yet, but context is important) -->
-        <Alert variant="warning" class="bg-amber-950/20 border-amber-900/50 text-amber-600 dark:text-amber-400">
-          <AlertTriangle class="h-4 w-4" />
-          <AlertTitle>Profile Updates</AlertTitle>
-          <AlertDescription>
-            Changes to your address, description, email, and websites usually update immediately.
-            <br/>Note: Updating the Business Display Name (not available here) triggers a Meta review process.
-          </AlertDescription>
-        </Alert>
-
-        <div class="grid gap-6 md:grid-cols-2">
-           <!-- Profile Picture Preview -->
-           <div class="md:col-span-2 flex items-center gap-4">
-              <div 
-                class="group relative h-24 w-24 rounded-full bg-secondary flex items-center justify-center overflow-hidden border border-border cursor-pointer transition-all hover:ring-2 hover:ring-emerald-500 hover:ring-offset-2 hover:ring-offset-background"
-                @click="triggerFileInput"
-              >
-                <!-- Loading Overlay -->
-                <div v-if="isUploading" class="absolute inset-0 bg-black/50 flex items-center justify-center z-10">
-                  <Loader2 class="h-6 w-6 text-white animate-spin" />
-                </div>
-                
-                <!-- Hover Overlay -->
-                <div class="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10" v-if="!isUploading">
-                  <Pencil class="h-6 w-6 text-white" />
-                </div>
-
-                <img v-if="profile.profile_picture_url" :src="profile.profile_picture_url" alt="Profile" class="h-full w-full object-cover" />
-                <ImageIcon v-else class="h-10 w-10 text-muted-foreground" />
-                
-                <input
-                  ref="fileInput"
-                  type="file"
-                  accept="image/png, image/jpeg"
-                  class="hidden"
-                  @change="handleFileChange"
-                />
-              </div>
-              <div class="flex-1">
-                <Label>Profile Picture</Label>
-                <p class="text-xs text-muted-foreground mt-1">
-                  Click to upload a new picture.
-                  <br/>Recommended: Square JPG or PNG, max 5MB.
-                </p>
-              </div>
-           </div>
-
-           <!-- About -->
-           <div class="md:col-span-2 space-y-2">
-            <Label for="about">About (Status)</Label>
-            <Input id="about" v-model="profile.about" placeholder="e.g., Available, Busy, At work" maxlength="139" />
-            <p class="text-xs text-muted-foreground text-right">{{ profile.about.length }}/139</p>
-          </div>
-
-          <!-- Description -->
-          <div class="md:col-span-2 space-y-2">
-            <Label for="description">Business Description</Label>
-            <Textarea id="description" v-model="profile.description" placeholder="Describe your business..." rows="3" maxlength="512" />
-            <p class="text-xs text-muted-foreground text-right">{{ profile.description.length }}/512</p>
-          </div>
-
-          <!-- Vertical (Category) -->
-          <div class="space-y-2">
-            <Label for="vertical">Industry (Vertical)</Label>
-            <select
-              id="vertical"
-              v-model="profile.vertical"
-              class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <option value="" disabled>Select a category</option>
-              <option v-for="v in verticals" :key="v.value" :value="v.value">{{ v.label }}</option>
-            </select>
-          </div>
-
-           <!-- Email -->
-           <div class="space-y-2">
-            <Label for="email">Contact Email</Label>
-            <div class="relative">
-              <Mail class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input id="email" v-model="profile.email" type="email" class="pl-9" placeholder="contact@example.com" maxlength="128" />
+      <div class="grid gap-6 md:grid-cols-2">
+        <!-- Profile Picture Preview -->
+        <div class="md:col-span-2 flex items-center gap-4">
+          <div
+            class="group relative h-24 w-24 rounded-full bg-secondary flex items-center justify-center overflow-hidden border border-border cursor-pointer transition-all hover:ring-2 hover:ring-emerald-500 hover:ring-offset-2 hover:ring-offset-background"
+            @click="triggerFileInput"
+          >
+            <!-- Loading Overlay -->
+            <div v-if="isUploading" class="absolute inset-0 bg-black/50 flex items-center justify-center z-10">
+              <Loader2 class="h-6 w-6 text-white animate-spin" />
             </div>
-          </div>
 
-          <!-- Address -->
-          <div class="md:col-span-2 space-y-2">
-            <Label for="address">Business Address</Label>
-            <div class="relative">
-              <MapPin class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input id="address" v-model="profile.address" class="pl-9" placeholder="Street, City, State, Zip" maxlength="256" />
+            <!-- Hover Overlay -->
+            <div v-if="!isUploading" class="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10">
+              <Pencil class="h-6 w-6 text-white" />
             </div>
-          </div>
 
-          <!-- Websites -->
-          <div class="md:col-span-2 space-y-3">
-             <Label>Websites (Max 2)</Label>
-             <div v-for="(_, index) in profile.websites" :key="index" class="relative">
-               <Globe class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-               <Input v-model="profile.websites[index]" class="pl-9" placeholder="https://www.example.com" maxlength="256" />
-             </div>
+            <img v-if="profile.profile_picture_url" :src="profile.profile_picture_url" alt="Profile" class="h-full w-full object-cover" />
+            <ImageIcon v-else class="h-10 w-10 text-muted-foreground" />
+
+            <input
+              ref="fileInput"
+              type="file"
+              accept="image/png, image/jpeg"
+              class="hidden"
+              @change="handleFileChange"
+            />
+          </div>
+          <div class="flex-1">
+            <Label>Profile Picture</Label>
+            <p class="text-xs text-muted-foreground mt-1">
+              Click to upload a new picture.
+              <br/>Recommended: Square JPG or PNG, max 5MB.
+            </p>
+          </div>
+        </div>
+
+        <!-- About -->
+        <div class="md:col-span-2 space-y-2">
+          <Label for="about">About (Status)</Label>
+          <Input id="about" v-model="profile.about" placeholder="e.g., Available, Busy, At work" maxlength="139" />
+          <p class="text-xs text-muted-foreground text-right">{{ profile.about.length }}/139</p>
+        </div>
+
+        <!-- Description -->
+        <div class="md:col-span-2 space-y-2">
+          <Label for="description">Business Description</Label>
+          <Textarea id="description" v-model="profile.description" placeholder="Describe your business..." rows="3" maxlength="512" />
+          <p class="text-xs text-muted-foreground text-right">{{ profile.description.length }}/512</p>
+        </div>
+
+        <!-- Vertical (Category) -->
+        <div class="space-y-2">
+          <Label for="vertical">Industry (Vertical)</Label>
+          <Select v-model="profile.vertical">
+            <SelectTrigger>
+              <SelectValue placeholder="Select a category">
+                <template v-if="profile.vertical">{{ selectedVerticalLabel }}</template>
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem v-for="v in verticals" :key="v.value" :value="v.value">
+                {{ v.label }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <!-- Email -->
+        <div class="space-y-2">
+          <Label for="email">Contact Email</Label>
+          <div class="relative">
+            <Mail class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input id="email" v-model="profile.email" type="email" class="pl-9" placeholder="contact@example.com" maxlength="128" />
+          </div>
+        </div>
+
+        <!-- Address -->
+        <div class="md:col-span-2 space-y-2">
+          <Label for="address">Business Address</Label>
+          <div class="relative">
+            <MapPin class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input id="address" v-model="profile.address" class="pl-9" placeholder="Street, City, State, Zip" maxlength="256" />
+          </div>
+        </div>
+
+        <!-- Websites -->
+        <div class="md:col-span-2 space-y-3">
+          <Label>Websites (Max 2)</Label>
+          <div v-for="(_, index) in profile.websites" :key="index" class="relative">
+            <Globe class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input v-model="profile.websites[index]" class="pl-9" placeholder="https://www.example.com" maxlength="256" />
           </div>
         </div>
       </div>
-
-      <DialogFooter>
-        <Button variant="outline" @click="$emit('update:open', false)">Cancel</Button>
-        <Button @click="saveProfile" :disabled="isSubmitting || isLoading">
-          <Loader2 v-if="isSubmitting" class="h-4 w-4 mr-2 animate-spin" />
-          <Save v-else class="h-4 w-4 mr-2" />
-          Save Changes
-        </Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
+    </div>
+  </CrudFormDialog>
 </template>

--- a/frontend/src/views/settings/BusinessProfileDialog.vue
+++ b/frontend/src/views/settings/BusinessProfileDialog.vue
@@ -1,0 +1,253 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Loader2,
+  Save,
+  Store,
+  Globe,
+  Mail,
+  MapPin,
+  Image as ImageIcon,
+  AlertTriangle
+} from 'lucide-vue-next'
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from '@/components/ui/alert'
+
+interface Props {
+  open: boolean
+  accountId: string | null
+  accountName: string
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits(['update:open'])
+
+interface BusinessProfile {
+  messaging_product: string
+  address: string
+  description: string
+  vertical: string
+  email: string
+  websites: string[]
+  profile_picture_url: string
+  about: string
+}
+
+const isLoading = ref(false)
+const isSubmitting = ref(false)
+const profile = ref<BusinessProfile>({
+  messaging_product: 'whatsapp',
+  address: '',
+  description: '',
+  vertical: '',
+  email: '',
+  websites: ['', ''],
+  profile_picture_url: '',
+  about: ''
+})
+
+// Categories (Verticals) supported by Meta
+const verticals = [
+  'ALCOHOL', 'APPAREL', 'AUTO', 'BEAUTY', 'EDU', 'ENTERTAIN', 'EVENT_PLAN',
+  'FINANCE', 'GOVT', 'GROCERY', 'HEALTH', 'HOTEL', 'NONPROFIT',
+  'ONLINE_GAMBLING', 'OTC_DRUGS', 'OTHER', 'PHYSICAL_GAMBLING',
+  'PROF_SERVICES', 'RETAIL', 'TRAVEL'
+]
+
+watch(() => props.open, async (isOpen) => {
+  if (isOpen && props.accountId) {
+    await fetchProfile()
+  }
+})
+
+async function fetchProfile() {
+  if (!props.accountId) return
+
+  isLoading.value = true
+  try {
+    const response = await api.get(`/accounts/${props.accountId}/business_profile`)
+    const data = response.data.data
+    
+    // Fill the form, ensure arrays have data
+    profile.value = {
+      messaging_product: data.messaging_product || 'whatsapp',
+      address: data.address || '',
+      description: data.description || '',
+      vertical: data.vertical || '',
+      email: data.email || '',
+      websites: data.websites && data.websites.length > 0 ? [...data.websites, ''] : ['', ''],
+      profile_picture_url: data.profile_picture_url || '',
+      about: data.about || ''
+    }
+    
+    // Ensure at least two slots for websites
+    if (profile.value.websites.length < 2) {
+      profile.value.websites.push('')
+    }
+    // Trim to max 2
+    profile.value.websites = profile.value.websites.slice(0, 2)
+    
+  } catch (error: any) {
+    console.error('Failed to fetch business profile:', error)
+    toast.error('Failed to load business profile')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function saveProfile() {
+  if (!props.accountId) return
+
+  isSubmitting.value = true
+  try {
+    // Filter out empty websites
+    const websites = profile.value.websites.filter(w => w.trim() !== '')
+
+    const payload = {
+      messaging_product: 'whatsapp',
+      address: profile.value.address,
+      description: profile.value.description,
+      vertical: profile.value.vertical,
+      email: profile.value.email,
+      websites: websites,
+      about: profile.value.about
+      // Note: profile_picture_handle is handled separately effectively by the user having to upload first (not implemented in this specific form yet)
+    }
+
+    await api.put(`/accounts/${props.accountId}/business_profile`, payload)
+    toast.success('Business profile updated successfully')
+    emit('update:open', false)
+  } catch (error: any) {
+    console.error('Failed to update profile:', error)
+    const message = error.response?.data?.message || 'Failed to update profile'
+    toast.error(message)
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="$emit('update:open', $event)">
+    <DialogContent class="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogHeader>
+        <DialogTitle class="flex items-center gap-2">
+          <Store class="h-5 w-5 text-emerald-500" />
+          Business Profile: {{ accountName }}
+        </DialogTitle>
+        <DialogDescription>
+          Update your WhatsApp Business profile details. These are visible to your customers.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div v-if="isLoading" class="py-12 flex justify-center">
+        <Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+
+      <div v-else class="space-y-6 py-4">
+        <!-- Warning about Name Review (Static for now as name update isn't directly exposed here yet, but context is important) -->
+        <Alert variant="warning" class="bg-amber-950/20 border-amber-900/50 text-amber-600 dark:text-amber-400">
+          <AlertTriangle class="h-4 w-4" />
+          <AlertTitle>Profile Updates</AlertTitle>
+          <AlertDescription>
+            Changes to your address, description, email, and websites usually update immediately.
+            <br/>Note: Updating the Business Display Name (not available here) triggers a Meta review process.
+          </AlertDescription>
+        </Alert>
+
+        <div class="grid gap-6 md:grid-cols-2">
+           <!-- Profile Picture Preview -->
+           <div class="md:col-span-2 flex items-center gap-4">
+              <div class="h-20 w-20 rounded-full bg-secondary flex items-center justify-center overflow-hidden border border-border">
+                <img v-if="profile.profile_picture_url" :src="profile.profile_picture_url" alt="Profile" class="h-full w-full object-cover" />
+                <ImageIcon v-else class="h-8 w-8 text-muted-foreground" />
+              </div>
+              <div>
+                <Label>Profile Picture</Label>
+                <p class="text-xs text-muted-foreground mt-1">
+                  Profile picture updates require a simpler media upload flow. 
+                  <br/>Currently, this can be updated via the Meta Business Manager directly.
+                </p>
+              </div>
+           </div>
+
+           <!-- About -->
+           <div class="md:col-span-2 space-y-2">
+            <Label for="about">About (Status)</Label>
+            <Input id="about" v-model="profile.about" placeholder="e.g., Available, Busy, At work" :maxlength="139" />
+            <p class="text-xs text-muted-foreground text-right">{{ profile.about.length }}/139</p>
+          </div>
+
+          <!-- Description -->
+          <div class="md:col-span-2 space-y-2">
+            <Label for="description">Business Description</Label>
+            <Textarea id="description" v-model="profile.description" placeholder="Describe your business..." rows="3" :maxlength="512" />
+            <p class="text-xs text-muted-foreground text-right">{{ profile.description.length }}/512</p>
+          </div>
+
+          <!-- Vertical (Category) -->
+          <div class="space-y-2">
+            <Label for="vertical">Industry (Vertical)</Label>
+            <select
+              id="vertical"
+              v-model="profile.vertical"
+              class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value="" disabled>Select a category</option>
+              <option v-for="v in verticals" :key="v" :value="v">{{ v }}</option>
+            </select>
+          </div>
+
+           <!-- Email -->
+           <div class="space-y-2">
+            <Label for="email">Contact Email</Label>
+            <div class="relative">
+              <Mail class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input id="email" v-model="profile.email" type="email" class="pl-9" placeholder="contact@example.com" :maxlength="128" />
+            </div>
+          </div>
+
+          <!-- Address -->
+          <div class="md:col-span-2 space-y-2">
+            <Label for="address">Business Address</Label>
+            <div class="relative">
+              <MapPin class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input id="address" v-model="profile.address" class="pl-9" placeholder="Street, City, State, Zip" :maxlength="256" />
+            </div>
+          </div>
+
+          <!-- Websites -->
+          <div class="md:col-span-2 space-y-3">
+             <Label>Websites (Max 2)</Label>
+             <div v-for="(_, index) in profile.websites" :key="index" class="relative">
+               <Globe class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+               <Input v-model="profile.websites[index]" class="pl-9" placeholder="https://www.example.com" :maxlength="256" />
+             </div>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" @click="$emit('update:open', false)">Cancel</Button>
+        <Button @click="saveProfile" :disabled="isSubmitting || isLoading">
+          <Loader2 v-if="isSubmitting" class="h-4 w-4 mr-2 animate-spin" />
+          <Save v-else class="h-4 w-4 mr-2" />
+          Save Changes
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/internal/handlers/business_profile.go
+++ b/internal/handlers/business_profile.go
@@ -10,7 +10,7 @@ import (
 
 // GetBusinessProfile returns the business profile for a WhatsApp account
 func (a *App) GetBusinessProfile(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -47,7 +47,7 @@ func (a *App) GetBusinessProfile(r *fastglue.Request) error {
 
 // UpdateBusinessProfile updates the business profile for a WhatsApp account
 func (a *App) UpdateBusinessProfile(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -104,7 +104,7 @@ func (a *App) UpdateBusinessProfile(r *fastglue.Request) error {
 
 // UpdateProfilePicture handles the profile picture upload
 func (a *App) UpdateProfilePicture(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}

--- a/internal/handlers/business_profile.go
+++ b/internal/handlers/business_profile.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"github.com/google/uuid"
+	"github.com/shridarpatil/whatomate/internal/models"
+	"github.com/shridarpatil/whatomate/pkg/whatsapp"
+	"github.com/valyala/fasthttp"
+	"github.com/zerodha/fastglue"
+)
+
+// GetBusinessProfile returns the business profile for a WhatsApp account
+func (a *App) GetBusinessProfile(r *fastglue.Request) error {
+	orgID, err := getOrganizationID(r)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
+	}
+
+	idStr := r.RequestCtx.UserValue("id").(string)
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid account ID", nil, "")
+	}
+
+	var account models.WhatsAppAccount
+	if err := a.DB.Where("id = ? AND organization_id = ?", id, orgID).First(&account).Error; err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Account not found", nil, "")
+	}
+
+	// Create a context for the request
+	ctx := r.RequestCtx
+
+	// Call the WhatsApp client
+	profile, err := a.WhatsApp.GetBusinessProfile(ctx, &whatsapp.Account{
+		PhoneID:     account.PhoneID,
+		BusinessID:  account.BusinessID,
+		AppID:       account.AppID,
+		APIVersion:  account.APIVersion,
+		AccessToken: account.AccessToken,
+	})
+	if err != nil {
+		a.Log.Error("Failed to get business profile", "error", err)
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to get business profile: "+err.Error(), nil, "")
+	}
+
+	return r.SendEnvelope(profile)
+}
+
+// UpdateBusinessProfile updates the business profile for a WhatsApp account
+func (a *App) UpdateBusinessProfile(r *fastglue.Request) error {
+	orgID, err := getOrganizationID(r)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
+	}
+
+	idStr := r.RequestCtx.UserValue("id").(string)
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid account ID", nil, "")
+	}
+
+	var account models.WhatsAppAccount
+	if err := a.DB.Where("id = ? AND organization_id = ?", id, orgID).First(&account).Error; err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Account not found", nil, "")
+	}
+
+	var input whatsapp.BusinessProfileInput
+	if err := r.Decode(&input, "json"); err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid request body", nil, "")
+	}
+
+	// Create a context for the request
+	ctx := r.RequestCtx
+
+	// Call the WhatsApp client
+	err = a.WhatsApp.UpdateBusinessProfile(ctx, &whatsapp.Account{
+		PhoneID:     account.PhoneID,
+		BusinessID:  account.BusinessID,
+		AppID:       account.AppID,
+		APIVersion:  account.APIVersion,
+		AccessToken: account.AccessToken,
+	}, input)
+
+	if err != nil {
+		a.Log.Error("Failed to update business profile", "error", err)
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update business profile: "+err.Error(), nil, "")
+	}
+
+	// Return updated profile to confirm
+	// We re-fetch it to ensure we have the latest state (including any server-side processing)
+	profile, err := a.WhatsApp.GetBusinessProfile(ctx, &whatsapp.Account{
+		PhoneID:     account.PhoneID,
+		BusinessID:  account.BusinessID,
+		AppID:       account.AppID,
+		APIVersion:  account.APIVersion,
+		AccessToken: account.AccessToken,
+	})
+	if err != nil {
+		// If re-fetch fails, just return success message
+		return r.SendEnvelope(map[string]string{"message": "Profile updated successfully"})
+	}
+
+	return r.SendEnvelope(profile)
+}

--- a/pkg/whatsapp/profile_extras.go
+++ b/pkg/whatsapp/profile_extras.go
@@ -1,0 +1,15 @@
+package whatsapp
+
+import (
+	"context"
+)
+
+// UploadProfilePicture uploads a profile picture and returns the handle
+// It uses the Resumable Upload API as required for profile pictures
+// UploadProfilePicture uploads a profile picture and returns the handle
+// It uses the Resumable Upload API as required for profile pictures
+func (c *Client) UploadProfilePicture(ctx context.Context, account *Account, fileData []byte, mimeType string) (string, error) {
+	// Profile pictures use the resumable upload API
+	// Note: ResumableUpload signature: (ctx, account, data, mimeType, filename)
+	return c.ResumableUpload(ctx, account, fileData, mimeType, "profile_picture")
+}

--- a/pkg/whatsapp/types.go
+++ b/pkg/whatsapp/types.go
@@ -276,3 +276,27 @@ type ProductListResponse struct {
 type ProductCreateResponse struct {
 	ID string `json:"id"`
 }
+
+// BusinessProfile represents the business profile of a phone number
+type BusinessProfile struct {
+	MessagingProduct string   `json:"messaging_product"`
+	Address          string   `json:"address"`
+	Description      string   `json:"description"`
+	Vertical         string   `json:"vertical"`
+	Email            string   `json:"email"`
+	Websites         []string `json:"websites"`
+	ProfilePicture   string   `json:"profile_picture_url"`
+	About            string   `json:"about"` // Status text
+}
+
+// BusinessProfileInput represents the input for updating a business profile
+type BusinessProfileInput struct {
+	MessagingProduct     string   `json:"messaging_product"`
+	Address              string   `json:"address,omitempty"`
+	Description          string   `json:"description,omitempty"`
+	Vertical             string   `json:"vertical,omitempty"`
+	Email                string   `json:"email,omitempty"`
+	Websites             []string `json:"websites,omitempty"`
+	ProfilePictureHandle string   `json:"profile_picture_handle,omitempty"`
+	About                string   `json:"about,omitempty"`
+}


### PR DESCRIPTION
# WhatsApp Business Profile Implementation Walkthrough (Updated)

I have implemented the ability to view and update WhatsApp Business Profile details, including **Profile Pictures**, directly from the application.

## Changes

### Backend
- **Core Logic**: Added [UploadProfilePicture](file:///Users/saifallahkhaled/PhpstormProjects/whatomate/pkg/whatsapp/profile_extras.go#8-15) to [pkg/whatsapp/profile_extras.go](file:///Users/saifallahkhaled/PhpstormProjects/whatomate/pkg/whatsapp/profile_extras.go) using the Resumable Upload API.
- **API Handlers**: Added [UpdateProfilePicture](file:///Users/saifallahkhaled/PhpstormProjects/whatomate/internal/handlers/business_profile.go#105-182) in [internal/handlers/business_profile.go](file:///Users/saifallahkhaled/PhpstormProjects/whatomate/internal/handlers/business_profile.go) which handles multipart file uploads.
- **Routes**: Registered `POST /api/accounts/{id}/business_profile/photo`.

### Frontend
- **UI Component**: Updated [BusinessProfileDialog.vue](file:///Users/saifallahkhaled/PhpstormProjects/whatomate/frontend/src/views/settings/BusinessProfileDialog.vue):
    - **Interactive Profile Picture**: Clicking the avatar now triggers a file upload dialog.
    - **Industry Labels**: Mapped internal codes to readable English labels (e.g., "Professional Services").
    - **Validation**: Added checks for file type (image/*) and size (<5MB).
    - **Status/About**: ensured `About` field is correctly mapped.

### Verification Results

#### Manual Verification
1.  **Profile Picture**:
    *   Click the "Store" icon.
    *   Hover over the profile picture -> see "Pencil" icon.
    *   Click and select a JPG/PNG (<5MB).
    *   Observe the loading spinner.
    *   Success toast appears and image updates.
2.  **Profile Details**:
    *   Edit Description, Address, Vertical, Email, Websites.
    *   Click "Save Changes".
    *   Verify changes persist.

#### Note on Display Name
Updating the **Display Name** requires a Meta Review process and is strictly controlled. I have prioritized the **Profile Picture** and **Status (About)** updates as they are instant. If Display Name updates are absolutely required via API, it involves a re-registration flow that is currently outside the standard profile update scope, but the current implementation handles all other business details.
