### PR TITLE
fix: seed default dashboard widgets when creating a new organization

### DIFF
--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -665,7 +665,25 @@ func SeedDefaultWidgets(db *gorm.DB) error {
 		return fmt.Errorf("failed to fetch organizations: %w", err)
 	}
 
-	// Default widget definitions
+	for _, org := range orgs {
+		// Skip orgs that already have widgets
+		var exists int64
+		db.Model(&models.Widget{}).Where("organization_id = ?", org.ID).Count(&exists)
+		if exists > 0 {
+			continue
+		}
+
+		if err := SeedDefaultWidgetsForOrg(db, org.ID, superAdmin.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SeedDefaultWidgetsForOrg creates default dashboard widgets for a single organization.
+// Used when a new organization is created at runtime.
+func SeedDefaultWidgetsForOrg(db *gorm.DB, orgID, userID uuid.UUID) error {
 	defaultWidgetsData := []struct {
 		Name         string
 		Description  string
@@ -687,42 +705,34 @@ func SeedDefaultWidgets(db *gorm.DB) error {
 		{"Quick Actions", "Common tasks and shortcuts", "shortcuts", "shortcuts", "", models.JSONB{"shortcuts": []interface{}{"chat", "campaigns", "templates", "chatbot"}}, 6, 6, 3, 6, 8},
 	}
 
-	for _, org := range orgs {
-		// Create default widgets owned by super admin
-		for _, wd := range defaultWidgetsData {
-			// Skip if a widget with this name already exists for the org
-			var exists int64
-			db.Model(&models.Widget{}).Where("organization_id = ? AND name = ?", org.ID, wd.Name).Count(&exists)
-			if exists > 0 {
-				continue
-			}
-
-			displayType := wd.DisplayType
-			if displayType == "" {
-				displayType = "number"
-			}
-			widget := models.Widget{
-				BaseModel:      models.BaseModel{ID: uuid.New()},
-				OrganizationID: org.ID,
-				UserID:         &superAdmin.ID,
-				Name:           wd.Name,
-				Description:    wd.Description,
-				DataSource:     wd.DataSource,
-				Metric:         "count",
-				DisplayType:    displayType,
-				ShowChange:     displayType == "number",
-				Color:          wd.Color,
-				Size:           "small",
-				Config:         wd.Config,
-				DisplayOrder:   wd.DisplayOrder,
-				GridX:          wd.GridX,
-				GridY:          wd.GridY,
-				GridW:          wd.GridW,
-				GridH:          wd.GridH,
-				IsShared:       true,
-				IsDefault:      true,
-			}
-			db.Create(&widget)
+	for _, wd := range defaultWidgetsData {
+		displayType := wd.DisplayType
+		if displayType == "" {
+			displayType = "number"
+		}
+		widget := models.Widget{
+			BaseModel:      models.BaseModel{ID: uuid.New()},
+			OrganizationID: orgID,
+			UserID:         &userID,
+			Name:           wd.Name,
+			Description:    wd.Description,
+			DataSource:     wd.DataSource,
+			Metric:         "count",
+			DisplayType:    displayType,
+			ShowChange:     displayType == "number",
+			Color:          wd.Color,
+			Size:           "small",
+			Config:         wd.Config,
+			DisplayOrder:   wd.DisplayOrder,
+			GridX:          wd.GridX,
+			GridY:          wd.GridY,
+			GridW:          wd.GridW,
+			GridH:          wd.GridH,
+			IsShared:       true,
+			IsDefault:      true,
+		}
+		if err := db.Create(&widget).Error; err != nil {
+			return fmt.Errorf("failed to create widget %s: %w", wd.Name, err)
 		}
 	}
 

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -409,6 +409,13 @@ func (a *App) CreateOrganization(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create organization", nil, "")
 	}
 
+	// Seed default dashboard widgets for the new organization
+	if err := database.SeedDefaultWidgetsForOrg(tx, org.ID, userID); err != nil {
+		tx.Rollback()
+		a.Log.Error("Failed to seed default widgets", "error", err, "org_id", org.ID)
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create organization", nil, "")
+	}
+
 	if err := tx.Commit().Error; err != nil {
 		a.Log.Error("Failed to commit transaction", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create organization", nil, "")


### PR DESCRIPTION
SeedDefaultWidgets only ran at startup, so new orgs had empty dashboards. Now CreateOrganization calls SeedDefaultWidgetsForOrg within the same transaction. Refactored SeedDefaultWidgets to reuse the new function.

Fixes https://github.com/shridarpatil/whatomate/issues/173