### PR TITLE
fix: call analytics field mapping, direction breakdown, and error toasts

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1928,8 +1928,12 @@
     "noTemplateAnalytics": "No template analytics data available",
     "totalCalls": "Total Calls",
     "totalDuration": "Total Duration",
+    "avgDuration": "Avg. Duration",
     "callsByType": "Calls by Type",
     "callsByDirection": "Calls by Direction",
+    "incoming": "Incoming",
+    "outgoing": "Outgoing",
+    "callsOverTime": "Calls Over Time",
     "noCallData": "No call data available",
     "noCallAnalytics": "No call analytics data available"
   },

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1927,8 +1927,12 @@
     "noTemplateAnalytics": "No hay analíticas de plantillas disponibles",
     "totalCalls": "Total de llamadas",
     "totalDuration": "Duración total",
+    "avgDuration": "Duración prom.",
     "callsByType": "Llamadas por tipo",
     "callsByDirection": "Llamadas por dirección",
+    "incoming": "Entrantes",
+    "outgoing": "Salientes",
+    "callsOverTime": "Llamadas a lo largo del tiempo",
     "noCallData": "No hay datos de llamadas disponibles",
     "noCallAnalytics": "No hay analíticas de llamadas disponibles"
   },

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -1927,8 +1927,12 @@
     "noTemplateAnalytics": "कोई नहीं",
     "totalCalls": "कुल कॉल",
     "totalDuration": "कुल अवधि",
+    "avgDuration": "औसत अवधि",
     "callsByType": "प्रकार",
     "callsByDirection": "दिशा",
+    "incoming": "इनकमिंग",
+    "outgoing": "आउटगोइंग",
+    "callsOverTime": "समय के अनुसार कॉल",
     "noCallData": "कोई नहीं",
     "noCallAnalytics": "कोई नहीं"
   },

--- a/frontend/src/i18n/locales/ta.json
+++ b/frontend/src/i18n/locales/ta.json
@@ -1927,8 +1927,12 @@
     "noTemplateAnalytics": "வார்ப்புரு பகுப்பாய்வு தரவு இல்லை",
     "totalCalls": "மொத்த அழைப்புகள்",
     "totalDuration": "மொத்த காலம்",
+    "avgDuration": "சராசரி காலம்",
     "callsByType": "வகை வாரியாக அழைப்புகள்",
     "callsByDirection": "திசை வாரியாக அழைப்புகள்",
+    "incoming": "உள்வரும்",
+    "outgoing": "வெளிச்செல்லும்",
+    "callsOverTime": "காலப்போக்கில் அழைப்புகள்",
     "noCallData": "அழைப்பு தரவு இல்லை",
     "noCallAnalytics": "அழைப்பு பகுப்பாய்வு தரவு இல்லை"
   },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -398,10 +398,10 @@ export interface MetaTemplateDataPoint {
 export interface MetaCallDataPoint {
   start: number
   end: number
-  total_calls: number
-  call_duration: number
-  call_type: string
-  call_direction: string
+  count: number
+  cost: number
+  average_duration: number
+  direction?: string // USER_INITIATED or BUSINESS_INITIATED
 }
 
 interface MetaAnalyticsData {

--- a/frontend/src/views/analytics/MetaInsightsView.vue
+++ b/frontend/src/views/analytics/MetaInsightsView.vue
@@ -49,6 +49,8 @@ import {
   DollarSign,
   FileText,
   Phone,
+  PhoneIncoming,
+  PhoneOutgoing,
   RefreshCw,
   TrendingUp,
   Send,
@@ -60,9 +62,9 @@ import {
 import type { DateRange } from 'reka-ui'
 import { CalendarDate } from '@internationalized/date'
 import { Line, Bar } from '@/lib/charts'
-import { useToast } from '@/components/ui/toast'
+import { toast } from 'vue-sonner'
 
-const { toast } = useToast()
+
 const { t } = useI18n()
 
 // State
@@ -247,11 +249,21 @@ const fetchAnalytics = async () => {
     }
 
     const response = await metaAnalyticsService.get(params)
-    const data = (response.data as any).data || response.data
+    const envelope = response.data as any
+    // Handle error envelope (status: "error")
+    if (envelope?.status === 'error') {
+      toast.error(envelope.message || 'Failed to load analytics')
+      analyticsData.value = []
+      return
+    }
+    const data = envelope?.data || envelope
     analyticsData.value = data.accounts || []
     isCached.value = data.cached || false
-  } catch (error) {
-    console.error('Failed to load analytics:', error)
+  } catch (error: any) {
+    console.error('Failed to load analytics:', error?.response?.data, error)
+    const errData = error?.response?.data
+    const msg = errData?.data?.message || errData?.message || error?.message || 'Failed to load analytics'
+    toast.error(msg)
     analyticsData.value = []
   } finally {
     isLoading.value = false
@@ -262,18 +274,11 @@ const refreshCache = async () => {
   isRefreshing.value = true
   try {
     await metaAnalyticsService.refresh()
-    toast({
-      title: t('metaInsights.cacheCleared'),
-      description: t('metaInsights.cacheRefreshed')
-    })
+    toast.success(t('metaInsights.cacheRefreshed'))
     await fetchAnalytics()
   } catch (error) {
     console.error('Failed to refresh cache:', error)
-    toast({
-      title: t('common.error'),
-      description: t('metaInsights.refreshFailed'),
-      variant: 'destructive'
-    })
+    toast.error(t('metaInsights.refreshFailed'))
   } finally {
     isRefreshing.value = false
   }
@@ -558,26 +563,45 @@ const filteredTemplateData = computed(() => {
 })
 
 function aggregateCallData(points: MetaCallDataPoint[]) {
-  const byType = new Map<string, number>()
-  const byDirection = new Map<string, number>()
+  const byTime = new Map<number, { incoming: number; outgoing: number; cost: number; totalDuration: number }>()
   let totalCalls = 0
+  let totalIncoming = 0
+  let totalOutgoing = 0
+  let totalCost = 0
   let totalDuration = 0
 
   for (const point of points) {
-    totalCalls += point.total_calls
-    totalDuration += point.call_duration
+    totalCalls += point.count
+    totalCost += point.cost
+    totalDuration += point.average_duration * point.count
 
-    const callType = point.call_type || 'UNKNOWN'
-    byType.set(callType, (byType.get(callType) || 0) + point.total_calls)
+    if (point.direction === 'USER_INITIATED') {
+      totalIncoming += point.count
+    } else if (point.direction === 'BUSINESS_INITIATED') {
+      totalOutgoing += point.count
+    }
 
-    const direction = point.call_direction || 'UNKNOWN'
-    byDirection.set(direction, (byDirection.get(direction) || 0) + point.total_calls)
+    const existing = byTime.get(point.start) || { incoming: 0, outgoing: 0, cost: 0, totalDuration: 0 }
+    const isIncoming = point.direction === 'USER_INITIATED'
+    byTime.set(point.start, {
+      incoming: existing.incoming + (isIncoming ? point.count : 0),
+      outgoing: existing.outgoing + (!isIncoming ? point.count : 0),
+      cost: existing.cost + point.cost,
+      totalDuration: existing.totalDuration + point.average_duration * point.count
+    })
   }
 
+  const avgDuration = totalCalls > 0 ? Math.round(totalDuration / totalCalls) : 0
+  const sortedTimes = Array.from(byTime.entries()).sort((a, b) => a[0] - b[0])
+
   return {
-    totals: { calls: totalCalls, duration: totalDuration },
-    byType: Object.fromEntries(byType),
-    byDirection: Object.fromEntries(byDirection)
+    totals: { calls: totalCalls, incoming: totalIncoming, outgoing: totalOutgoing, cost: totalCost, avgDuration },
+    timeSeries: sortedTimes.map(([time, data]) => ({
+      time,
+      incoming: data.incoming,
+      outgoing: data.outgoing,
+      cost: data.cost
+    }))
   }
 }
 
@@ -632,6 +656,36 @@ const pricingChartData = computed(() => {
         label: t('metaInsights.cost'),
         data: categories.map(([, val]) => val.cost),
         backgroundColor: 'rgba(16, 185, 129, 0.8)'
+      }
+    ]
+  }
+})
+
+const callChartData = computed(() => {
+  if (!aggregatedData.value || activeTab.value !== 'call_analytics') {
+    return { labels: [], datasets: [] }
+  }
+
+  const data = aggregatedData.value as ReturnType<typeof aggregateCallData>
+
+  return {
+    labels: data.timeSeries.map(ts => formatTimestamp(ts.time)),
+    datasets: [
+      {
+        label: t('metaInsights.incoming'),
+        data: data.timeSeries.map(d => d.incoming),
+        borderColor: 'rgb(59, 130, 246)',
+        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+        fill: true,
+        tension: 0.3
+      },
+      {
+        label: t('metaInsights.outgoing'),
+        data: data.timeSeries.map(d => d.outgoing),
+        borderColor: 'rgb(168, 85, 247)',
+        backgroundColor: 'rgba(168, 85, 247, 0.1)',
+        fill: true,
+        tension: 0.3
       }
     ]
   }
@@ -1217,7 +1271,7 @@ const chartOptions = {
             </template>
             <template v-else-if="aggregatedData && activeTab === 'call_analytics'">
               <!-- Stats Cards -->
-              <div class="grid gap-4 md:grid-cols-2">
+              <div class="grid gap-4 md:grid-cols-5">
                 <div class="card-depth rounded-xl border border-white/[0.08] bg-white/[0.04] p-6 light:bg-white light:border-gray-200">
                   <div class="flex flex-row items-center justify-between space-y-0 pb-2">
                     <span class="text-sm font-medium text-white/50 light:text-gray-500">{{ $t('metaInsights.totalCalls') }}</span>
@@ -1234,63 +1288,75 @@ const chartOptions = {
 
                 <div class="card-depth rounded-xl border border-white/[0.08] bg-white/[0.04] p-6 light:bg-white light:border-gray-200">
                   <div class="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <span class="text-sm font-medium text-white/50 light:text-gray-500">{{ $t('metaInsights.totalDuration') }}</span>
+                    <span class="text-sm font-medium text-white/50 light:text-gray-500">{{ $t('metaInsights.incoming') }}</span>
+                    <div class="h-10 w-10 rounded-lg bg-blue-500/20 flex items-center justify-center">
+                      <PhoneIncoming class="h-5 w-5 text-blue-400" />
+                    </div>
+                  </div>
+                  <div class="pt-2">
+                    <div class="text-3xl font-bold text-white light:text-gray-900">
+                      {{ (aggregatedData as ReturnType<typeof aggregateCallData>).totals.incoming.toLocaleString() }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="card-depth rounded-xl border border-white/[0.08] bg-white/[0.04] p-6 light:bg-white light:border-gray-200">
+                  <div class="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <span class="text-sm font-medium text-white/50 light:text-gray-500">{{ $t('metaInsights.outgoing') }}</span>
+                    <div class="h-10 w-10 rounded-lg bg-purple-500/20 flex items-center justify-center">
+                      <PhoneOutgoing class="h-5 w-5 text-purple-400" />
+                    </div>
+                  </div>
+                  <div class="pt-2">
+                    <div class="text-3xl font-bold text-white light:text-gray-900">
+                      {{ (aggregatedData as ReturnType<typeof aggregateCallData>).totals.outgoing.toLocaleString() }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="card-depth rounded-xl border border-white/[0.08] bg-white/[0.04] p-6 light:bg-white light:border-gray-200">
+                  <div class="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <span class="text-sm font-medium text-white/50 light:text-gray-500">{{ $t('metaInsights.avgDuration') }}</span>
                     <div class="h-10 w-10 rounded-lg bg-emerald-500/20 flex items-center justify-center">
                       <TrendingUp class="h-5 w-5 text-emerald-400" />
                     </div>
                   </div>
                   <div class="pt-2">
                     <div class="text-3xl font-bold text-white light:text-gray-900">
-                      {{ formatDuration((aggregatedData as ReturnType<typeof aggregateCallData>).totals.duration) }}
+                      {{ formatDuration((aggregatedData as ReturnType<typeof aggregateCallData>).totals.avgDuration) }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="card-depth rounded-xl border border-white/[0.08] bg-white/[0.04] p-6 light:bg-white light:border-gray-200">
+                  <div class="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <span class="text-sm font-medium text-white/50 light:text-gray-500">{{ $t('metaInsights.totalCost') }}</span>
+                    <div class="h-10 w-10 rounded-lg bg-amber-500/20 flex items-center justify-center">
+                      <DollarSign class="h-5 w-5 text-amber-400" />
+                    </div>
+                  </div>
+                  <div class="pt-2">
+                    <div class="text-3xl font-bold text-white light:text-gray-900">
+                      ${{ (aggregatedData as ReturnType<typeof aggregateCallData>).totals.cost.toFixed(2) }}
                     </div>
                   </div>
                 </div>
               </div>
 
-              <!-- Call Breakdown -->
-              <div class="grid gap-4 md:grid-cols-2">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{{ $t('metaInsights.callsByType') }}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div class="space-y-3">
-                      <div
-                        v-for="[type, count] in Object.entries((aggregatedData as ReturnType<typeof aggregateCallData>).byType)"
-                        :key="type"
-                        class="flex items-center justify-between"
-                      >
-                        <span class="text-white/70 light:text-gray-600">{{ formatCategory(type) }}</span>
-                        <span class="font-medium text-white light:text-gray-900">{{ count.toLocaleString() }}</span>
-                      </div>
-                      <div v-if="Object.keys((aggregatedData as ReturnType<typeof aggregateCallData>).byType).length === 0" class="text-muted-foreground text-center py-4">
-                        {{ $t('metaInsights.noCallData') }}
-                      </div>
+              <!-- Chart -->
+              <Card>
+                <CardHeader>
+                  <CardTitle>{{ $t('metaInsights.callsOverTime') }}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div class="h-80">
+                    <Line v-if="callChartData.labels.length > 0" :data="callChartData" :options="chartOptions" />
+                    <div v-else class="h-full flex items-center justify-center text-muted-foreground">
+                      {{ $t('metaInsights.noDataForPeriod') }}
                     </div>
-                  </CardContent>
-                </Card>
-
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{{ $t('metaInsights.callsByDirection') }}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div class="space-y-3">
-                      <div
-                        v-for="[direction, count] in Object.entries((aggregatedData as ReturnType<typeof aggregateCallData>).byDirection)"
-                        :key="direction"
-                        class="flex items-center justify-between"
-                      >
-                        <span class="text-white/70 light:text-gray-600">{{ formatCategory(direction) }}</span>
-                        <span class="font-medium text-white light:text-gray-900">{{ count.toLocaleString() }}</span>
-                      </div>
-                      <div v-if="Object.keys((aggregatedData as ReturnType<typeof aggregateCallData>).byDirection).length === 0" class="text-muted-foreground text-center py-4">
-                        {{ $t('metaInsights.noCallData') }}
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
+                  </div>
+                </CardContent>
+              </Card>
             </template>
             <template v-else>
               <div class="text-center py-12 text-muted-foreground">

--- a/pkg/whatsapp/analytics.go
+++ b/pkg/whatsapp/analytics.go
@@ -136,12 +136,12 @@ type TemplateAnalytics struct {
 
 // CallAnalyticsDataPoint represents a single data point for call analytics
 type CallAnalyticsDataPoint struct {
-	Start         int64  `json:"start"`
-	End           int64  `json:"end"`
-	TotalCalls    int64  `json:"total_calls"`
-	CallDuration  int64  `json:"call_duration"`  // Total duration in seconds
-	CallType      string `json:"call_type"`      // "VOICE", "VIDEO"
-	CallDirection string `json:"call_direction"` // "INBOUND", "OUTBOUND"
+	Start           int64   `json:"start"`
+	End             int64   `json:"end"`
+	Count           int64   `json:"count"`
+	Cost            float64 `json:"cost"`
+	AverageDuration int64   `json:"average_duration"` // Average duration in seconds
+	Direction       string  `json:"direction,omitempty"` // USER_INITIATED or BUSINESS_INITIATED (from dimensions)
 }
 
 // CallAnalyticsEntry represents a single phone number's call data
@@ -330,6 +330,12 @@ func (c *Client) buildAnalyticsURL(account *Account, analyticsType AnalyticsType
 	// Add dimensions for pricing_analytics to get detailed breakdown
 	if analyticsType == AnalyticsTypePricing {
 		filters = append(filters, "dimensions(PRICING_CATEGORY,PRICING_TYPE,COUNTRY)")
+	}
+
+	// Add dimensions for call_analytics to get direction breakdown
+	if analyticsType == AnalyticsTypeCall {
+		filters = append(filters, "dimensions(direction)")
+		filters = append(filters, "metric_types(COUNT,COST,AVERAGE_DURATION)")
 	}
 
 	field := fmt.Sprintf("%s.%s", analyticsType, strings.Join(filters, "."))


### PR DESCRIPTION
- Fix CallAnalyticsDataPoint struct to match Meta API response (count, cost, average_duration instead of total_calls, call_duration)
- Add dimensions(direction) to call analytics URL for incoming/outgoing breakdown
- Show 5 stat cards: total calls, incoming, outgoing, avg duration, cost
- Add calls over time chart with incoming vs outgoing lines
- Switch MetaInsightsView from shadcn useToast to vue-sonner (matches App.vue Toaster)
- Handle error envelope in success path for API error messages