### PR TITLE
refactor: Deduplicate backend code across handlers, worker, and database

### DIFF
--- a/internal/contactutil/contactutil.go
+++ b/internal/contactutil/contactutil.go
@@ -1,0 +1,57 @@
+package contactutil
+
+import (
+	"github.com/google/uuid"
+	"github.com/shridarpatil/whatomate/internal/models"
+	"gorm.io/gorm"
+)
+
+// GetOrCreateContact finds or creates a contact for the given phone number.
+// Merges behaviors from both handler and worker implementations:
+//   - Normalizes phone (strips leading "+")
+//   - Tries both normalized and +prefix forms
+//   - Updates profile name if changed
+//   - Handles race conditions on create by re-fetching
+//
+// Returns the contact, whether it was newly created, and any error.
+func GetOrCreateContact(db *gorm.DB, orgID uuid.UUID, phoneNumber, profileName string) (*models.Contact, bool, error) {
+	// Normalize phone number (remove + prefix if present)
+	normalizedPhone := phoneNumber
+	if len(normalizedPhone) > 0 && normalizedPhone[0] == '+' {
+		normalizedPhone = normalizedPhone[1:]
+	}
+
+	// Try to find existing contact with normalized phone
+	var contact models.Contact
+	if err := db.Where("organization_id = ? AND phone_number = ?", orgID, normalizedPhone).First(&contact).Error; err == nil {
+		// Update profile name if changed
+		if profileName != "" && contact.ProfileName != profileName {
+			db.Model(&contact).Update("profile_name", profileName)
+		}
+		return &contact, false, nil
+	}
+
+	// Also try with + prefix (contacts may have been stored with it)
+	if err := db.Where("organization_id = ? AND phone_number = ?", orgID, "+"+normalizedPhone).First(&contact).Error; err == nil {
+		if profileName != "" && contact.ProfileName != profileName {
+			db.Model(&contact).Update("profile_name", profileName)
+		}
+		return &contact, false, nil
+	}
+
+	// Create new contact
+	contact = models.Contact{
+		BaseModel:      models.BaseModel{ID: uuid.New()},
+		OrganizationID: orgID,
+		PhoneNumber:    normalizedPhone,
+		ProfileName:    profileName,
+	}
+	if err := db.Create(&contact).Error; err != nil {
+		// Race condition: another goroutine may have created the contact
+		if err2 := db.Where("organization_id = ? AND phone_number = ?", orgID, normalizedPhone).First(&contact).Error; err2 == nil {
+			return &contact, false, nil
+		}
+		return nil, false, err
+	}
+	return &contact, true, nil
+}

--- a/internal/contactutil/contactutil_test.go
+++ b/internal/contactutil/contactutil_test.go
@@ -1,0 +1,107 @@
+package contactutil
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shridarpatil/whatomate/internal/models"
+	"github.com/shridarpatil/whatomate/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOrCreateContact_CreatesNew(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	uid := uuid.New().String()[:8]
+	org := models.Organization{BaseModel: models.BaseModel{ID: uuid.New()}, Name: "test-" + uid, Slug: "test-" + uid}
+	require.NoError(t, db.Create(&org).Error)
+
+	contact, isNew, err := GetOrCreateContact(db, org.ID, "1234567890", "Alice")
+	require.NoError(t, err)
+	assert.True(t, isNew)
+	assert.Equal(t, "1234567890", contact.PhoneNumber)
+	assert.Equal(t, "Alice", contact.ProfileName)
+}
+
+func TestGetOrCreateContact_FindsExisting(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	uid := uuid.New().String()[:8]
+	org := models.Organization{BaseModel: models.BaseModel{ID: uuid.New()}, Name: "test-" + uid, Slug: "test-" + uid}
+	require.NoError(t, db.Create(&org).Error)
+
+	existing := models.Contact{
+		BaseModel:      models.BaseModel{ID: uuid.New()},
+		OrganizationID: org.ID,
+		PhoneNumber:    "1234567890",
+		ProfileName:    "Alice",
+	}
+	require.NoError(t, db.Create(&existing).Error)
+
+	contact, isNew, err := GetOrCreateContact(db, org.ID, "1234567890", "Alice")
+	require.NoError(t, err)
+	assert.False(t, isNew)
+	assert.Equal(t, existing.ID, contact.ID)
+}
+
+func TestGetOrCreateContact_NormalizesPlus(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	uid := uuid.New().String()[:8]
+	org := models.Organization{BaseModel: models.BaseModel{ID: uuid.New()}, Name: "test-" + uid, Slug: "test-" + uid}
+	require.NoError(t, db.Create(&org).Error)
+
+	existing := models.Contact{
+		BaseModel:      models.BaseModel{ID: uuid.New()},
+		OrganizationID: org.ID,
+		PhoneNumber:    "1234567890",
+		ProfileName:    "Bob",
+	}
+	require.NoError(t, db.Create(&existing).Error)
+
+	contact, isNew, err := GetOrCreateContact(db, org.ID, "+1234567890", "Bob")
+	require.NoError(t, err)
+	assert.False(t, isNew)
+	assert.Equal(t, existing.ID, contact.ID)
+}
+
+func TestGetOrCreateContact_FindsPlusPrefix(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	uid := uuid.New().String()[:8]
+	org := models.Organization{BaseModel: models.BaseModel{ID: uuid.New()}, Name: "test-" + uid, Slug: "test-" + uid}
+	require.NoError(t, db.Create(&org).Error)
+
+	existing := models.Contact{
+		BaseModel:      models.BaseModel{ID: uuid.New()},
+		OrganizationID: org.ID,
+		PhoneNumber:    "+1234567890",
+		ProfileName:    "Charlie",
+	}
+	require.NoError(t, db.Create(&existing).Error)
+
+	contact, isNew, err := GetOrCreateContact(db, org.ID, "1234567890", "Charlie")
+	require.NoError(t, err)
+	assert.False(t, isNew)
+	assert.Equal(t, existing.ID, contact.ID)
+}
+
+func TestGetOrCreateContact_UpdatesProfileName(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	uid := uuid.New().String()[:8]
+	org := models.Organization{BaseModel: models.BaseModel{ID: uuid.New()}, Name: "test-" + uid, Slug: "test-" + uid}
+	require.NoError(t, db.Create(&org).Error)
+
+	existing := models.Contact{
+		BaseModel:      models.BaseModel{ID: uuid.New()},
+		OrganizationID: org.ID,
+		PhoneNumber:    "1234567890",
+		ProfileName:    "Old Name",
+	}
+	require.NoError(t, db.Create(&existing).Error)
+
+	contact, isNew, err := GetOrCreateContact(db, org.ID, "1234567890", "New Name")
+	require.NoError(t, err)
+	assert.False(t, isNew)
+
+	var reloaded models.Contact
+	require.NoError(t, db.First(&reloaded, contact.ID).Error)
+	assert.Equal(t, "New Name", reloaded.ProfileName)
+}

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -236,6 +236,10 @@ func getIndexes() []string {
 		`CREATE INDEX IF NOT EXISTS idx_availability_logs_user_time ON user_availability_logs(user_id, started_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_availability_logs_org_time ON user_availability_logs(organization_id, started_at DESC)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_sso_providers_org_provider ON sso_providers(organization_id, provider)`,
+		// Teams indexes
+		`CREATE INDEX IF NOT EXISTS idx_teams_org_active ON teams(organization_id, is_active)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_team_members_unique ON team_members(team_id, user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id)`,
 		// Custom roles indexes
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_custom_roles_org_name ON custom_roles(organization_id, name)`,
 		`CREATE INDEX IF NOT EXISTS idx_custom_roles_org_system ON custom_roles(organization_id, is_system)`,
@@ -245,77 +249,11 @@ func getIndexes() []string {
 
 // CreateIndexes creates additional indexes not handled by GORM tags
 func CreateIndexes(db *gorm.DB) error {
-	indexes := []string{
-		// Messages indexes
-		`CREATE INDEX IF NOT EXISTS idx_messages_contact_created ON messages(contact_id, created_at DESC)`,
-		`CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id)`,
-
-		// Contacts indexes
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_org_phone ON contacts(organization_id, phone_number)`,
-		`CREATE INDEX IF NOT EXISTS idx_contacts_assigned_read ON contacts(assigned_user_id, is_read)`,
-
-		// Sessions indexes
-		`CREATE INDEX IF NOT EXISTS idx_sessions_phone_status ON chatbot_sessions(organization_id, phone_number, status)`,
-
-		// Keyword rules indexes
-		`CREATE INDEX IF NOT EXISTS idx_keyword_rules_priority ON keyword_rules(organization_id, is_enabled, priority DESC)`,
-
-		// Agent transfers indexes
-		`CREATE INDEX IF NOT EXISTS idx_agent_transfers_active ON agent_transfers(organization_id, phone_number, status)`,
-		`CREATE INDEX IF NOT EXISTS idx_agent_transfers_org_contact ON agent_transfers(organization_id, contact_id, status)`,
-		`CREATE INDEX IF NOT EXISTS idx_agent_transfers_agent_active ON agent_transfers(agent_id, status) WHERE status = 'active'`,
-		`CREATE INDEX IF NOT EXISTS idx_agent_transfers_team ON agent_transfers(team_id, status) WHERE team_id IS NOT NULL`,
-
-		// Teams indexes
-		`CREATE INDEX IF NOT EXISTS idx_teams_org_active ON teams(organization_id, is_active)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_team_members_unique ON team_members(team_id, user_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id)`,
-
-		// WhatsApp accounts indexes
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_whatsapp_accounts_org_phone ON whatsapp_accounts(organization_id, phone_id)`,
-
-		// Templates indexes
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_templates_account_name_lang ON templates(whats_app_account, name, language)`,
-
-		// Chatbot indexes with account
-		`CREATE INDEX IF NOT EXISTS idx_keyword_rules_account ON keyword_rules(whats_app_account, is_enabled, priority DESC)`,
-		`CREATE INDEX IF NOT EXISTS idx_chatbot_flows_account ON chatbot_flows(whats_app_account, is_enabled)`,
-		`CREATE INDEX IF NOT EXISTS idx_ai_contexts_account ON ai_contexts(whats_app_account, is_enabled, priority DESC)`,
-
-		// Bulk messaging indexes
-		`CREATE INDEX IF NOT EXISTS idx_bulk_campaigns_account ON bulk_message_campaigns(whats_app_account, status)`,
-		`CREATE INDEX IF NOT EXISTS idx_notification_rules_account ON notification_rules(whats_app_account, is_enabled)`,
-
-		// Messages and contacts by account
-		`CREATE INDEX IF NOT EXISTS idx_messages_account ON messages(whats_app_account, created_at DESC)`,
-		`CREATE INDEX IF NOT EXISTS idx_contacts_account ON contacts(whats_app_account)`,
-
-		// Canned responses indexes
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_canned_responses_org_name ON canned_responses(organization_id, name)`,
-		`CREATE INDEX IF NOT EXISTS idx_canned_responses_active ON canned_responses(organization_id, is_active, usage_count DESC)`,
-
-		// Webhooks indexes
-		`CREATE INDEX IF NOT EXISTS idx_webhooks_org_active ON webhooks(organization_id, is_active)`,
-
-		// User availability logs indexes
-		`CREATE INDEX IF NOT EXISTS idx_availability_logs_user_time ON user_availability_logs(user_id, started_at DESC)`,
-		`CREATE INDEX IF NOT EXISTS idx_availability_logs_org_time ON user_availability_logs(organization_id, started_at DESC)`,
-
-		// SSO providers indexes
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_sso_providers_org_provider ON sso_providers(organization_id, provider)`,
-
-		// Custom roles indexes
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_custom_roles_org_name ON custom_roles(organization_id, name)`,
-		`CREATE INDEX IF NOT EXISTS idx_custom_roles_org_system ON custom_roles(organization_id, is_system)`,
-		`CREATE INDEX IF NOT EXISTS idx_custom_roles_org_default ON custom_roles(organization_id, is_default) WHERE is_default = true`,
-	}
-
-	for _, idx := range indexes {
+	for _, idx := range getIndexes() {
 		if err := db.Exec(idx).Error; err != nil {
 			return fmt.Errorf("failed to create index: %w", err)
 		}
 	}
-
 	return nil
 }
 

--- a/internal/handlers/analytics.go
+++ b/internal/handlers/analytics.go
@@ -32,7 +32,7 @@ type RecentMessageResponse struct {
 
 // GetDashboardStats returns dashboard statistics for the organization
 func (a *App) GetDashboardStats(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -55,7 +55,7 @@ func (a *App) GetDashboardStats(r *fastglue.Request) error {
 			return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid 'to' date format. Use YYYY-MM-DD", nil, "")
 		}
 		// End of day for the to date
-		periodEnd = periodEnd.Add(24*time.Hour - time.Nanosecond)
+		periodEnd = endOfDay(periodEnd)
 	} else {
 		// Default to current month
 		periodStart = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)

--- a/internal/handlers/apikeys.go
+++ b/internal/handlers/apikeys.go
@@ -50,7 +50,7 @@ func generateAPIKey() (string, error) {
 
 // ListAPIKeys returns all API keys for the organization
 func (a *App) ListAPIKeys(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -85,7 +85,7 @@ func (a *App) ListAPIKeys(r *fastglue.Request) error {
 
 // CreateAPIKey creates a new API key
 func (a *App) CreateAPIKey(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -160,7 +160,7 @@ func (a *App) CreateAPIKey(r *fastglue.Request) error {
 
 // DeleteAPIKey revokes an API key
 func (a *App) DeleteAPIKey(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}

--- a/internal/handlers/campaigns_test.go
+++ b/internal/handlers/campaigns_test.go
@@ -309,7 +309,7 @@ func TestApp_CreateCampaign_TemplateNotFound(t *testing.T) {
 
 	err := app.CreateCampaign(req)
 	require.NoError(t, err)
-	assert.Equal(t, fasthttp.StatusBadRequest, testutil.GetResponseStatusCode(req))
+	assert.Equal(t, fasthttp.StatusNotFound, testutil.GetResponseStatusCode(req))
 }
 
 func TestApp_CreateCampaign_AccountNotFound(t *testing.T) {

--- a/internal/handlers/canned_responses.go
+++ b/internal/handlers/canned_responses.go
@@ -32,7 +32,7 @@ type CannedResponseResponse struct {
 
 // ListCannedResponses returns all canned responses for the organization
 func (a *App) ListCannedResponses(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -77,7 +77,7 @@ func (a *App) ListCannedResponses(r *fastglue.Request) error {
 
 // CreateCannedResponse creates a new canned response
 func (a *App) CreateCannedResponse(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -123,15 +123,14 @@ func (a *App) CreateCannedResponse(r *fastglue.Request) error {
 
 // GetCannedResponse returns a single canned response
 func (a *App) GetCannedResponse(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
 
-	idStr, _ := r.RequestCtx.UserValue("id").(string)
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id", "canned response")
 	if err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid ID", nil, "")
+		return nil
 	}
 
 	var cannedResponse models.CannedResponse
@@ -146,15 +145,14 @@ func (a *App) GetCannedResponse(r *fastglue.Request) error {
 
 // UpdateCannedResponse updates an existing canned response
 func (a *App) UpdateCannedResponse(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
 
-	idStr, _ := r.RequestCtx.UserValue("id").(string)
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id", "canned response")
 	if err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid ID", nil, "")
+		return nil
 	}
 
 	var cannedResponse models.CannedResponse
@@ -191,15 +189,14 @@ func (a *App) UpdateCannedResponse(r *fastglue.Request) error {
 
 // DeleteCannedResponse deletes a canned response
 func (a *App) DeleteCannedResponse(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
 
-	idStr, _ := r.RequestCtx.UserValue("id").(string)
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id", "canned response")
 	if err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid ID", nil, "")
+		return nil
 	}
 
 	var cannedResponse models.CannedResponse
@@ -220,15 +217,14 @@ func (a *App) DeleteCannedResponse(r *fastglue.Request) error {
 
 // IncrementCannedResponseUsage increments the usage counter
 func (a *App) IncrementCannedResponseUsage(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
 
-	idStr, _ := r.RequestCtx.UserValue("id").(string)
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id", "canned response")
 	if err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid ID", nil, "")
+		return nil
 	}
 
 	if err := a.DB.Model(&models.CannedResponse{}).

--- a/internal/handlers/chatbot.go
+++ b/internal/handlers/chatbot.go
@@ -98,7 +98,7 @@ type AIContextResponse struct {
 
 // GetChatbotSettings returns chatbot settings and stats
 func (a *App) GetChatbotSettings(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -195,7 +195,7 @@ func (a *App) GetChatbotSettings(r *fastglue.Request) error {
 
 // UpdateChatbotSettings updates chatbot settings
 func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -386,7 +386,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 
 // ListKeywordRules lists all keyword rules for the organization
 func (a *App) ListKeywordRules(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -421,7 +421,7 @@ func (a *App) ListKeywordRules(r *fastglue.Request) error {
 
 // CreateKeywordRule creates a new keyword rule
 func (a *App) CreateKeywordRule(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -482,7 +482,7 @@ func (a *App) CreateKeywordRule(r *fastglue.Request) error {
 
 // GetKeywordRule gets a single keyword rule
 func (a *App) GetKeywordRule(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -493,9 +493,9 @@ func (a *App) GetKeywordRule(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid rule ID", nil, "")
 	}
 
-	var rule models.KeywordRule
-	if err := a.DB.Where("id = ? AND organization_id = ?", id, orgID).First(&rule).Error; err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Keyword rule not found", nil, "")
+	rule, err := findByIDAndOrg[models.KeywordRule](a.DB, r, id, orgID, "Keyword rule")
+	if err != nil {
+		return nil
 	}
 
 	responseContent, _ := json.Marshal(rule.ResponseContent)
@@ -516,7 +516,7 @@ func (a *App) GetKeywordRule(r *fastglue.Request) error {
 
 // UpdateKeywordRule updates a keyword rule
 func (a *App) UpdateKeywordRule(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -527,9 +527,9 @@ func (a *App) UpdateKeywordRule(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid rule ID", nil, "")
 	}
 
-	var rule models.KeywordRule
-	if err := a.DB.Where("id = ? AND organization_id = ?", id, orgID).First(&rule).Error; err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Keyword rule not found", nil, "")
+	rule, err := findByIDAndOrg[models.KeywordRule](a.DB, r, id, orgID, "Keyword rule")
+	if err != nil {
+		return nil
 	}
 
 	var req struct {
@@ -569,7 +569,7 @@ func (a *App) UpdateKeywordRule(r *fastglue.Request) error {
 		rule.IsEnabled = *req.Enabled
 	}
 
-	if err := a.DB.Save(&rule).Error; err != nil {
+	if err := a.DB.Save(rule).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update keyword rule", nil, "")
 	}
 
@@ -583,7 +583,7 @@ func (a *App) UpdateKeywordRule(r *fastglue.Request) error {
 
 // DeleteKeywordRule deletes a keyword rule
 func (a *App) DeleteKeywordRule(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -617,7 +617,7 @@ func (a *App) ListChatbotFlows(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Permission denied", nil, "")
 	}
 
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -676,7 +676,7 @@ func (a *App) CreateChatbotFlow(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Permission denied", nil, "")
 	}
 
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -784,7 +784,7 @@ func (a *App) GetChatbotFlow(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Permission denied", nil, "")
 	}
 
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -814,7 +814,7 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Permission denied", nil, "")
 	}
 
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -825,9 +825,9 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid flow ID", nil, "")
 	}
 
-	var flow models.ChatbotFlow
-	if err := a.DB.Where("id = ? AND organization_id = ?", id, orgID).First(&flow).Error; err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Flow not found", nil, "")
+	flow, err := findByIDAndOrg[models.ChatbotFlow](a.DB, r, id, orgID, "Flow")
+	if err != nil {
+		return nil
 	}
 
 	var req struct {
@@ -877,7 +877,7 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 		flow.IsEnabled = *req.Enabled
 	}
 
-	if err := tx.Save(&flow).Error; err != nil {
+	if err := tx.Save(flow).Error; err != nil {
 		tx.Rollback()
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update flow", nil, "")
 	}
@@ -949,7 +949,7 @@ func (a *App) DeleteChatbotFlow(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Permission denied", nil, "")
 	}
 
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -992,7 +992,7 @@ func (a *App) DeleteChatbotFlow(r *fastglue.Request) error {
 
 // ListAIContexts lists all AI contexts
 func (a *App) ListAIContexts(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -1025,7 +1025,7 @@ func (a *App) ListAIContexts(r *fastglue.Request) error {
 
 // CreateAIContext creates a new AI context
 func (a *App) CreateAIContext(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -1076,7 +1076,7 @@ func (a *App) CreateAIContext(r *fastglue.Request) error {
 
 // GetAIContext gets a single AI context
 func (a *App) GetAIContext(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -1087,17 +1087,17 @@ func (a *App) GetAIContext(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid context ID", nil, "")
 	}
 
-	var ctx models.AIContext
-	if err := a.DB.Where("id = ? AND organization_id = ?", id, orgID).First(&ctx).Error; err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "AI context not found", nil, "")
+	aiCtx, err := findByIDAndOrg[models.AIContext](a.DB, r, id, orgID, "AI context")
+	if err != nil {
+		return nil
 	}
 
-	return r.SendEnvelope(ctx)
+	return r.SendEnvelope(aiCtx)
 }
 
 // UpdateAIContext updates an AI context
 func (a *App) UpdateAIContext(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -1108,9 +1108,9 @@ func (a *App) UpdateAIContext(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid context ID", nil, "")
 	}
 
-	var ctx models.AIContext
-	if err := a.DB.Where("id = ? AND organization_id = ?", id, orgID).First(&ctx).Error; err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "AI context not found", nil, "")
+	aiCtx, err := findByIDAndOrg[models.AIContext](a.DB, r, id, orgID, "AI context")
+	if err != nil {
+		return nil
 	}
 
 	var req struct {
@@ -1127,25 +1127,25 @@ func (a *App) UpdateAIContext(r *fastglue.Request) error {
 	}
 
 	if req.Name != nil {
-		ctx.Name = *req.Name
+		aiCtx.Name = *req.Name
 	}
 	if req.ContextType != nil {
-		ctx.ContextType = *req.ContextType
+		aiCtx.ContextType = *req.ContextType
 	}
 	if len(req.TriggerKeywords) > 0 {
-		ctx.TriggerKeywords = req.TriggerKeywords
+		aiCtx.TriggerKeywords = req.TriggerKeywords
 	}
 	if req.StaticContent != nil {
-		ctx.StaticContent = *req.StaticContent
+		aiCtx.StaticContent = *req.StaticContent
 	}
 	if req.Priority != nil {
-		ctx.Priority = *req.Priority
+		aiCtx.Priority = *req.Priority
 	}
 	if req.Enabled != nil {
-		ctx.IsEnabled = *req.Enabled
+		aiCtx.IsEnabled = *req.Enabled
 	}
 
-	if err := a.DB.Save(&ctx).Error; err != nil {
+	if err := a.DB.Save(aiCtx).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update AI context", nil, "")
 	}
 
@@ -1159,7 +1159,7 @@ func (a *App) UpdateAIContext(r *fastglue.Request) error {
 
 // DeleteAIContext deletes an AI context
 func (a *App) DeleteAIContext(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -1188,7 +1188,7 @@ func (a *App) DeleteAIContext(r *fastglue.Request) error {
 
 // ListChatbotSessions lists chatbot sessions
 func (a *App) ListChatbotSessions(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -1215,7 +1215,7 @@ func (a *App) ListChatbotSessions(r *fastglue.Request) error {
 
 // GetChatbotSession gets a single chatbot session with messages
 func (a *App) GetChatbotSession(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valyala/fasthttp"
+	"github.com/zerodha/fastglue"
+	"gorm.io/gorm"
+)
+
+// errEnvelopeSent is a sentinel returned by helpers after they have already
+// written an error envelope to the response. Callers should return nil to the framework.
+var errEnvelopeSent = errors.New("error envelope sent")
+
+// parsePathUUID extracts a UUID from a path parameter. On failure, it sends a
+// 400 error envelope and returns uuid.Nil plus an error.
+func parsePathUUID(r *fastglue.Request, param, label string) (uuid.UUID, error) {
+	idStr, _ := r.RequestCtx.UserValue(param).(string)
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		_ = r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid "+label+" ID", nil, "")
+		return uuid.Nil, errEnvelopeSent
+	}
+	return id, nil
+}
+
+// Pagination holds parsed pagination parameters.
+type Pagination struct {
+	Page   int
+	Limit  int
+	Offset int
+}
+
+// parsePagination extracts page-based pagination from query params with
+// default limit=50 and max limit=100.
+func parsePagination(r *fastglue.Request) Pagination {
+	return parsePaginationWithDefaults(r, 50, 100)
+}
+
+// parsePaginationWithDefaults extracts page-based pagination with custom defaults.
+func parsePaginationWithDefaults(r *fastglue.Request, defaultLimit, maxLimit int) Pagination {
+	page, _ := strconv.Atoi(string(r.RequestCtx.QueryArgs().Peek("page")))
+	limit, _ := strconv.Atoi(string(r.RequestCtx.QueryArgs().Peek("limit")))
+
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > maxLimit {
+		limit = defaultLimit
+	}
+	return Pagination{
+		Page:   page,
+		Limit:  limit,
+		Offset: (page - 1) * limit,
+	}
+}
+
+// parseDateParam parses a YYYY-MM-DD date from the named query parameter.
+// Returns the parsed time and true on success, or zero time and false if the
+// parameter is missing or malformed.
+func parseDateParam(r *fastglue.Request, param string) (time.Time, bool) {
+	s := string(r.RequestCtx.QueryArgs().Peek(param))
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// endOfDay returns the last nanosecond of the given day.
+func endOfDay(t time.Time) time.Time {
+	return t.Add(24*time.Hour - time.Nanosecond)
+}
+
+// findByIDAndOrg fetches a single record scoped by ID and organization.
+// Sends a 404 error envelope on failure and returns the error.
+func findByIDAndOrg[T any](db *gorm.DB, r *fastglue.Request, id, orgID uuid.UUID, label string) (*T, error) {
+	var model T
+	if err := db.Where("id = ? AND organization_id = ?", id, orgID).First(&model).Error; err != nil {
+		_ = r.SendErrorEnvelope(fasthttp.StatusNotFound, label+" not found", nil, "")
+		return nil, errEnvelopeSent
+	}
+	return &model, nil
+}

--- a/internal/handlers/media.go
+++ b/internal/handlers/media.go
@@ -148,9 +148,9 @@ func (a *App) ServeMedia(r *fastglue.Request) error {
 	}
 
 	// Find the message and verify access
-	var message models.Message
-	if err := a.DB.Where("id = ? AND organization_id = ?", messageID, orgID).First(&message).Error; err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Message not found", nil, "")
+	message, err := findByIDAndOrg[models.Message](a.DB, r, messageID, orgID, "Message")
+	if err != nil {
+		return nil
 	}
 
 	// Users without contacts:read permission can only access media from their assigned contacts

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -3,12 +3,12 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/shridarpatil/whatomate/internal/models"
+	"github.com/shridarpatil/whatomate/internal/templateutil"
 	"github.com/shridarpatil/whatomate/internal/websocket"
 	"github.com/shridarpatil/whatomate/pkg/whatsapp"
 	"github.com/valyala/fasthttp"
@@ -271,7 +271,7 @@ func (a *App) createOutgoingMessage(req OutgoingMessageRequest, opts MessageSend
 	case models.MessageTypeTemplate:
 		if req.Template != nil {
 			// Store actual rendered content instead of just template name
-			content := replaceTemplateParams(req.Template.BodyContent, req.BodyParams)
+			content := templateutil.ReplaceWithStringParams(req.Template.BodyContent, req.BodyParams)
 			if content == "" {
 				content = fmt.Sprintf("[Template: %s]", req.Template.DisplayName)
 			}
@@ -499,7 +499,7 @@ type SendTemplateMessageRequest struct {
 
 // SendTemplateMessage sends a template message to a contact or phone number
 func (a *App) SendTemplateMessage(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -527,9 +527,11 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		if err != nil {
 			return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid template_id", nil, "")
 		}
-		if err := a.DB.Where("id = ? AND organization_id = ?", templateID, orgID).First(&template).Error; err != nil {
-			return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Template not found", nil, "")
+		t, err := findByIDAndOrg[models.Template](a.DB, r, templateID, orgID, "Template")
+		if err != nil {
+			return nil
 		}
+		template = *t
 	} else {
 		if err := a.DB.Where("name = ? AND organization_id = ?", req.TemplateName, orgID).First(&template).Error; err != nil {
 			return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Template not found", nil, "")
@@ -550,11 +552,11 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		if err != nil {
 			return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid contact_id", nil, "")
 		}
-		var c models.Contact
-		if err := a.DB.Where("id = ? AND organization_id = ?", cID, orgID).First(&c).Error; err != nil {
-			return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
+		c, err := findByIDAndOrg[models.Contact](a.DB, r, cID, orgID, "Contact")
+		if err != nil {
+			return nil
 		}
-		contact = &c
+		contact = c
 		phoneNumber = c.PhoneNumber
 	} else {
 		// Find or create contact from phone number
@@ -601,8 +603,8 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 	}
 
 	// Extract parameter names and resolve values
-	paramNames := ExtractParamNamesFromContent(template.BodyContent)
-	bodyParams := ResolveParams(paramNames, req.TemplateParams)
+	paramNames := templateutil.ExtParamNames(template.BodyContent)
+	bodyParams := templateutil.ResolveParamsFromMap(paramNames, req.TemplateParams)
 
 	// Validate that all required parameters are provided
 	if len(paramNames) > 0 {
@@ -645,75 +647,3 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 	})
 }
 
-// ExtractParamNamesFromContent extracts parameter names from template content
-// Supports both positional ({{1}}, {{2}}) and named ({{name}}, {{order_id}}) parameters
-var templateParamPattern = regexp.MustCompile(`\{\{([^}]+)\}\}`)
-
-func ExtractParamNamesFromContent(content string) []string {
-	matches := templateParamPattern.FindAllStringSubmatch(content, -1)
-	if len(matches) == 0 {
-		return nil
-	}
-
-	seen := make(map[string]bool)
-	var names []string
-	for _, match := range matches {
-		if len(match) > 1 {
-			name := strings.TrimSpace(match[1])
-			if name != "" && !seen[name] {
-				seen[name] = true
-				names = append(names, name)
-			}
-		}
-	}
-	return names
-}
-
-// replaceTemplateParams replaces {{1}}, {{2}}, {{name}}, etc. placeholders with actual values
-func replaceTemplateParams(content string, params map[string]string) string {
-	if content == "" || len(params) == 0 {
-		return content
-	}
-
-	result := content
-	// Extract param names from content to replace placeholders
-	paramNames := ExtractParamNamesFromContent(content)
-	for i, name := range paramNames {
-		// Try to get value by name first (works for both named and positional)
-		if val, ok := params[name]; ok {
-			result = strings.ReplaceAll(result, fmt.Sprintf("{{%s}}", name), val)
-			continue
-		}
-		// Fall back to positional key (1-indexed)
-		key := fmt.Sprintf("%d", i+1)
-		if val, ok := params[key]; ok {
-			result = strings.ReplaceAll(result, fmt.Sprintf("{{%s}}", name), val)
-		}
-	}
-	return result
-}
-
-// ResolveParams resolves both positional and named parameters to ordered values
-func ResolveParams(paramNames []string, params map[string]string) []string {
-	if len(paramNames) == 0 || len(params) == 0 {
-		return nil
-	}
-
-	result := make([]string, len(paramNames))
-	for i, name := range paramNames {
-		// Try named key first
-		if val, ok := params[name]; ok {
-			result[i] = val
-			continue
-		}
-		// Fall back to positional key (1-indexed)
-		key := fmt.Sprintf("%d", i+1)
-		if val, ok := params[key]; ok {
-			result[i] = val
-			continue
-		}
-		// Default to empty string
-		result[i] = ""
-	}
-	return result
-}

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -18,7 +18,7 @@ type OrganizationSettings struct {
 
 // GetOrganizationSettings returns the organization settings
 func (a *App) GetOrganizationSettings(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -55,7 +55,7 @@ func (a *App) GetOrganizationSettings(r *fastglue.Request) error {
 
 // UpdateOrganizationSettings updates the organization settings
 func (a *App) UpdateOrganizationSettings(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -197,7 +197,7 @@ func (a *App) ListOrganizations(r *fastglue.Request) error {
 
 // GetCurrentOrganization returns the current user's organization details
 func (a *App) GetCurrentOrganization(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}

--- a/internal/handlers/sso.go
+++ b/internal/handlers/sso.go
@@ -353,7 +353,7 @@ func (a *App) CallbackSSO(r *fastglue.Request) error {
 
 // GetSSOSettings returns all SSO provider configs for the organization (admin only)
 func (a *App) GetSSOSettings(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -386,7 +386,7 @@ func (a *App) GetSSOSettings(r *fastglue.Request) error {
 
 // UpdateSSOProvider creates or updates an SSO provider config (admin only)
 func (a *App) UpdateSSOProvider(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -467,7 +467,7 @@ func (a *App) UpdateSSOProvider(r *fastglue.Request) error {
 
 // DeleteSSOProvider removes an SSO provider config (admin only)
 func (a *App) DeleteSSOProvider(r *fastglue.Request) error {
-	orgID, err := a.getOrgIDFromContext(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}

--- a/internal/handlers/teams.go
+++ b/internal/handlers/teams.go
@@ -345,9 +345,9 @@ func (a *App) AddTeamMember(r *fastglue.Request) error {
 	}
 
 	// Verify user exists in org
-	var user models.User
-	if err := a.DB.Where("id = ? AND organization_id = ?", memberUserID, orgID).First(&user).Error; err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "User not found", nil, "")
+	user, err := findByIDAndOrg[models.User](a.DB, r, memberUserID, orgID, "User")
+	if err != nil {
+		return nil
 	}
 
 	// Check if already a member

--- a/internal/handlers/templates_test.go
+++ b/internal/handlers/templates_test.go
@@ -3,42 +3,43 @@ package handlers
 import (
 	"testing"
 
+	"github.com/shridarpatil/whatomate/internal/templateutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtractParameterNames_PositionalParams(t *testing.T) {
+func TestExtParamNames_PositionalParams(t *testing.T) {
 	content := "Hello {{1}}, your order {{2}} is ready!"
-	result := extractParameterNames(content)
+	result := templateutil.ExtParamNames(content)
 	assert.Equal(t, []string{"1", "2"}, result)
 }
 
-func TestExtractParameterNames_NamedParams(t *testing.T) {
+func TestExtParamNames_NamedParams(t *testing.T) {
 	content := "Hello {{name}}, your order {{order_id}} is ready!"
-	result := extractParameterNames(content)
+	result := templateutil.ExtParamNames(content)
 	assert.Equal(t, []string{"name", "order_id"}, result)
 }
 
-func TestExtractParameterNames_MixedParams(t *testing.T) {
+func TestExtParamNames_MixedParams(t *testing.T) {
 	content := "Hello {{1}}, your order {{order_id}} is ready! Amount: {{3}}"
-	result := extractParameterNames(content)
+	result := templateutil.ExtParamNames(content)
 	assert.Equal(t, []string{"1", "order_id", "3"}, result)
 }
 
-func TestExtractParameterNames_NoParams(t *testing.T) {
+func TestExtParamNames_NoParams(t *testing.T) {
 	content := "Hello, your order is ready!"
-	result := extractParameterNames(content)
+	result := templateutil.ExtParamNames(content)
 	assert.Nil(t, result)
 }
 
-func TestExtractParameterNames_DuplicateParams(t *testing.T) {
+func TestExtParamNames_DuplicateParams(t *testing.T) {
 	content := "Hello {{name}}, {{name}} your order {{order_id}} is ready!"
-	result := extractParameterNames(content)
+	result := templateutil.ExtParamNames(content)
 	// Should only return unique names in order of first occurrence
 	assert.Equal(t, []string{"name", "order_id"}, result)
 }
 
-func TestExtractParameterNames_UnderscoreParams(t *testing.T) {
+func TestExtParamNames_UnderscoreParams(t *testing.T) {
 	content := "Hello {{customer_name}}, order {{order_number}} total {{total_amount}}"
-	result := extractParameterNames(content)
+	result := templateutil.ExtParamNames(content)
 	assert.Equal(t, []string{"customer_name", "order_number", "total_amount"}, result)
 }

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -68,7 +68,7 @@ type ChangePasswordRequest struct {
 
 // ListUsers returns all users for the organization
 func (a *App) ListUsers(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -100,7 +100,7 @@ func (a *App) ListUsers(r *fastglue.Request) error {
 
 // GetUser returns a single user
 func (a *App) GetUser(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -123,7 +123,7 @@ func (a *App) GetUser(r *fastglue.Request) error {
 
 // CreateUser creates a new user (admin only)
 func (a *App) CreateUser(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -203,7 +203,7 @@ func (a *App) CreateUser(r *fastglue.Request) error {
 
 // UpdateUser updates a user
 func (a *App) UpdateUser(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -317,7 +317,7 @@ func (a *App) UpdateUser(r *fastglue.Request) error {
 
 // DeleteUser deletes a user
 func (a *App) DeleteUser(r *fastglue.Request) error {
-	orgID, err := getOrganizationID(r)
+	orgID, err := a.getOrgID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}

--- a/internal/templateutil/templateutil.go
+++ b/internal/templateutil/templateutil.go
@@ -1,0 +1,145 @@
+package templateutil
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ParameterPattern matches template parameters like {{1}}, {{name}}, {{order_id}}
+var ParameterPattern = regexp.MustCompile(`\{\{([^}]+)\}\}`)
+
+// ExtParamNames extracts parameter names from template content.
+// Supports both positional ({{1}}, {{2}}) and named ({{name}}, {{order_id}}) parameters.
+// Returns parameter names in order of first occurrence, without duplicates.
+func ExtParamNames(content string) []string {
+	matches := ParameterPattern.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var names []string
+	for _, match := range matches {
+		if len(match) > 1 {
+			name := strings.TrimSpace(match[1])
+			if name != "" && !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// ResolveParamsFromMap resolves both positional and named parameters to ordered values
+// using a map[string]string parameter source.
+func ResolveParamsFromMap(paramNames []string, params map[string]string) []string {
+	if len(paramNames) == 0 || len(params) == 0 {
+		return nil
+	}
+
+	result := make([]string, len(paramNames))
+	for i, name := range paramNames {
+		// Try named key first
+		if val, ok := params[name]; ok {
+			result[i] = val
+			continue
+		}
+		// Fall back to positional key (1-indexed)
+		key := fmt.Sprintf("%d", i+1)
+		if val, ok := params[key]; ok {
+			result[i] = val
+			continue
+		}
+		// Default to empty string
+		result[i] = ""
+	}
+	return result
+}
+
+// ResolveParams resolves both positional and named parameters to ordered values
+// using a map[string]interface{} parameter source (e.g. models.JSONB).
+func ResolveParams(bodyContent string, params map[string]interface{}) []string {
+	if len(params) == 0 {
+		return nil
+	}
+
+	paramNames := ExtParamNames(bodyContent)
+	if len(paramNames) == 0 {
+		return nil
+	}
+
+	result := make([]string, len(paramNames))
+	for i, name := range paramNames {
+		// Try named key first
+		if val, ok := params[name]; ok {
+			result[i] = fmt.Sprintf("%v", val)
+			continue
+		}
+		// Fall back to positional key (1-indexed)
+		key := fmt.Sprintf("%d", i+1)
+		if val, ok := params[key]; ok {
+			result[i] = fmt.Sprintf("%v", val)
+			continue
+		}
+		// Default to empty string
+		result[i] = ""
+	}
+	return result
+}
+
+// ReplaceWithStringParams replaces {{1}}, {{2}}, {{name}}, etc. placeholders with actual values
+// from a map[string]string.
+func ReplaceWithStringParams(content string, params map[string]string) string {
+	if content == "" || len(params) == 0 {
+		return content
+	}
+
+	result := content
+	paramNames := ExtParamNames(content)
+	for i, name := range paramNames {
+		// Try to get value by name first (works for both named and positional)
+		if val, ok := params[name]; ok {
+			result = strings.ReplaceAll(result, fmt.Sprintf("{{%s}}", name), val)
+			continue
+		}
+		// Fall back to positional key (1-indexed)
+		key := fmt.Sprintf("%d", i+1)
+		if val, ok := params[key]; ok {
+			result = strings.ReplaceAll(result, fmt.Sprintf("{{%s}}", name), val)
+		}
+	}
+	return result
+}
+
+// ReplaceWithJSONBParams replaces both positional ({{1}}) and named ({{name}}) placeholders
+// using a map[string]interface{} parameter source. bodyContent is used to extract parameter
+// names (typically the template's body content), and content is the string to perform
+// replacements on.
+func ReplaceWithJSONBParams(bodyContent, content string, params map[string]interface{}) string {
+	if len(params) == 0 {
+		return content
+	}
+
+	paramNames := ExtParamNames(bodyContent)
+	if len(paramNames) == 0 {
+		return content
+	}
+
+	for i, name := range paramNames {
+		// Try named key first
+		var val string
+		if v, ok := params[name]; ok {
+			val = fmt.Sprintf("%v", v)
+		} else if v, ok := params[fmt.Sprintf("%d", i+1)]; ok {
+			// Fall back to positional key
+			val = fmt.Sprintf("%v", v)
+		}
+
+		// Replace both named and positional placeholders
+		content = strings.ReplaceAll(content, fmt.Sprintf("{{%s}}", name), val)
+		content = strings.ReplaceAll(content, fmt.Sprintf("{{%d}}", i+1), val)
+	}
+	return content
+}

--- a/internal/templateutil/templateutil_test.go
+++ b/internal/templateutil/templateutil_test.go
@@ -1,0 +1,152 @@
+package templateutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtParamNames_PositionalParams(t *testing.T) {
+	content := "Hello {{1}}, your order {{2}} is ready!"
+	result := ExtParamNames(content)
+	assert.Equal(t, []string{"1", "2"}, result)
+}
+
+func TestExtParamNames_NamedParams(t *testing.T) {
+	content := "Hello {{name}}, your order {{order_id}} is ready!"
+	result := ExtParamNames(content)
+	assert.Equal(t, []string{"name", "order_id"}, result)
+}
+
+func TestExtParamNames_MixedParams(t *testing.T) {
+	content := "Hello {{1}}, your order {{order_id}} is ready! Amount: {{3}}"
+	result := ExtParamNames(content)
+	assert.Equal(t, []string{"1", "order_id", "3"}, result)
+}
+
+func TestExtParamNames_NoParams(t *testing.T) {
+	content := "Hello, your order is ready!"
+	result := ExtParamNames(content)
+	assert.Nil(t, result)
+}
+
+func TestExtParamNames_DuplicateParams(t *testing.T) {
+	content := "Hello {{name}}, {{name}} your order {{order_id}} is ready!"
+	result := ExtParamNames(content)
+	assert.Equal(t, []string{"name", "order_id"}, result)
+}
+
+func TestExtParamNames_UnderscoreParams(t *testing.T) {
+	content := "Hello {{customer_name}}, order {{order_number}} total {{total_amount}}"
+	result := ExtParamNames(content)
+	assert.Equal(t, []string{"customer_name", "order_number", "total_amount"}, result)
+}
+
+func TestResolveParamsFromMap_NamedMatch(t *testing.T) {
+	paramNames := []string{"name", "order_id"}
+	params := map[string]string{
+		"name":     "John",
+		"order_id": "ORD-123",
+	}
+	result := ResolveParamsFromMap(paramNames, params)
+	assert.Equal(t, []string{"John", "ORD-123"}, result)
+}
+
+func TestResolveParamsFromMap_PositionalMatch(t *testing.T) {
+	paramNames := []string{"1", "2"}
+	params := map[string]string{
+		"1": "John",
+		"2": "ORD-123",
+	}
+	result := ResolveParamsFromMap(paramNames, params)
+	assert.Equal(t, []string{"John", "ORD-123"}, result)
+}
+
+func TestResolveParamsFromMap_FallbackToPositional(t *testing.T) {
+	paramNames := []string{"name", "order_id"}
+	params := map[string]string{
+		"1": "John",
+		"2": "ORD-123",
+	}
+	result := ResolveParamsFromMap(paramNames, params)
+	assert.Equal(t, []string{"John", "ORD-123"}, result)
+}
+
+func TestResolveParamsFromMap_MissingParams(t *testing.T) {
+	paramNames := []string{"name", "order_id"}
+	params := map[string]string{
+		"name": "John",
+	}
+	result := ResolveParamsFromMap(paramNames, params)
+	assert.Equal(t, []string{"John", ""}, result)
+}
+
+func TestResolveParamsFromMap_EmptyInputs(t *testing.T) {
+	result1 := ResolveParamsFromMap([]string{}, map[string]string{"a": "b"})
+	assert.Nil(t, result1)
+
+	result2 := ResolveParamsFromMap([]string{"a"}, map[string]string{})
+	assert.Nil(t, result2)
+
+	result3 := ResolveParamsFromMap([]string{}, map[string]string{})
+	assert.Nil(t, result3)
+}
+
+func TestResolveParams(t *testing.T) {
+	bodyContent := "Hello {{name}}, order {{order_id}}"
+	params := map[string]interface{}{
+		"name":     "John",
+		"order_id": "ORD-123",
+	}
+	result := ResolveParams(bodyContent, params)
+	assert.Equal(t, []string{"John", "ORD-123"}, result)
+}
+
+func TestResolveParams_Positional(t *testing.T) {
+	bodyContent := "Hello {{name}}, order {{order_id}}"
+	params := map[string]interface{}{
+		"1": "John",
+		"2": "ORD-123",
+	}
+	result := ResolveParams(bodyContent, params)
+	assert.Equal(t, []string{"John", "ORD-123"}, result)
+}
+
+func TestResolveParams_Empty(t *testing.T) {
+	result := ResolveParams("Hello {{name}}", map[string]interface{}{})
+	assert.Nil(t, result)
+
+	result = ResolveParams("Hello world", map[string]interface{}{"a": "b"})
+	assert.Nil(t, result)
+}
+
+func TestReplaceWithStringParams(t *testing.T) {
+	content := "Hello {{name}}, your order {{order_id}} is ready!"
+	params := map[string]string{
+		"name":     "John",
+		"order_id": "ORD-123",
+	}
+	result := ReplaceWithStringParams(content, params)
+	assert.Equal(t, "Hello John, your order ORD-123 is ready!", result)
+}
+
+func TestReplaceWithStringParams_Empty(t *testing.T) {
+	assert.Equal(t, "", ReplaceWithStringParams("", map[string]string{"a": "b"}))
+	assert.Equal(t, "hello", ReplaceWithStringParams("hello", map[string]string{}))
+}
+
+func TestReplaceWithJSONBParams(t *testing.T) {
+	bodyContent := "Hello {{name}}, order {{order_id}}"
+	content := "Hello {{name}}, order {{order_id}}"
+	params := map[string]interface{}{
+		"name":     "John",
+		"order_id": "ORD-123",
+	}
+	result := ReplaceWithJSONBParams(bodyContent, content, params)
+	assert.Equal(t, "Hello John, order ORD-123", result)
+}
+
+func TestReplaceWithJSONBParams_Empty(t *testing.T) {
+	result := ReplaceWithJSONBParams("Hello {{name}}", "Hello {{name}}", map[string]interface{}{})
+	assert.Equal(t, "Hello {{name}}", result)
+}


### PR DESCRIPTION
- Unify org ID extraction into a single getOrgID method
- Extract shared template parameter utilities into internal/templateutil
- Consolidate duplicate database index definitions in postgres.go
- Merge media parameter builders into a single buildMediaParameter function
- Add request parsing helpers (parsePathUUID, parsePagination, parseDateParam)
- Add generic findByIDAndOrg[T] helper for org-scoped DB lookups
- Unify contact creation logic into internal/contactutil
- Net reduction of ~500 lines across 26 files