### PR TITLE
fix: add error logging before all 5xx error responses in handlers

### DIFF
--- a/internal/handlers/agent_transfers.go
+++ b/internal/handlers/agent_transfers.go
@@ -245,6 +245,7 @@ func (a *App) ListAgentTransfers(r *fastglue.Request) error {
 
 	var transfers []agentTransferRow
 	if err := query.Scan(&transfers).Error; err != nil {
+		a.Log.Error("Failed to fetch transfers", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch transfers", nil, "")
 	}
 
@@ -638,6 +639,7 @@ func (a *App) ResumeFromTransfer(r *fastglue.Request) error {
 	transfer.ResumedBy = &userID
 
 	if err := a.DB.Save(transfer).Error; err != nil {
+		a.Log.Error("Failed to resume transfer", "error", err, "transfer_id", transfer.ID)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to resume transfer", nil, "")
 	}
 
@@ -767,6 +769,7 @@ func (a *App) AssignAgentTransfer(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Save(&transfer).Error; err != nil {
+		a.Log.Error("Failed to assign transfer", "error", err, "transfer_id", transfer.ID)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to assign transfer", nil, "")
 	}
 
@@ -928,17 +931,20 @@ func (a *App) PickNextTransfer(r *fastglue.Request) error {
 
 	if err := tx.Save(&transfer).Error; err != nil {
 		tx.Rollback()
+		a.Log.Error("Failed to pick transfer", "error", err, "transfer_id", transfer.ID)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to pick transfer", nil, "")
 	}
 
 	// Update contact assignment within transaction
 	if err := tx.Model(&models.Contact{}).Where("id = ?", transfer.ContactID).Update("assigned_user_id", userID).Error; err != nil {
 		tx.Rollback()
+		a.Log.Error("Failed to update contact assignment", "error", err, "transfer_id", transfer.ID)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update contact assignment", nil, "")
 	}
 
 	// Commit the transaction
 	if err := tx.Commit().Error; err != nil {
+		a.Log.Error("Failed to complete pickup", "error", err, "transfer_id", transfer.ID)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to complete pickup", nil, "")
 	}
 

--- a/internal/handlers/app.go
+++ b/internal/handlers/app.go
@@ -112,14 +112,17 @@ func (a *App) ReadyCheck(r *fastglue.Request) error {
 	// Check database connection
 	sqlDB, err := a.DB.DB()
 	if err != nil {
+		a.Log.Error("Database connection error", "error", err)
 		return r.SendErrorEnvelope(500, "Database connection error", nil, "")
 	}
 	if err := sqlDB.Ping(); err != nil {
+		a.Log.Error("Database ping failed", "error", err)
 		return r.SendErrorEnvelope(500, "Database ping failed", nil, "")
 	}
 
 	// Check Redis connection
 	if err := a.Redis.Ping(r.RequestCtx).Err(); err != nil {
+		a.Log.Error("Redis connection error", "error", err)
 		return r.SendErrorEnvelope(500, "Redis connection error", nil, "")
 	}
 

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -127,6 +127,7 @@ func (a *App) Register(r *fastglue.Request) error {
 	var defaultRole models.CustomRole
 	if err := a.DB.Where("organization_id = ? AND is_default = ?", req.OrganizationID, true).First(&defaultRole).Error; err != nil {
 		if err := a.DB.Where("organization_id = ? AND name = ? AND is_system = ?", req.OrganizationID, "agent", true).First(&defaultRole).Error; err != nil {
+			a.Log.Error("Failed to find default role", "error", err)
 			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to find default role", nil, "")
 		}
 	}

--- a/internal/handlers/business_profile.go
+++ b/internal/handlers/business_profile.go
@@ -102,6 +102,7 @@ func (a *App) UpdateProfilePicture(r *fastglue.Request) error {
 	// 2. Open and read file
 	file, err := fileHeader.Open()
 	if err != nil {
+		a.Log.Error("Failed to open file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to open file", nil, "")
 	}
 	defer file.Close() //nolint:errcheck
@@ -110,6 +111,7 @@ func (a *App) UpdateProfilePicture(r *fastglue.Request) error {
 	fileContent := make([]byte, fileSize)
 	_, err = file.Read(fileContent)
 	if err != nil {
+		a.Log.Error("Failed to read file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file", nil, "")
 	}
 

--- a/internal/handlers/call_logs.go
+++ b/internal/handlers/call_logs.go
@@ -79,6 +79,7 @@ func (a *App) ListCallLogs(r *fastglue.Request) error {
 
 	var callLogs []models.CallLog
 	if err := pg.Apply(query).Find(&callLogs).Error; err != nil {
+		a.Log.Error("Failed to fetch call logs", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch call logs", nil, "")
 	}
 

--- a/internal/handlers/call_transfers.go
+++ b/internal/handlers/call_transfers.go
@@ -40,6 +40,7 @@ func (a *App) ListCallTransfers(r *fastglue.Request) error {
 
 	var transfers []models.CallTransfer
 	if err := pg.Apply(query).Find(&transfers).Error; err != nil {
+		a.Log.Error("Failed to fetch call transfers", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch call transfers", nil, "")
 	}
 

--- a/internal/handlers/campaigns.go
+++ b/internal/handlers/campaigns.go
@@ -812,6 +812,7 @@ func (a *App) UploadCampaignMedia(r *fastglue.Request) error {
 	const maxMediaSize = 16 << 20 // 16MB
 	data, err := io.ReadAll(io.LimitReader(file, maxMediaSize+1))
 	if err != nil {
+		a.Log.Error("Failed to read file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file", nil, "")
 	}
 	if len(data) > maxMediaSize {
@@ -934,6 +935,7 @@ func (a *App) ServeCampaignMedia(r *fastglue.Request) error {
 	filePath := filepath.Clean(campaign.HeaderMediaLocalPath)
 	baseDir, err := filepath.Abs(a.getMediaStoragePath())
 	if err != nil {
+		a.Log.Error("Storage configuration error", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Storage configuration error", nil, "")
 	}
 	fullPath, err := filepath.Abs(filepath.Join(baseDir, filePath))

--- a/internal/handlers/canned_responses.go
+++ b/internal/handlers/canned_responses.go
@@ -237,6 +237,7 @@ func (a *App) IncrementCannedResponseUsage(r *fastglue.Request) error {
 	if err := a.DB.Model(&models.CannedResponse{}).
 		Where("id = ? AND organization_id = ?", id, orgID).
 		UpdateColumn("usage_count", gorm.Expr("usage_count + 1")).Error; err != nil {
+		a.Log.Error("Failed to update usage", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError,
 			"Failed to update usage", nil, "")
 	}

--- a/internal/handlers/chatbot.go
+++ b/internal/handlers/chatbot.go
@@ -374,6 +374,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Save(&settings).Error; err != nil {
+		a.Log.Error("Failed to save settings", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to save settings", nil, "")
 	}
 
@@ -394,6 +395,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 		}
 		if len(zeroOverrides) > 0 {
 			if err := a.DB.Model(&settings).Updates(zeroOverrides).Error; err != nil {
+				a.Log.Error("Failed to save settings", "error", err)
 				return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to save settings", nil, "")
 			}
 		}
@@ -433,6 +435,7 @@ func (a *App) ListKeywordRules(r *fastglue.Request) error {
 	var rules []models.KeywordRule
 	if err := pg.Apply(query.Order("priority DESC, created_at DESC")).
 		Find(&rules).Error; err != nil {
+		a.Log.Error("Failed to fetch keyword rules", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch keyword rules", nil, "")
 	}
 
@@ -509,6 +512,7 @@ func (a *App) CreateKeywordRule(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Create(&rule).Error; err != nil {
+		a.Log.Error("Failed to create keyword rule", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create keyword rule", nil, "")
 	}
 
@@ -609,6 +613,7 @@ func (a *App) UpdateKeywordRule(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Save(rule).Error; err != nil {
+		a.Log.Error("Failed to update keyword rule", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update keyword rule", nil, "")
 	}
 
@@ -634,6 +639,7 @@ func (a *App) DeleteKeywordRule(r *fastglue.Request) error {
 
 	result := a.DB.Where("id = ? AND organization_id = ?", id, orgID).Delete(&models.KeywordRule{})
 	if result.Error != nil {
+		a.Log.Error("Failed to delete keyword rule", "error", result.Error)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to delete keyword rule", nil, "")
 	}
 	if result.RowsAffected == 0 {
@@ -676,6 +682,7 @@ func (a *App) ListChatbotFlows(r *fastglue.Request) error {
 	var flows []models.ChatbotFlow
 	if err := pg.Apply(query.Preload("Steps").Order("created_at DESC")).
 		Find(&flows).Error; err != nil {
+		a.Log.Error("Failed to fetch flows", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch flows", nil, "")
 	}
 
@@ -773,6 +780,7 @@ func (a *App) CreateChatbotFlow(r *fastglue.Request) error {
 
 	if err := tx.Create(&flow).Error; err != nil {
 		tx.Rollback()
+		a.Log.Error("Failed to create flow", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create flow", nil, "")
 	}
 
@@ -813,6 +821,7 @@ func (a *App) CreateChatbotFlow(r *fastglue.Request) error {
 		}
 		if err := tx.Create(&step).Error; err != nil {
 			tx.Rollback()
+			a.Log.Error("Failed to create flow step", "error", err)
 			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create flow step", nil, "")
 		}
 	}
@@ -926,6 +935,7 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 
 	if err := tx.Save(flow).Error; err != nil {
 		tx.Rollback()
+		a.Log.Error("Failed to update flow", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update flow", nil, "")
 	}
 
@@ -934,6 +944,7 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 		// Delete existing steps
 		if err := tx.Where("flow_id = ?", id).Delete(&models.ChatbotFlowStep{}).Error; err != nil {
 			tx.Rollback()
+			a.Log.Error("Failed to update flow steps", "error", err)
 			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update flow steps", nil, "")
 		}
 
@@ -974,6 +985,7 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 			}
 			if err := tx.Create(&step).Error; err != nil {
 				tx.Rollback()
+				a.Log.Error("Failed to create flow step", "error", err)
 				return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create flow step", nil, "")
 			}
 		}
@@ -1011,6 +1023,7 @@ func (a *App) DeleteChatbotFlow(r *fastglue.Request) error {
 	// Delete steps first
 	if err := tx.Where("flow_id = ?", id).Delete(&models.ChatbotFlowStep{}).Error; err != nil {
 		tx.Rollback()
+		a.Log.Error("Failed to delete flow steps", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to delete flow steps", nil, "")
 	}
 
@@ -1018,6 +1031,7 @@ func (a *App) DeleteChatbotFlow(r *fastglue.Request) error {
 	result := tx.Where("id = ? AND organization_id = ?", id, orgID).Delete(&models.ChatbotFlow{})
 	if result.Error != nil {
 		tx.Rollback()
+		a.Log.Error("Failed to delete flow", "error", result.Error)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to delete flow", nil, "")
 	}
 	if result.RowsAffected == 0 {
@@ -1059,6 +1073,7 @@ func (a *App) ListAIContexts(r *fastglue.Request) error {
 	var contexts []models.AIContext
 	if err := pg.Apply(query.Order("priority DESC, created_at DESC")).
 		Find(&contexts).Error; err != nil {
+		a.Log.Error("Failed to fetch AI contexts", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch AI contexts", nil, "")
 	}
 
@@ -1123,6 +1138,7 @@ func (a *App) CreateAIContext(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Create(&ctx).Error; err != nil {
+		a.Log.Error("Failed to create AI context", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create AI context", nil, "")
 	}
 
@@ -1205,6 +1221,7 @@ func (a *App) UpdateAIContext(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Save(aiCtx).Error; err != nil {
+		a.Log.Error("Failed to update AI context", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update AI context", nil, "")
 	}
 
@@ -1230,6 +1247,7 @@ func (a *App) DeleteAIContext(r *fastglue.Request) error {
 
 	result := a.DB.Where("id = ? AND organization_id = ?", id, orgID).Delete(&models.AIContext{})
 	if result.Error != nil {
+		a.Log.Error("Failed to delete AI context", "error", result.Error)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to delete AI context", nil, "")
 	}
 	if result.RowsAffected == 0 {
@@ -1263,6 +1281,7 @@ func (a *App) ListChatbotSessions(r *fastglue.Request) error {
 
 	var sessions []models.ChatbotSession
 	if err := query.Limit(100).Find(&sessions).Error; err != nil {
+		a.Log.Error("Failed to fetch sessions", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch sessions", nil, "")
 	}
 

--- a/internal/handlers/contacts.go
+++ b/internal/handlers/contacts.go
@@ -615,6 +615,7 @@ func (a *App) SendMessage(r *fastglue.Request) error {
 	ctx := context.Background()
 	message, err := a.SendOutgoingMessage(ctx, msgReq, opts)
 	if err != nil {
+		a.Log.Error("Failed to send message", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to send message", nil, "")
 	}
 
@@ -746,6 +747,7 @@ func (a *App) SendMediaMessage(r *fastglue.Request) error {
 	// Read file data
 	fileData, err := io.ReadAll(file)
 	if err != nil {
+		a.Log.Error("Failed to read file data", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file data", nil, "")
 	}
 
@@ -800,6 +802,7 @@ func (a *App) SendMediaMessage(r *fastglue.Request) error {
 	ctx := context.Background()
 	message, err := a.SendOutgoingMessage(ctx, msgReq, opts)
 	if err != nil {
+		a.Log.Error("Failed to send message", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to send message", nil, "")
 	}
 

--- a/internal/handlers/ivr_flows.go
+++ b/internal/handlers/ivr_flows.go
@@ -51,6 +51,7 @@ func (a *App) ListIVRFlows(r *fastglue.Request) error {
 
 	var flows []models.IVRFlow
 	if err := pg.Apply(query).Find(&flows).Error; err != nil {
+		a.Log.Error("Failed to fetch IVR flows", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch IVR flows", nil, "")
 	}
 
@@ -276,6 +277,7 @@ func (a *App) DeleteIVRFlow(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Delete(flow).Error; err != nil {
+		a.Log.Error("Failed to delete IVR flow", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to delete IVR flow", nil, "")
 	}
 
@@ -328,6 +330,7 @@ func (a *App) UploadIVRAudio(r *fastglue.Request) error {
 	const maxAudioSize = 5 << 20 // 5MB
 	data, err := io.ReadAll(io.LimitReader(file, maxAudioSize+1))
 	if err != nil {
+		a.Log.Error("Failed to read IVR audio file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file", nil, "")
 	}
 	if len(data) > maxAudioSize {
@@ -337,23 +340,23 @@ func (a *App) UploadIVRAudio(r *fastglue.Request) error {
 	// Validate MIME type
 	mimeType := fileHeader.Header.Get("Content-Type")
 	allowedAudio := map[string]bool{
-		"audio/ogg":             true,
-		"audio/opus":            true,
-		"audio/mpeg":            true,
-		"audio/mp3":             true,
-		"audio/aac":             true,
-		"audio/mp4":             true,
-		"audio/wav":             true,
-		"audio/x-wav":           true,
-		"audio/wave":            true,
-		"audio/webm":            true,
-		"audio/flac":            true,
-		"audio/x-flac":          true,
-		"audio/x-m4a":           true,
-		"audio/m4a":             true,
-		"application/ogg":       true,
+		"audio/ogg":                true,
+		"audio/opus":               true,
+		"audio/mpeg":               true,
+		"audio/mp3":                true,
+		"audio/aac":                true,
+		"audio/mp4":                true,
+		"audio/wav":                true,
+		"audio/x-wav":              true,
+		"audio/wave":               true,
+		"audio/webm":               true,
+		"audio/flac":               true,
+		"audio/x-flac":             true,
+		"audio/x-m4a":              true,
+		"audio/m4a":                true,
+		"application/ogg":          true,
 		"application/octet-stream": true, // fallback for unknown audio
-		"video/ogg":             true, // some browsers report .ogg as video/ogg
+		"video/ogg":                true, // some browsers report .ogg as video/ogg
 	}
 	if !allowedAudio[mimeType] {
 		a.Log.Error("Unsupported audio MIME type", "mime_type", mimeType, "filename", fileHeader.Filename)
@@ -370,12 +373,14 @@ func (a *App) UploadIVRAudio(r *fastglue.Request) error {
 	// Save uploaded file to a temp location for transcoding
 	tmpInput, err := os.CreateTemp("", "ivr-audio-input-*")
 	if err != nil {
+		a.Log.Error("Failed to create IVR temp file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create temp file", nil, "")
 	}
 	defer func() { _ = os.Remove(tmpInput.Name()) }()
 
 	if _, err := tmpInput.Write(data); err != nil {
 		_ = tmpInput.Close()
+		a.Log.Error("Failed to write IVR temp file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to write temp file", nil, "")
 	}
 	_ = tmpInput.Close()
@@ -415,6 +420,7 @@ func (a *App) ServeIVRAudio(r *fastglue.Request) error {
 	audioDir := a.getAudioDir()
 	baseDir, err := filepath.Abs(audioDir)
 	if err != nil {
+		a.Log.Error("Failed to resolve audio directory", "error", err, "audio_dir", audioDir)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Storage configuration error", nil, "")
 	}
 	fullPath, err := filepath.Abs(filepath.Join(baseDir, filename))
@@ -487,6 +493,7 @@ func (a *App) UploadOrgAudio(r *fastglue.Request) error {
 	const maxAudioSize = 5 << 20
 	data, err := io.ReadAll(io.LimitReader(file, maxAudioSize+1))
 	if err != nil {
+		a.Log.Error("Failed to read org audio file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file", nil, "")
 	}
 	if len(data) > maxAudioSize {
@@ -509,18 +516,21 @@ func (a *App) UploadOrgAudio(r *fastglue.Request) error {
 	// Ensure audio directory exists
 	audioDir := a.getAudioDir()
 	if err := os.MkdirAll(audioDir, 0755); err != nil {
+		a.Log.Error("Failed to create org audio directory", "error", err, "audio_dir", audioDir)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create audio directory", nil, "")
 	}
 
 	// Save uploaded file to a temp location for transcoding
 	tmpInput, err := os.CreateTemp("", "org-audio-input-*")
 	if err != nil {
+		a.Log.Error("Failed to create org temp file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create temp file", nil, "")
 	}
 	defer func() { _ = os.Remove(tmpInput.Name()) }()
 
 	if _, err := tmpInput.Write(data); err != nil {
 		_ = tmpInput.Close()
+		a.Log.Error("Failed to write org temp file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to write temp file", nil, "")
 	}
 	_ = tmpInput.Close()
@@ -537,6 +547,7 @@ func (a *App) UploadOrgAudio(r *fastglue.Request) error {
 	// Update org settings with the new filename
 	var org models.Organization
 	if err := a.DB.Where("id = ?", orgID).First(&org).Error; err != nil {
+		a.Log.Error("Failed to load organization for audio update", "error", err, "org_id", orgID)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to load organization", nil, "")
 	}
 	if org.Settings == nil {
@@ -545,6 +556,7 @@ func (a *App) UploadOrgAudio(r *fastglue.Request) error {
 	settingsKey := audioType + "_file"
 	org.Settings[settingsKey] = filename
 	if err := a.DB.Save(&org).Error; err != nil {
+		a.Log.Error("Failed to update organization audio settings", "error", err, "org_id", orgID, "audio_type", audioType)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update organization settings", nil, "")
 	}
 
@@ -564,13 +576,13 @@ func transcodeToOpus(inputPath, outputPath string) error {
 	cmd := exec.Command("ffmpeg",
 		"-y",            // overwrite output
 		"-i", inputPath, // input file
-		"-ac", "1",      // mono
-		"-ar", "48000",  // 48kHz (Opus standard)
+		"-ac", "1", // mono
+		"-ar", "48000", // 48kHz (Opus standard)
 		"-c:a", "libopus",
 		"-b:a", "48k", // bitrate
 		"-application", "audio",
 		"-frame_duration", "20", // 20ms frames (matches RTP packetization)
-		"-vn",        // strip video/cover art
+		"-vn", // strip video/cover art
 		outputPath,
 	)
 

--- a/internal/handlers/media.go
+++ b/internal/handlers/media.go
@@ -180,6 +180,7 @@ func (a *App) ServeMedia(r *fastglue.Request) error {
 	filePath := filepath.Clean(message.MediaURL)
 	baseDir, err := filepath.Abs(a.getMediaStoragePath())
 	if err != nil {
+		a.Log.Error("Storage configuration error", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Storage configuration error", nil, "")
 	}
 	fullPath, err := filepath.Abs(filepath.Join(baseDir, filePath))

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -665,6 +665,7 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 	ctx := context.Background()
 	message, err := a.SendOutgoingMessage(ctx, msgReq, opts)
 	if err != nil {
+		a.Log.Error("Failed to send template message", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to send template message", nil, "")
 	}
 

--- a/internal/handlers/meta_analytics.go
+++ b/internal/handlers/meta_analytics.go
@@ -135,6 +135,7 @@ func (a *App) GetMetaAnalytics(r *fastglue.Request) error {
 	} else {
 		// All accounts for the organization
 		if err := a.DB.Where("organization_id = ?", orgID).Find(&accounts).Error; err != nil {
+			a.Log.Error("Failed to fetch accounts", "error", err)
 			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch accounts", nil, "")
 		}
 	}
@@ -359,6 +360,7 @@ func (a *App) ListMetaAccountsForAnalytics(r *fastglue.Request) error {
 
 	var accounts []models.WhatsAppAccount
 	if err := a.DB.Select("id, name, phone_id").Where("organization_id = ?", orgID).Find(&accounts).Error; err != nil {
+		a.Log.Error("Failed to fetch accounts", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch accounts", nil, "")
 	}
 

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -142,6 +142,7 @@ func (a *App) UpdateOrganizationSettings(r *fastglue.Request) error {
 	}
 
 	if err := a.DB.Save(&org).Error; err != nil {
+		a.Log.Error("Failed to update settings", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update settings", nil, "")
 	}
 

--- a/internal/handlers/teams.go
+++ b/internal/handlers/teams.go
@@ -69,6 +69,7 @@ func (a *App) ListTeams(r *fastglue.Request) error {
 		if err := pg.Apply(baseQuery.
 			Preload("Members").Preload("Members.User").
 			Order("name ASC")).Find(&teams).Error; err != nil {
+			a.Log.Error("Failed to list teams", "error", err)
 			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to list teams", nil, "")
 		}
 	} else {
@@ -82,6 +83,7 @@ func (a *App) ListTeams(r *fastglue.Request) error {
 		if err := pg.Apply(baseQuery.
 			Preload("Members").Preload("Members.User").
 			Order("teams.name ASC")).Find(&teams).Error; err != nil {
+			a.Log.Error("Failed to list teams", "error", err)
 			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to list teams", nil, "")
 		}
 	}

--- a/internal/handlers/templates.go
+++ b/internal/handlers/templates.go
@@ -558,6 +558,7 @@ func (a *App) UploadTemplateMedia(r *fastglue.Request) error {
 
 	file, err := fileHeader.Open()
 	if err != nil {
+		a.Log.Error("Failed to open uploaded file", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to open uploaded file", nil, "")
 	}
 	defer func() { _ = file.Close() }()
@@ -565,6 +566,7 @@ func (a *App) UploadTemplateMedia(r *fastglue.Request) error {
 	// Read file data
 	fileData := make([]byte, fileHeader.Size)
 	if _, err := file.Read(fileData); err != nil {
+		a.Log.Error("Failed to read file data", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file data", nil, "")
 	}
 

--- a/internal/handlers/webhooks.go
+++ b/internal/handlers/webhooks.go
@@ -356,6 +356,7 @@ func (a *App) TestWebhook(r *fastglue.Request) error {
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
+		a.Log.Error("Failed to create test payload", "error", err)
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create test payload", nil, "")
 	}
 


### PR DESCRIPTION
All SendErrorEnvelope(StatusInternalServerError) calls now have a preceding a.Log.Error with the error value. Previously ~70 server errors across 18 handler files were returned to clients without being logged, making production debugging difficult.