### PR TITLE
fix: handle template quick_reply button clicks showing [Message]

### DIFF
--- a/internal/handlers/chatbot_processor.go
+++ b/internal/handlers/chatbot_processor.go
@@ -86,6 +86,10 @@ type IncomingTextMessage struct {
 		Name      string  `json:"name,omitempty"`
 		Address   string  `json:"address,omitempty"`
 	} `json:"location,omitempty"`
+	Button *struct {
+		Text    string `json:"text"`
+		Payload string `json:"payload"`
+	} `json:"button,omitempty"`
 	Contacts []struct {
 		Name struct {
 			FormattedName string `json:"formatted_name"`
@@ -145,6 +149,11 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 
 	if msg.Type == "text" && msg.Text != nil {
 		messageText = msg.Text.Body
+	} else if msg.Type == "button" && msg.Button != nil {
+		// Template quick_reply button click — WhatsApp sends type "button"
+		messageText = msg.Button.Text
+		buttonID = msg.Button.Payload
+		messageType = "button_reply"
 	} else if msg.Type == "interactive" && msg.Interactive != nil {
 		// Handle button reply
 		if msg.Interactive.ButtonReply != nil {
@@ -2240,7 +2249,7 @@ func (a *App) saveIncomingMessage(account *models.WhatsAppAccount, contact *mode
 	if len(preview) > 100 {
 		preview = preview[:97] + "..."
 	}
-	if msgType != "text" {
+	if msgType != "text" && msgType != "button_reply" {
 		preview = "[" + msgType + "]"
 	}
 

--- a/internal/handlers/webhook.go
+++ b/internal/handlers/webhook.go
@@ -162,6 +162,10 @@ type WebhookPayload struct {
 							ResponseSource      string      `json:"response_source"`
 						} `json:"call_permission_reply,omitempty"`
 					} `json:"interactive,omitempty"`
+					Button *struct {
+						Text    string `json:"text"`
+						Payload string `json:"payload"`
+					} `json:"button,omitempty"`
 					Reaction *struct {
 						MessageID string `json:"message_id"`
 						Emoji     string `json:"emoji"`


### PR DESCRIPTION
WhatsApp sends template button clicks as type "button" (not "interactive"), but neither the webhook struct nor IncomingTextMessage had a Button field — the data was silently dropped, causing the frontend to show [Message] instead of the actual button text.

Fixes: https://github.com/shridarpatil/whatomate/issues/185