### PR TITLE
feat: add Redis TLS and username support (fixes #255)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,8 +84,10 @@ jobs:
           [redis]
           host = "localhost"
           port = 6379
+          username = ""
           password = ""
           db = 0
+          tls = false
 
           [jwt]
           secret = "test-secret-key-for-ci"

--- a/config.example.toml
+++ b/config.example.toml
@@ -32,8 +32,10 @@ conn_max_lifetime = 300
 [redis]
 host = "redis"  # Use "localhost" for local development
 port = 6379
+username = ""  # Redis ACL username (Redis 6+). Leave empty to use the default user.
 password = ""
 db = 0
+tls = false    # Set to true for TLS connections (e.g. Upstash, Redis Cloud)
 
 [jwt]
 secret = "your-super-secret-jwt-key-change-in-production"  # Must be 32+ chars in production

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -35,8 +35,10 @@ sslmode = "disable"
 [redis]
 host = "localhost"
 port = 6379
+username = ""  # Redis ACL username (Redis 6+). Leave empty to use the default user.
 password = ""
 db = 0
+tls = false    # Set to true for TLS connections (e.g. Upstash, Redis Cloud)
 
 # JWT settings
 [jwt]
@@ -68,6 +70,9 @@ Configuration values can be overridden using environment variables:
 | `WHATOMATE_DATABASE_NAME` | Database name |
 | `WHATOMATE_REDIS_HOST` | Redis host |
 | `WHATOMATE_REDIS_PORT` | Redis port |
+| `WHATOMATE_REDIS_USERNAME` | Redis ACL username (leave empty for default user) |
+| `WHATOMATE_REDIS_PASSWORD` | Redis password |
+| `WHATOMATE_REDIS_TLS` | Enable TLS (`true`/`false`) |
 | `WHATOMATE_JWT_SECRET` | JWT signing secret |
 
 ## Database Setup
@@ -206,7 +211,8 @@ For production deployments:
 - Set `environment = "production"` and `debug = false`
 - Use strong, unique values for `jwt.secret`
 - Enable SSL for database connections (`sslmode = "require"`)
-- Use Redis authentication in production
+- Use Redis authentication in production (`password`, and `username` for Redis 6+ ACL)
+- Enable `tls = true` for managed Redis services (Upstash, Redis Cloud, etc.)
 - Configure proper firewall rules
 - Set up SSL/TLS termination (nginx, Caddy, or cloud load balancer)
 - Consider running API and workers separately for better scaling

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,8 +83,10 @@ type DatabaseConfig struct {
 type RedisConfig struct {
 	Host     string `koanf:"host"`
 	Port     int    `koanf:"port"`
+	Username string `koanf:"username"`
 	Password string `koanf:"password"`
 	DB       int    `koanf:"db"`
+	TLS      bool   `koanf:"tls"`
 }
 
 type JWTConfig struct {

--- a/internal/database/redis.go
+++ b/internal/database/redis.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 
 	"github.com/redis/go-redis/v9"
@@ -10,11 +11,20 @@ import (
 
 // NewRedis creates a new Redis client
 func NewRedis(cfg *config.RedisConfig) (*redis.Client, error) {
-	client := redis.NewClient(&redis.Options{
+	opts := &redis.Options{
 		Addr:     fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
+		Username: cfg.Username,
 		Password: cfg.Password,
 		DB:       cfg.DB,
-	})
+	}
+	
+	if cfg.TLS {
+		opts.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	client := redis.NewClient(opts)
 
 	// Test connection
 	ctx := context.Background()

--- a/internal/database/redis_test.go
+++ b/internal/database/redis_test.go
@@ -1,0 +1,119 @@
+package database_test
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/shridarpatil/whatomate/internal/config"
+	"github.com/shridarpatil/whatomate/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseTestRedisURL splits TEST_REDIS_URL (redis://[user:pass@]host:port[/db])
+// into a RedisConfig so we can pass individual fields to NewRedis.
+func parseTestRedisConfig(t *testing.T) *config.RedisConfig {
+	t.Helper()
+
+	raw := os.Getenv("TEST_REDIS_URL")
+	if raw == "" {
+		t.Skip("TEST_REDIS_URL not set, skipping Redis test")
+	}
+
+	// Strip scheme
+	raw = strings.TrimPrefix(raw, "redis://")
+
+	cfg := &config.RedisConfig{
+		Port: 6379,
+	}
+
+	// Optional userinfo
+	if at := strings.LastIndex(raw, "@"); at != -1 {
+		userinfo := raw[:at]
+		raw = raw[at+1:]
+		if colon := strings.Index(userinfo, ":"); colon != -1 {
+			cfg.Username = userinfo[:colon]
+			cfg.Password = userinfo[colon+1:]
+		} else {
+			cfg.Username = userinfo
+		}
+	}
+
+	// Optional /db suffix
+	if slash := strings.Index(raw, "/"); slash != -1 {
+		dbStr := raw[slash+1:]
+		raw = raw[:slash]
+		if db, err := strconv.Atoi(dbStr); err == nil {
+			cfg.DB = db
+		}
+	}
+
+	// host:port
+	if colon := strings.LastIndex(raw, ":"); colon != -1 {
+		cfg.Host = raw[:colon]
+		if port, err := strconv.Atoi(raw[colon+1:]); err == nil {
+			cfg.Port = port
+		}
+	} else {
+		cfg.Host = raw
+	}
+
+	return cfg
+}
+
+func TestNewRedis_ConnectsWithDefaultOptions(t *testing.T) {
+	cfg := parseTestRedisConfig(t)
+
+	client, err := database.NewRedis(cfg)
+	require.NoError(t, err, "NewRedis should connect successfully")
+	require.NotNil(t, client)
+	defer client.Close()
+}
+
+func TestNewRedis_EmptyUsernameUsesDefaultUser(t *testing.T) {
+	cfg := parseTestRedisConfig(t)
+	cfg.Username = "" // explicit zero value — should fall back to Redis "default" user
+
+	client, err := database.NewRedis(cfg)
+	require.NoError(t, err, "empty username should connect using the default ACL user")
+	require.NotNil(t, client)
+	defer client.Close()
+}
+
+func TestNewRedis_TLSFalseDoesNotSetTLSConfig(t *testing.T) {
+	cfg := parseTestRedisConfig(t)
+	cfg.TLS = false
+
+	client, err := database.NewRedis(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	defer client.Close()
+
+	// Connection must still be usable (PING succeeds)
+	ctx := t.Context()
+	assert.NoError(t, client.Ping(ctx).Err())
+}
+
+func TestNewRedis_InvalidHostReturnsError(t *testing.T) {
+	parseTestRedisConfig(t) // still skip if TEST_REDIS_URL is unset
+
+	cfg := &config.RedisConfig{
+		Host: "localhost",
+		Port: 19999, // nothing listening here
+	}
+
+	client, err := database.NewRedis(cfg)
+	assert.Error(t, err, "should fail when Redis is unreachable")
+	assert.Nil(t, client)
+}
+
+func TestNewRedis_TLSEnabledFailsAgainstPlainTextServer(t *testing.T) {
+	cfg := parseTestRedisConfig(t)
+	cfg.TLS = true // our test Redis has no TLS — handshake must fail
+
+	client, err := database.NewRedis(cfg)
+	assert.Error(t, err, "TLS handshake against a plain-text server should fail")
+	assert.Nil(t, client)
+}


### PR DESCRIPTION
Fixes #255

- Add Username and TLS fields to RedisConfig
- Set TLSConfig with MinVersion TLS 1.2 when tls = true
- Empty username correctly falls back to Redis default ACL user
- Update config.example.toml and docs with new options
- Add tests for connection, empty username, TLS flag, and error paths