### PR TITLE
Fix: ensure notification toasts respect dark mode settings

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,14 +5,14 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { useColorMode } from '@/composables/useColorMode'
 
 // Initialize color mode early
-useColorMode()
+const { colorMode } = useColorMode()
 </script>
 
 <template>
   <TooltipProvider>
     <div class="min-h-screen bg-background font-sans antialiased">
       <RouterView />
-      <Toaster position="top-right" richColors />
+      <Toaster position="top-right" richColors :theme="colorMode" />
     </div>
   </TooltipProvider>
 </template>


### PR DESCRIPTION
# fix(ui): sync notification toast theme with application color mode

## Description
This PR fixes an issue where notification toasts (using `vue-sonner`) remained in light mode even when the application was switched to dark mode. The `Toaster` component was missing the `theme` prop binding, causing it to ignore the application's current color scheme.

## Changes
- Updated `App.vue` to destructure `colorMode` from the `useColorMode` composable.
- Bound the `colorMode` state to the `theme` prop of the `<Toaster />` component.

## 📸 Screenshots

| Before (Dark Mode with Light Toast) | After (Dark Mode with Dark Toast) |
|:-----------------------------------:|:---------------------------------:|
| <img width="400" alt="Before Fix" src="https://github.com/user-attachments/assets/a11339c2-eacf-42e1-b018-6e968e0ccffb" /> | <img width="400" alt="After Fix" src="https://github.com/user-attachments/assets/a47f760d-35f7-4383-90bb-952ca3f349ab" /> |