### PR TITLE
feat: Add "Group By" field for chart widgets

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -323,6 +323,7 @@ export interface DashboardWidget {
   filters: Array<{ field: string; operator: string; value: string }>
   display_type: string
   chart_type: string
+  group_by_field: string
   show_change: boolean
   color: string
   size: string
@@ -342,6 +343,10 @@ export interface WidgetData {
   prev_value: number
   chart_data: Array<{ label: string; value: number }>
   data_points: Array<{ label: string; value: number; color?: string }>
+  grouped_series?: {
+    labels: string[]
+    datasets: Array<{ label: string; data: number[] }>
+  }
 }
 
 export interface DataSourceInfo {
@@ -362,6 +367,7 @@ export const dashboardWidgetsService = {
     filters?: Array<{ field: string; operator: string; value: string }>
     display_type?: string
     chart_type?: string
+    group_by_field?: string
     show_change?: boolean
     color?: string
     size?: string
@@ -376,6 +382,7 @@ export const dashboardWidgetsService = {
     filters: Array<{ field: string; operator: string; value: string }>
     display_type: string
     chart_type: string
+    group_by_field: string
     show_change: boolean
     color: string
     size: string

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -413,6 +413,7 @@ type DashboardWidget struct {
 	Filters        JSONBArray `gorm:"type:jsonb;default:'[]'" json:"filters"`
 	DisplayType    string     `gorm:"size:20;default:'number'" json:"display_type"` // number, percentage, chart
 	ChartType      string     `gorm:"size:20" json:"chart_type"`                    // line, bar, pie (when display_type is chart)
+	GroupByField   string     `gorm:"size:100" json:"group_by_field"`               // Field to group by (e.g., status, direction)
 	ShowChange     bool       `gorm:"default:true" json:"show_change"`              // Show % change vs previous period
 	Color          string     `gorm:"size:20" json:"color"`                         // Widget color theme
 	Size           string     `gorm:"size:10;default:'small'" json:"size"`          // small, medium, large


### PR DESCRIPTION
Allow chart widgets (line, bar, pie) to show count breakdowns grouped by a field value (e.g., messages by status, campaigns by message_status).

- Line + group by: multiple lines over time (one per group value)
- Bar/Pie + group by: slices/bars for each group value
- Campaigns support virtual "message_status" field using pre-aggregated sent/delivered/read/failed counters
- Without group by: existing time-series behavior unchanged
- Refactor: extract resolveDataSourceTable and appendFilterSQL helpers to remove duplicated table resolution and filter appending logic
- Fix: replace color picker buttons with Select dropdown for reliable interaction inside Radix Dialog