### PR TITLE
fix: espeak-ng-data path in Docker and update Piper references

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -64,12 +64,12 @@ window_seconds = 60            # Time window in seconds
 trust_proxy = false            # Trust X-Forwarded-For / X-Real-IP headers (set true behind reverse proxy)
 
 # Text-to-Speech for IVR greetings (optional, requires piper + opusenc installed)
-# Download piper: https://github.com/rhasspy/piper/releases
+# Download piper: https://github.com/rhasspy/piper/releases (standalone binary)
 # Download voice models: https://huggingface.co/rhasspy/piper-voices
 # Install opusenc: apt install opus-tools (Debian/Ubuntu) / dnf install opus-tools (Fedora)
 [tts]
-piper_binary = "/usr/local/bin/piper"
-piper_model = "/opt/piper/models/en_US-lessac-medium.onnx"
+# piper_binary = "/usr/local/bin/piper"
+# piper_model = "/opt/piper/models/en_US-lessac-medium.onnx"
 # opusenc_binary = "opusenc"  # defaults to finding in PATH
 
 # WhatsApp Calling / WebRTC

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=builder /app/config.example.toml ./config.toml
 # Install Piper TTS binary + shared libraries
 COPY --from=piper-dl /tmp/piper/piper /usr/local/bin/piper
 COPY --from=piper-dl /tmp/piper/lib*.so* /usr/local/lib/
-COPY --from=piper-dl /tmp/piper/espeak-ng-data /usr/local/share/espeak-ng-data
+COPY --from=piper-dl /tmp/piper/espeak-ng-data /usr/share/espeak-ng-data
 RUN ldconfig
 
 # Install default voice model

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -30,7 +30,7 @@ COPY whatomate .
 # Install Piper TTS binary + shared libraries
 COPY --from=piper-dl /tmp/piper/piper /usr/local/bin/piper
 COPY --from=piper-dl /tmp/piper/lib*.so* /usr/local/lib/
-COPY --from=piper-dl /tmp/piper/espeak-ng-data /usr/local/share/espeak-ng-data
+COPY --from=piper-dl /tmp/piper/espeak-ng-data /usr/share/espeak-ng-data
 RUN ldconfig
 
 # Install default voice model

--- a/docs/src/content/docs/features/calling.mdx
+++ b/docs/src/content/docs/features/calling.mdx
@@ -158,7 +158,7 @@ Calling is enabled per-organization in the database. Set `calling_enabled = true
 
 ## Text-to-Speech (IVR Greetings)
 
-Whatomate uses [Piper](https://github.com/rhasspy/piper) for offline text-to-speech generation. When admins type greeting text in the IVR flow editor, the server generates OGG/Opus audio files using Piper + `opusenc`. This is optional — you can also upload pre-recorded audio files directly.
+Whatomate uses [Piper](https://github.com/OHF-Voice/piper1-gpl) for offline text-to-speech generation. When admins type greeting text in the IVR flow editor, the server generates OGG/Opus audio files using Piper + `opusenc`. This is optional — you can also upload pre-recorded audio files directly.
 
 ### Install Dependencies
 
@@ -183,7 +183,7 @@ sudo mv piper/piper /usr/local/bin/
 
 ### Download a Voice Model
 
-Piper voices are available at [huggingface.co/rhasspy/piper-voices](https://huggingface.co/rhasspy/piper-voices). Each voice has a `.onnx` model file and a `.onnx.json` config file — both are required.
+Piper voices are available at [huggingface.co/rhasspy/piper-voices](https://huggingface.co/rhasspy/piper-voices) (mirrors at [OHF-Voice](https://huggingface.co/OHF-Voice)). Each voice has a `.onnx` model file and a `.onnx.json` config file — both are required.
 
 **Choosing a voice:**
 - Browse voices and listen to samples at [rhasspy.github.io/piper-samples](https://rhasspy.github.io/piper-samples/)


### PR DESCRIPTION
Copy espeak-ng-data to /usr/share/ where Piper expects it (not /usr/local/share/), re-comment TTS config defaults, and update Piper project links to OHF-Voice/piper1-gpl.