### PR TITLE
Update main.go

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -217,6 +217,7 @@ func runServer(args []string) {
 		Handler:      corsWrapper(g.Handler(), allowedOrigins),
 		ReadTimeout:  time.Duration(cfg.Server.ReadTimeout) * time.Second,
 		WriteTimeout: time.Duration(cfg.Server.WriteTimeout) * time.Second,
+		MaxRequestBodySize: 15 * 1024 * 1024,
 		Name:         "Whatomate",
 	}
 


### PR DESCRIPTION
added 
MaxRequestBodySize: 15 * 1024 * 1024,
so on uploading document in the template creation we can handle this error