### PR TITLE
docs: in quickstart doc add step to copy config.toml to docker/

### DIFF
--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -15,6 +15,7 @@ The fastest way to get started:
 # Clone the repository
 git clone https://github.com/shridarpatil/whatomate.git
 cd whatomate
+cp config.example.toml docker/config.toml
 
 # Start all services (PostgreSQL, Redis, Server)
 make docker-up


### PR DESCRIPTION
docs: in quickstart doc add step to copy config.toml to docker/ when getting started using docker. Without this, the automatic volume mount creates a directory called config.toml instead in docker/