### PR TITLE
feat: polish flow builder UI and extract shared FlowCanvas

### DIFF
--- a/frontend/src/components/calling/nodes/BaseNode.vue
+++ b/frontend/src/components/calling/nodes/BaseNode.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Handle, Position } from '@vue-flow/core'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     label: string
     headerClass: string
@@ -10,28 +11,41 @@ withDefaults(
   }>(),
   { hasInput: true },
 )
+
+const gradientMap: Record<string, string> = {
+  'bg-blue-600': 'from-blue-600 to-blue-500',
+  'bg-purple-600': 'from-purple-600 to-purple-500',
+  'bg-orange-600': 'from-orange-600 to-amber-500',
+  'bg-green-600': 'from-green-600 to-emerald-500',
+  'bg-amber-600': 'from-amber-600 to-yellow-500',
+  'bg-red-600': 'from-red-600 to-rose-500',
+  'bg-cyan-600': 'from-cyan-600 to-cyan-500',
+  'bg-teal-600': 'from-teal-600 to-teal-500',
+}
+
+const headerGradient = computed(() => gradientMap[props.headerClass] || props.headerClass)
 </script>
 
 <template>
-  <div class="relative bg-background border rounded-lg shadow-sm min-w-[180px] max-w-[240px] overflow-visible">
+  <div class="base-node relative bg-background border rounded-lg shadow-md hover:shadow-lg min-w-[180px] max-w-[240px] overflow-visible transition-shadow duration-200">
     <!-- Input handle (top) -->
     <Handle
       v-if="hasInput !== false"
       id="input"
       type="target"
       :position="Position.Top"
-      class="!w-3 !h-3 !rounded-full !bg-slate-400 !border-2 !border-background"
+      class="!w-3.5 !h-3.5 !rounded-full !bg-slate-400 !border-2 !border-background hover:!bg-slate-300 !transition-colors"
       style="z-index: 10;"
     />
 
     <!-- Header -->
-    <div :class="['px-3 py-1.5 rounded-t-lg text-white text-xs font-medium flex items-center gap-1.5 overflow-hidden', headerClass]">
+    <div :class="['px-3 py-2 rounded-t-lg text-white text-xs font-semibold flex items-center gap-2 overflow-hidden bg-gradient-to-r', headerGradient]">
       <slot name="icon" />
       <span class="truncate">{{ label }}</span>
     </div>
 
     <!-- Body -->
-    <div class="px-3 py-2 text-xs text-muted-foreground">
+    <div class="px-3 py-2.5 text-xs text-muted-foreground">
       <slot />
     </div>
 
@@ -57,7 +71,7 @@ withDefaults(
           left: outputHandles.length === 1 ? '50%' : `${((idx + 1) / (outputHandles.length + 1)) * 100}%`,
           zIndex: 10,
         }"
-        class="!w-3 !h-3 !rounded-full !bg-primary !border-2 !border-background"
+        class="!w-3.5 !h-3.5 !rounded-full !bg-primary !border-2 !border-background hover:!bg-primary/80 !transition-colors"
       />
     </template>
     <template v-else-if="!outputHandles">
@@ -65,7 +79,7 @@ withDefaults(
         id="default"
         type="source"
         :position="Position.Bottom"
-        class="!w-3 !h-3 !rounded-full !bg-primary !border-2 !border-background"
+        class="!w-3.5 !h-3.5 !rounded-full !bg-primary !border-2 !border-background hover:!bg-primary/80 !transition-colors"
         style="z-index: 10;"
       />
     </template>

--- a/frontend/src/components/calling/nodes/GatherNode.vue
+++ b/frontend/src/components/calling/nodes/GatherNode.vue
@@ -24,7 +24,7 @@ const outputHandles = [
 
 <template>
   <BaseNode :label="data?.label || 'Gather'" header-class="bg-blue-600" :output-handles="outputHandles" :has-input="!data?.isEntryNode">
-    <template #icon><Hash class="w-3 h-3" /></template>
+    <template #icon><Hash class="w-4 h-4" /></template>
     <p class="truncate">{{ summary }}</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/calling/nodes/GotoFlowNode.vue
+++ b/frontend/src/components/calling/nodes/GotoFlowNode.vue
@@ -19,7 +19,7 @@ const summary = computed(() => {
 
 <template>
   <BaseNode :label="data?.label || 'Goto Flow'" header-class="bg-teal-600" :output-handles="[]" :has-input="!data?.isEntryNode">
-    <template #icon><ExternalLink class="w-3 h-3" /></template>
+    <template #icon><ExternalLink class="w-4 h-4" /></template>
     <p class="truncate">{{ summary }}</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/calling/nodes/GreetingNode.vue
+++ b/frontend/src/components/calling/nodes/GreetingNode.vue
@@ -19,7 +19,7 @@ const outputHandles = [{ id: 'default', label: 'next' }]
 
 <template>
   <BaseNode :label="data?.label || 'Greeting'" header-class="bg-green-600" :output-handles="outputHandles" :has-input="!data?.isEntryNode">
-    <template #icon><Volume2 class="w-3 h-3" /></template>
+    <template #icon><Volume2 class="w-4 h-4" /></template>
     <p class="truncate">{{ summary }}</p>
     <p v-if="data?.config?.interruptible" class="text-[10px] text-green-600 mt-0.5">Interruptible</p>
   </BaseNode>

--- a/frontend/src/components/calling/nodes/HTTPCallbackNode.vue
+++ b/frontend/src/components/calling/nodes/HTTPCallbackNode.vue
@@ -22,7 +22,7 @@ const outputHandles = [
 
 <template>
   <BaseNode :label="data?.label || 'HTTP Callback'" header-class="bg-orange-600" :output-handles="outputHandles" :has-input="!data?.isEntryNode">
-    <template #icon><Globe class="w-3 h-3" /></template>
+    <template #icon><Globe class="w-4 h-4" /></template>
     <p class="truncate font-mono text-[10px]">{{ summary }}</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/calling/nodes/HangupNode.vue
+++ b/frontend/src/components/calling/nodes/HangupNode.vue
@@ -9,7 +9,7 @@ defineProps<{ data: Record<string, any> }>()
 
 <template>
   <BaseNode :label="data?.label || 'Hangup'" header-class="bg-red-600" :output-handles="[]" :has-input="!data?.isEntryNode">
-    <template #icon><PhoneOff class="w-3 h-3" /></template>
+    <template #icon><PhoneOff class="w-4 h-4" /></template>
     <p v-if="data?.config?.audio_file || data?.config?.greeting_text" class="truncate">
       {{ data.config.greeting_text || data.config.audio_file }}
     </p>

--- a/frontend/src/components/calling/nodes/MenuNode.vue
+++ b/frontend/src/components/calling/nodes/MenuNode.vue
@@ -25,7 +25,7 @@ const outputHandles = computed(() => {
 
 <template>
   <BaseNode :label="data?.label || 'Menu'" header-class="bg-purple-600" :output-handles="outputHandles" :has-input="!data?.isEntryNode">
-    <template #icon><Grid3X3 class="w-3 h-3" /></template>
+    <template #icon><Grid3X3 class="w-4 h-4" /></template>
     <div v-if="options.length > 0" class="space-y-0.5">
       <div v-for="[digit, opt] in options" :key="digit" class="flex gap-1">
         <span class="font-mono font-bold">{{ digit }}:</span>

--- a/frontend/src/components/calling/nodes/TimingNode.vue
+++ b/frontend/src/components/calling/nodes/TimingNode.vue
@@ -22,7 +22,7 @@ const outputHandles = [
 
 <template>
   <BaseNode :label="data?.label || 'Timing'" header-class="bg-cyan-600" :output-handles="outputHandles" :has-input="!data?.isEntryNode">
-    <template #icon><Clock class="w-3 h-3" /></template>
+    <template #icon><Clock class="w-4 h-4" /></template>
     <p class="truncate">{{ summary }}</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/calling/nodes/TransferNode.vue
+++ b/frontend/src/components/calling/nodes/TransferNode.vue
@@ -19,7 +19,7 @@ const summary = computed(() => {
 
 <template>
   <BaseNode :label="data?.label || 'Transfer'" header-class="bg-amber-600" :output-handles="[{ id: 'completed', label: 'completed' }, { id: 'no_answer', label: 'no answer' }]" :has-input="!data?.isEntryNode">
-    <template #icon><Users class="w-3 h-3" /></template>
+    <template #icon><Users class="w-4 h-4" /></template>
     <p class="truncate">{{ summary }}</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/chatbot/flow-builder/FlowChart.vue
+++ b/frontend/src/components/chatbot/flow-builder/FlowChart.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
 import { ref, watch, markRaw, nextTick } from 'vue'
-import { VueFlow, useVueFlow, MarkerType } from '@vue-flow/core'
+import { useVueFlow, MarkerType } from '@vue-flow/core'
 import type { Node, Edge, NodeMouseEvent, Connection } from '@vue-flow/core'
-import { Background } from '@vue-flow/background'
-import { Controls } from '@vue-flow/controls'
-import { MiniMap } from '@vue-flow/minimap'
 import { Button } from '@/components/ui/button'
 import { GitBranch, Play, Plus, MessageSquare, MousePointerClick, Globe, MessageCircle, UserPlus } from 'lucide-vue-next'
 import { stepsToNodesAndEdges, extractCanvasLayout } from '@/composables/useChatbotFlowConverter'
 import type { CanvasLayout } from '@/composables/useChatbotFlowConverter'
+import FlowCanvas from '@/components/shared/FlowCanvas.vue'
 import ChatbotTextNode from '@/components/chatbot/nodes/ChatbotTextNode.vue'
 import ChatbotButtonsNode from '@/components/chatbot/nodes/ChatbotButtonsNode.vue'
 import ChatbotApiNode from '@/components/chatbot/nodes/ChatbotApiNode.vue'
@@ -160,7 +158,6 @@ function onPaneClick() {
 
 function onPaletteClick(type: string) {
   if (selectedOnCanvas.value !== null) {
-    // Change the selected step's type
     emit('changeStepType', selectedOnCanvas.value, type)
   }
 }
@@ -245,31 +242,21 @@ function onEdgeRemove(edges: Edge[]) {
         @click="selectedOnCanvas !== null ? onPaletteClick(p.type) : emit('addStep')"
       >
         <div :class="['w-2 h-2 rounded-full', p.color]" />
-        <component :is="p.icon" class="w-3 h-3" />
+        <component :is="p.icon" class="w-3.5 h-3.5" />
         {{ p.label }}
       </Button>
     </div>
 
     <!-- Vue Flow Canvas -->
     <div class="flex-1">
-      <VueFlow
-        v-model:nodes="flowNodes"
-        v-model:edges="flowEdges"
+      <FlowCanvas
+        :nodes="flowNodes"
+        :edges="flowEdges"
         :node-types="nodeTypes"
-        :nodes-draggable="true"
-        :nodes-connectable="true"
-        :edges-updatable="true"
-        :zoom-on-scroll="true"
-        :zoom-on-pinch="true"
-        :pan-on-drag="true"
-        :pan-on-scroll="false"
-        :snap-to-grid="true"
-        :snap-grid="[20, 20]"
-        :min-zoom="0.2"
-        :max-zoom="2"
-        :delete-key-code="['Backspace', 'Delete']"
-        :default-edge-options="{ type: 'smoothstep', animated: true, markerEnd: MarkerType.ArrowClosed }"
+        edge-type="default"
         fit-view-on-init
+        @update:nodes="flowNodes = $event"
+        @update:edges="flowEdges = $event"
         @node-click="onNodeClick"
         @node-drag-stop="onNodeDragStop"
         @pane-click="onPaneClick"
@@ -278,11 +265,7 @@ function onEdgeRemove(edges: Edge[]) {
           const removals = changes.filter((c: any) => c.type === 'remove')
           if (removals.length) onEdgeRemove(removals.map((r: any) => flowEdges.find((e) => e.id === r.id)).filter(Boolean) as Edge[])
         }"
-      >
-        <Background :gap="20" />
-        <Controls position="bottom-left" />
-        <MiniMap />
-      </VueFlow>
+      />
 
       <!-- Empty state overlay -->
       <div
@@ -300,16 +283,3 @@ function onEdgeRemove(edges: Edge[]) {
     </div>
   </div>
 </template>
-
-<style>
-@import '@vue-flow/core/dist/style.css';
-@import '@vue-flow/core/dist/theme-default.css';
-@import '@vue-flow/controls/dist/style.css';
-@import '@vue-flow/minimap/dist/style.css';
-
-.selected-node {
-  outline: 3px solid hsl(var(--primary));
-  outline-offset: 2px;
-  border-radius: 0.5rem;
-}
-</style>

--- a/frontend/src/components/chatbot/nodes/ChatbotApiNode.vue
+++ b/frontend/src/components/chatbot/nodes/ChatbotApiNode.vue
@@ -18,7 +18,7 @@ const summary = computed(() => {
 
 <template>
   <BaseNode :label="data?.label || 'API Fetch'" header-class="bg-orange-600" :has-input="!data?.isEntryNode">
-    <template #icon><Globe class="w-3 h-3" /></template>
-    <p class="truncate font-mono text-[10px]">{{ summary }}</p>
+    <template #icon><Globe class="w-4 h-4" /></template>
+    <p class="truncate font-mono text-[10px]" :title="data?.config?.api_config?.url || ''">{{ summary }}</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/chatbot/nodes/ChatbotButtonsNode.vue
+++ b/frontend/src/components/chatbot/nodes/ChatbotButtonsNode.vue
@@ -19,10 +19,10 @@ const outputHandles = computed(() => {
 
 <template>
   <BaseNode :label="data?.label || 'Buttons'" header-class="bg-purple-600" :output-handles="outputHandles" :has-input="!data?.isEntryNode">
-    <template #icon><MousePointerClick class="w-3 h-3" /></template>
+    <template #icon><MousePointerClick class="w-4 h-4" /></template>
     <div v-if="buttons.length > 0" class="space-y-0.5">
-      <div v-for="btn in buttons" :key="btn.id" class="truncate">{{ btn.title || '—' }}</div>
+      <div v-for="btn in buttons" :key="btn.id" class="truncate text-muted-foreground/80" :title="btn.title">{{ btn.title || '—' }}</div>
     </div>
-    <p v-else class="text-muted-foreground">No buttons</p>
+    <p v-else class="text-muted-foreground italic">No buttons</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/chatbot/nodes/ChatbotTextNode.vue
+++ b/frontend/src/components/chatbot/nodes/ChatbotTextNode.vue
@@ -17,9 +17,9 @@ const inputType = computed(() => props.data?.config?.input_type)
 
 <template>
   <BaseNode :label="data?.label || 'Text'" header-class="bg-blue-600" :has-input="!data?.isEntryNode">
-    <template #icon><MessageSquare class="w-3 h-3" /></template>
-    <p class="truncate">{{ message }}</p>
-    <span v-if="inputType && inputType !== 'none'" class="inline-block mt-1 px-1.5 py-0.5 bg-blue-100 text-blue-700 rounded text-[10px] font-medium">
+    <template #icon><MessageSquare class="w-4 h-4" /></template>
+    <p class="truncate" :title="data?.config?.message || ''">{{ message }}</p>
+    <span v-if="inputType && inputType !== 'none'" class="inline-block mt-1 px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 rounded text-[10px] font-medium">
       {{ inputType }}
     </span>
   </BaseNode>

--- a/frontend/src/components/chatbot/nodes/ChatbotTransferNode.vue
+++ b/frontend/src/components/chatbot/nodes/ChatbotTransferNode.vue
@@ -23,10 +23,10 @@ const notes = computed(() => {
 
 <template>
   <BaseNode :label="data?.label || 'Transfer'" header-class="bg-amber-600" :output-handles="[]" :has-input="!data?.isEntryNode">
-    <template #icon><UserPlus class="w-3 h-3" /></template>
+    <template #icon><UserPlus class="w-4 h-4" /></template>
     <div>
-      <p class="font-medium truncate">→ {{ teamLabel }}</p>
-      <p v-if="notes" class="truncate text-muted-foreground/70 mt-0.5">{{ notes }}</p>
+      <p class="font-medium truncate" :title="teamLabel">→ {{ teamLabel }}</p>
+      <p v-if="notes" class="truncate text-muted-foreground/70 mt-0.5" :title="notes">{{ notes }}</p>
     </div>
   </BaseNode>
 </template>

--- a/frontend/src/components/chatbot/nodes/ChatbotWhatsAppFlowNode.vue
+++ b/frontend/src/components/chatbot/nodes/ChatbotWhatsAppFlowNode.vue
@@ -14,7 +14,7 @@ const summary = computed(() => {
 
 <template>
   <BaseNode :label="data?.label || 'WhatsApp Flow'" header-class="bg-green-600" :has-input="!data?.isEntryNode">
-    <template #icon><MessageCircle class="w-3 h-3" /></template>
-    <p class="truncate">{{ summary }}</p>
+    <template #icon><MessageCircle class="w-4 h-4" /></template>
+    <p class="truncate" :title="summary">{{ summary }}</p>
   </BaseNode>
 </template>

--- a/frontend/src/components/shared/FlowCanvas.vue
+++ b/frontend/src/components/shared/FlowCanvas.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { VueFlow, MarkerType } from '@vue-flow/core'
+import type { Node, Edge, NodeMouseEvent, Connection, EdgeMouseEvent } from '@vue-flow/core'
+import { Background } from '@vue-flow/background'
+import { Controls } from '@vue-flow/controls'
+import { MiniMap } from '@vue-flow/minimap'
+
+withDefaults(
+  defineProps<{
+    nodes?: Node[]
+    edges?: Edge[]
+    nodeTypes: Record<string, any>
+    edgeType?: string
+    fitViewOnInit?: boolean
+    controlsPosition?: string
+  }>(),
+  {
+    edgeType: 'smoothstep',
+    fitViewOnInit: false,
+    controlsPosition: 'bottom-left',
+  },
+)
+
+defineEmits<{
+  'update:nodes': [nodes: Node[]]
+  'update:edges': [edges: Edge[]]
+  'node-click': [event: NodeMouseEvent]
+  'pane-click': []
+  'connect': [connection: Connection]
+  'edge-click': [event: EdgeMouseEvent]
+  'edge-update': [payload: { edge: Edge; connection: Connection }]
+  'node-drag-stop': []
+  'edges-change': [changes: any[]]
+}>()
+</script>
+
+<template>
+  <div class="flow-canvas h-full relative">
+    <VueFlow
+      :nodes="nodes"
+      :edges="edges"
+      :node-types="nodeTypes"
+      :nodes-draggable="true"
+      :nodes-connectable="true"
+      :edges-updatable="true"
+      :zoom-on-scroll="true"
+      :zoom-on-pinch="true"
+      :pan-on-drag="true"
+      :pan-on-scroll="false"
+      :snap-to-grid="true"
+      :snap-grid="[20, 20]"
+      :min-zoom="0.2"
+      :max-zoom="2"
+      :delete-key-code="['Backspace', 'Delete']"
+      :default-edge-options="{ type: edgeType, animated: true, markerEnd: MarkerType.ArrowClosed }"
+      :fit-view-on-init="fitViewOnInit"
+      class="h-full"
+      @update:nodes="$emit('update:nodes', $event)"
+      @update:edges="$emit('update:edges', $event)"
+      @node-click="$emit('node-click', $event)"
+      @pane-click="$emit('pane-click')"
+      @connect="$emit('connect', $event)"
+      @edge-click="$emit('edge-click', $event)"
+      @edge-update="$emit('edge-update', $event)"
+      @node-drag-stop="$emit('node-drag-stop')"
+      @edges-change="$emit('edges-change', $event)"
+    >
+      <Background
+        pattern-color="hsl(var(--muted-foreground) / 0.15)"
+        :gap="20"
+        :size="1"
+        variant="dots"
+      />
+      <Controls :position="controlsPosition as any" />
+      <MiniMap />
+      <slot />
+    </VueFlow>
+  </div>
+</template>
+
+<style>
+@import '@vue-flow/core/dist/style.css';
+@import '@vue-flow/core/dist/theme-default.css';
+@import '@vue-flow/controls/dist/style.css';
+@import '@vue-flow/minimap/dist/style.css';
+
+.vue-flow__edge-textbg {
+  fill: transparent;
+}
+
+.selected-node {
+  outline: none;
+  border-radius: 0.5rem;
+  box-shadow:
+    0 0 0 2px hsl(var(--background)),
+    0 0 0 4px hsl(var(--primary)),
+    0 0 16px hsl(var(--primary) / 0.35);
+}
+
+.selected-node .base-node {
+  border-color: hsl(var(--primary));
+}
+</style>

--- a/frontend/src/views/calling/IVRFlowEditorView.vue
+++ b/frontend/src/views/calling/IVRFlowEditorView.vue
@@ -2,14 +2,8 @@
 import { ref, computed, onMounted, markRaw } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import { VueFlow, useVueFlow, MarkerType, type NodeMouseEvent, type Edge, type EdgeMouseEvent, type Connection } from '@vue-flow/core'
-import { Background } from '@vue-flow/background'
-import { Controls } from '@vue-flow/controls'
-import { MiniMap } from '@vue-flow/minimap'
-import '@vue-flow/core/dist/style.css'
-import '@vue-flow/core/dist/theme-default.css'
-import '@vue-flow/controls/dist/style.css'
-import '@vue-flow/minimap/dist/style.css'
+import { useVueFlow, MarkerType, type NodeMouseEvent, type Edge, type EdgeMouseEvent, type Connection } from '@vue-flow/core'
+import FlowCanvas from '@/components/shared/FlowCanvas.vue'
 import { useCallingStore } from '@/stores/calling'
 import { useTeamsStore } from '@/stores/teams'
 import { ivrFlowsService, type IVRNode, type IVREdge, type IVRFlowData, type IVRNodeType } from '@/services/api'
@@ -455,23 +449,14 @@ onMounted(() => {
             </div>
           </template>
         </ErrorState>
-        <VueFlow
+        <FlowCanvas
           :node-types="nodeTypes"
-          :default-viewport="{ x: 0, y: 0, zoom: 1 }"
-          :snap-to-grid="true"
-          :snap-grid="[20, 20]"
-          :edges-updatable="true"
-          :delete-key-code="['Backspace', 'Delete']"
-          class="h-full"
+          edge-type="default"
           @node-click="onNodeClick"
           @pane-click="onPaneClick"
           @edge-update="onEdgeUpdate"
           @edge-click="onEdgeClick"
-        >
-          <Background :gap="20" />
-          <Controls />
-          <MiniMap />
-        </VueFlow>
+        />
       </div>
 
       <!-- Properties Panel -->

--- a/frontend/src/views/chatbot/ChatbotFlowBuilderView.vue
+++ b/frontend/src/views/chatbot/ChatbotFlowBuilderView.vue
@@ -380,6 +380,17 @@ function getStepIcon(messageType: string) {
   return type?.icon || MessageSquare
 }
 
+function getStepColor(messageType: string): string {
+  const colors: Record<string, string> = {
+    text: 'border-l-blue-500',
+    buttons: 'border-l-purple-500',
+    api_fetch: 'border-l-orange-500',
+    whatsapp_flow: 'border-l-green-500',
+    transfer: 'border-l-amber-500',
+  }
+  return colors[messageType] || 'border-l-slate-400'
+}
+
 function getStepLabel(messageType: string) {
   const type = messageTypes.value.find(t => t.value === messageType)
   return type?.label || t('flowBuilder.messageTypeText')
@@ -1026,17 +1037,19 @@ function confirmCancel() {
               v-model="formData.steps"
               item-key="step_name"
               handle=".drag-handle"
-              class="space-y-1"
+              class="space-y-2"
               @end="updateStepOrders"
             >
               <template #item="{ element: step, index }">
-                <div
-                  :class="[
-                    'group flex items-center gap-2 p-2 rounded-md cursor-pointer transition-colors',
-                    selectedStepIndex === index ? 'bg-primary/10 border border-primary/20' : 'hover:bg-muted'
-                  ]"
-                  @click="selectStep(index)"
-                >
+                <div>
+                  <div
+                    :class="[
+                      'group flex items-center gap-2 p-2 rounded-md cursor-pointer transition-colors border-l-[3px] shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]',
+                      getStepColor(step.message_type),
+                      selectedStepIndex === index ? 'bg-primary/10' : 'hover:bg-muted'
+                    ]"
+                    @click="selectStep(index)"
+                  >
                   <GripVertical class="h-4 w-4 text-muted-foreground cursor-grab drag-handle flex-shrink-0" />
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
@@ -1056,6 +1069,7 @@ function confirmCancel() {
                   >
                     <Trash2 class="h-4 w-4" />
                   </Button>
+                  </div>
                 </div>
               </template>
             </draggable>


### PR DESCRIPTION
- Gradient node headers with shadow and larger icons (w-3 → w-4)
- Hover tooltips on node body text for full content preview
- Glow ring on selected nodes instead of plain outline
- Dot grid background with muted opacity
- Colored left border on sidebar step items by node type
- Bezier curve edges matching IVR flow style

Extract shared FlowCanvas component used by both chatbot and IVR flow editors, consolidating VueFlow setup, Background/Controls/MiniMap, CSS imports, and shared styles (transparent edge labels, selection glow).