### PR TITLE
perf: replace permissions Preload(IN) with JOIN query

### DIFF
--- a/internal/handlers/cache.go
+++ b/internal/handlers/cache.go
@@ -437,9 +437,12 @@ func (a *App) getUserPermissionsCached(userID uuid.UUID, orgIDs ...uuid.UUID) (*
 		return nil, gorm.ErrRecordNotFound
 	}
 
-	// Fetch role with permissions
+	// Fetch role and load permissions via JOIN
 	var role models.CustomRole
-	if err := a.DB.Preload("Permissions").Where("id = ?", roleID).First(&role).Error; err != nil {
+	if err := a.DB.Where("id = ?", roleID).First(&role).Error; err != nil {
+		return nil, err
+	}
+	if err := a.loadRolePermissions(&role); err != nil {
 		return nil, err
 	}
 
@@ -555,9 +558,12 @@ func (a *App) GetRolePermissionsCached(roleID uuid.UUID) ([]string, error) {
 		}
 	}
 
-	// Cache miss - fetch from database
+	// Cache miss - fetch from database via JOIN
 	var role models.CustomRole
-	if err := a.DB.Preload("Permissions").Where("id = ?", roleID).First(&role).Error; err != nil {
+	if err := a.DB.Where("id = ?", roleID).First(&role).Error; err != nil {
+		return nil, err
+	}
+	if err := a.loadRolePermissions(&role); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
GORM's Preload("Permissions") on many-to-many generates a slow SELECT * FROM permissions WHERE id IN (...67 UUIDs...) query. Replace with a single JOIN through role_permissions, reducing from 3 queries to 2 and shrinking the IN clause from 67 permission UUIDs to just the role IDs.