### PR TITLE
fix: prevent random logouts caused by token refresh race condition

### DIFF
--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -27,9 +27,12 @@ const authStore = useAuthStore()
 const isCollapsed = ref(false)
 const isMobileMenuOpen = ref(false)
 
-// Connect WebSocket on mount using short-lived WS token
+// Refresh user data and connect WebSocket on mount
 onMounted(() => {
   if (authStore.isAuthenticated) {
+    // Fetch fresh permissions in background (non-destructive — interceptor handles 401)
+    authStore.refreshUserData()
+
     wsService.connect(async () => {
       try {
         const resp = await authService.getWSToken()

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -61,6 +61,18 @@ api.interceptors.request.use(
   }
 )
 
+// Token refresh mutex — ensures only one refresh runs at a time.
+// Without this, multiple concurrent 401s each trigger a refresh, but the
+// single-use refresh token (JTI deleted from Redis) causes all but the first
+// to fail, which clears auth and logs the user out.
+let isRefreshing = false
+let refreshSubscribers: Array<(success: boolean) => void> = []
+
+function onRefreshComplete(success: boolean) {
+  refreshSubscribers.forEach(cb => cb(success))
+  refreshSubscribers = []
+}
+
 // Response interceptor for error handling
 api.interceptors.response.use(
   (response) => response,
@@ -74,14 +86,36 @@ api.interceptors.response.use(
     if (error.response?.status === 401 && !originalRequest._retry && !isAuthEndpoint) {
       originalRequest._retry = true
 
+      // If a refresh is already in flight, queue this request to wait for it
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          refreshSubscribers.push((success: boolean) => {
+            if (success) {
+              resolve(api(originalRequest))
+            } else {
+              reject(error)
+            }
+          })
+        })
+      }
+
+      isRefreshing = true
+
       try {
         // Browser sends whm_refresh cookie automatically via withCredentials
         await axios.post(`${API_BASE_URL}/auth/refresh`, {}, { withCredentials: true })
 
-        // Cookies are updated by the server response — retry the original request
+        // Cookies are updated by the server response — notify waiting requests
+        onRefreshComplete(true)
+        isRefreshing = false
+
+        // Retry the original request
         return api(originalRequest)
       } catch {
-        // Refresh failed, clear user and redirect to login
+        // Refresh failed — notify waiting requests and redirect to login
+        onRefreshComplete(false)
+        isRefreshing = false
+
         localStorage.removeItem('user')
         localStorage.removeItem('auth_token')
         localStorage.removeItem('refresh_token')

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -64,6 +64,12 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('refresh_token')
   }
 
+  /**
+   * Restore session from localStorage (synchronous, no API calls).
+   * Returns true if a valid user object was found in localStorage.
+   * Does NOT verify the session with the server — the API interceptor
+   * handles 401s and token refresh automatically.
+   */
   function restoreSession(): boolean {
     const storedUser = localStorage.getItem('user')
 
@@ -83,8 +89,6 @@ export const useAuthStore = defineStore('auth', () => {
           return false
         }
         user.value = parsed
-        // Fetch fresh user data in background to verify session + get updated permissions
-        refreshUserData()
         return true
       } catch {
         clearAuth()


### PR DESCRIPTION
When access tokens expire, multiple concurrent API calls fail with 401 simultaneously. Each independently triggers a refresh, but the refresh token is single-use (JTI deleted from Redis), so all but the first fail and clear auth, logging the user out despite a successful refresh.

Changes:
- Add refresh mutex in api.ts interceptor: first 401 starts the refresh, subsequent 401s queue and wait for the result instead of racing
- Remove fire-and-forget refreshUserData() from restoreSession(), which could trigger the race on page load before the user even interacts
- Move refreshUserData() to AppLayout mount, where it goes through the interceptor with proper mutex protection

Fixes: https://github.com/shridarpatil/whatomate/issues/190