### PR TITLE
fix: improve button node labels and handle numbering

### DIFF
--- a/frontend/src/components/calling/nodes/BaseNode.vue
+++ b/frontend/src/components/calling/nodes/BaseNode.vue
@@ -27,7 +27,7 @@ const headerGradient = computed(() => gradientMap[props.headerClass] || props.he
 </script>
 
 <template>
-  <div class="base-node relative bg-background border rounded-lg shadow-md hover:shadow-lg min-w-[180px] max-w-[240px] overflow-visible transition-shadow duration-200">
+  <div class="base-node relative bg-background border rounded-lg shadow-md hover:shadow-lg min-w-48 w-max max-w-sm overflow-visible transition-shadow duration-200">
     <!-- Input handle (top) -->
     <Handle
       v-if="hasInput !== false"
@@ -51,28 +51,29 @@ const headerGradient = computed(() => gradientMap[props.headerClass] || props.he
 
     <!-- Output handles (bottom) -->
     <template v-if="outputHandles && outputHandles.length > 0">
-      <!-- Handle labels -->
-      <div v-if="outputHandles.length > 1" class="flex px-1 pt-1 border-t border-dashed">
-        <div
-          v-for="handle in outputHandles"
-          :key="'label-' + handle.id"
-          class="flex-1 text-center"
-        >
-          <span class="text-[9px] font-medium text-muted-foreground cursor-default" :title="handle.title">{{ handle.label }}</span>
-        </div>
-      </div>
       <Handle
         v-for="(handle, idx) in outputHandles"
         :key="handle.id"
         type="source"
         :id="handle.id"
         :position="Position.Bottom"
+        :title="handle.title || handle.label"
         :style="{
           left: outputHandles.length === 1 ? '50%' : `${((idx + 1) / (outputHandles.length + 1)) * 100}%`,
           zIndex: 10,
         }"
         class="!w-3.5 !h-3.5 !rounded-full !bg-primary !border-2 !border-background hover:!bg-primary/80 !transition-colors"
       />
+      <span
+        v-for="(handle, idx) in outputHandles"
+        :key="'num-' + handle.id"
+        class="absolute text-[9px] font-bold text-muted-foreground pointer-events-none"
+        :style="{
+          left: outputHandles.length === 1 ? '50%' : `${((idx + 1) / (outputHandles.length + 1)) * 100}%`,
+          bottom: '-18px',
+          transform: 'translateX(-50%)',
+        }"
+      >{{ idx + 1 }}</span>
     </template>
     <template v-else-if="!outputHandles">
       <Handle

--- a/frontend/src/components/chatbot/nodes/ChatbotButtonsNode.vue
+++ b/frontend/src/components/chatbot/nodes/ChatbotButtonsNode.vue
@@ -12,7 +12,8 @@ const buttons = computed(() => props.data?.config?.buttons || [])
 const outputHandles = computed(() => {
   return buttons.value.map((b: any) => ({
     id: b.id,
-    label: b.title?.length > 12 ? b.title.slice(0, 12) + '...' : b.title || '—',
+    label: b.title || '—',
+    title: b.title || '—',
   }))
 })
 </script>
@@ -21,7 +22,10 @@ const outputHandles = computed(() => {
   <BaseNode :label="data?.label || 'Buttons'" header-class="bg-purple-600" :output-handles="outputHandles" :has-input="!data?.isEntryNode">
     <template #icon><MousePointerClick class="w-4 h-4" /></template>
     <div v-if="buttons.length > 0" class="space-y-0.5">
-      <div v-for="btn in buttons" :key="btn.id" class="truncate text-muted-foreground/80" :title="btn.title">{{ btn.title || '—' }}</div>
+      <div v-for="(btn, idx) in buttons" :key="btn.id" class="flex gap-1" :title="btn.title">
+        <span class="font-mono font-bold">{{ idx + 1 }}:</span>
+        <span class="truncate">{{ btn.title || '—' }}</span>
+      </div>
     </div>
     <p v-else class="text-muted-foreground italic">No buttons</p>
   </BaseNode>


### PR DESCRIPTION
Show button labels as numbered list (1: label) matching IVR menu style. Replace plain handle dots with numbered labels below each connection point. Widen nodes to fit content (w-max, max-w-sm).