### PR TITLE
feat: expand dashboard shortcuts with all nav pages

### DIFF
--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -1198,7 +1198,7 @@ onMounted(() => {
               </div>
 
               <div class="flex-1 min-h-0 overflow-y-auto px-6 pb-6">
-                <div class="grid grid-cols-2 lg:grid-cols-3 gap-3">
+                <div :class="['grid gap-3 pt-1', item.w >= 8 ? 'grid-cols-3' : 'grid-cols-2']">
                   <template v-for="key in (getWidgetById(item.i)!.config?.shortcuts || [])" :key="key">
                     <RouterLink
                       v-if="SHORTCUT_REGISTRY[key as keyof typeof SHORTCUT_REGISTRY]"


### PR DESCRIPTION
Add all settings and nav pages to the SHORTCUT_REGISTRY (users, tags, canned responses, roles, API keys, webhooks, SSO, custom actions, teams, accounts, flows, transfers, analytics). Use correct icons from navigation config and reuse existing nav i18n keys. Add overflow scroll to shortcuts widget and 3-column layout on large screens.