### PR TITLE
refactor: replace interface{} with any and fix linter warnings

### DIFF
--- a/internal/calling/bridge.go
+++ b/internal/calling/bridge.go
@@ -81,8 +81,8 @@ func (b *AudioBridge) forward(src *webrtc.TrackRemote, dst *webrtc.TrackLocalSta
 			pkt := &rtp.Packet{}
 			if err := pkt.Unmarshal(buf[:n]); err == nil {
 				if trackSeq {
-					b.lastCallerSeq = pkt.Header.SequenceNumber
-					b.lastCallerTS = pkt.Header.Timestamp
+					b.lastCallerSeq = pkt.SequenceNumber
+					b.lastCallerTS = pkt.Timestamp
 				}
 				if rec != nil && len(pkt.Payload) > 0 {
 					rec.WritePacket(pkt.Payload)

--- a/internal/calling/ivr.go
+++ b/internal/calling/ivr.go
@@ -55,9 +55,9 @@ func (m *Manager) runIVRFlow(session *CallSession, waAccount *whatsapp.Account) 
 	var existingLog models.CallLog
 	if err := m.db.Select("ivr_path").Where("id = ?", session.CallLogID).First(&existingLog).Error; err == nil {
 		if existingLog.IVRPath != nil {
-			if steps, ok := existingLog.IVRPath["steps"].([]interface{}); ok {
+			if steps, ok := existingLog.IVRPath["steps"].([]any); ok {
 				for _, s := range steps {
-					if stepMap, ok := s.(map[string]interface{}); ok {
+					if stepMap, ok := s.(map[string]any); ok {
 						entry := map[string]string{}
 						for k, v := range stepMap {
 							if str, ok := v.(string); ok {
@@ -200,8 +200,8 @@ func (m *Manager) executeNodeLoop(session *CallSession, waAccount *whatsapp.Acco
 		if node.Type == IVRNodeMenu && strings.HasPrefix(outcome, "digit:") {
 			digit := strings.TrimPrefix(outcome, "digit:")
 			step["digit"] = digit
-			if opts, ok := node.Config["options"].(map[string]interface{}); ok {
-				if optMap, ok := opts[digit].(map[string]interface{}); ok {
+			if opts, ok := node.Config["options"].(map[string]any); ok {
+				if optMap, ok := opts[digit].(map[string]any); ok {
 					if optLabel, ok := optMap["label"].(string); ok {
 						step["option_label"] = optLabel
 					}
@@ -266,7 +266,7 @@ func (m *Manager) executeMenu(session *CallSession, node *IVRNode, ctx *IVRConte
 
 	// Build set of valid digits from menu options
 	validDigits := make(map[string]bool)
-	if opts, ok := node.Config["options"].(map[string]interface{}); ok {
+	if opts, ok := node.Config["options"].(map[string]any); ok {
 		for digit := range opts {
 			validDigits[digit] = true
 		}
@@ -404,7 +404,7 @@ func (m *Manager) executeHTTPCallback(session *CallSession, node *IVRNode, ctx *
 	responseStoreAs, _ := node.Config["response_store_as"].(string)
 
 	// Build headers map
-	headersRaw, _ := node.Config["headers"].(map[string]interface{})
+	headersRaw, _ := node.Config["headers"].(map[string]any)
 	headers := make(map[string]string, len(headersRaw))
 	for k, v := range headersRaw {
 		if s, ok := v.(string); ok {
@@ -541,9 +541,9 @@ func (m *Manager) executeTiming(session *CallSession, node *IVRNode) string {
 	now := time.Now()
 	dayName := strings.ToLower(now.Weekday().String())
 
-	scheduleRaw, _ := node.Config["schedule"].([]interface{})
+	scheduleRaw, _ := node.Config["schedule"].([]any)
 	for _, item := range scheduleRaw {
-		entry, ok := item.(map[string]interface{})
+		entry, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -672,7 +672,7 @@ func (m *Manager) saveIVRPath(session *CallSession, path []map[string]string) {
 }
 
 // getConfigInt extracts an int from a config map with a default fallback.
-func getConfigInt(config map[string]interface{}, key string, defaultVal int) int {
+func getConfigInt(config map[string]any, key string, defaultVal int) int {
 	v, ok := config[key]
 	if !ok {
 		return defaultVal

--- a/internal/calling/session.go
+++ b/internal/calling/session.go
@@ -117,7 +117,7 @@ type IVRNode struct {
 	Type     IVRNodeType            `json:"type"`
 	Label    string                 `json:"label"`
 	Position IVRNodePosition        `json:"position"`
-	Config   map[string]interface{} `json:"config"`
+	Config   map[string]any `json:"config"`
 }
 
 // IVREdge connects two nodes in the flow graph.

--- a/internal/calling/transfer.go
+++ b/internal/calling/transfer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 	"time"
 
@@ -708,11 +709,7 @@ func (m *Manager) runTransferRotation(session *CallSession, transfer models.Call
 		basePayload["initiating_agent_id"] = transfer.InitiatingAgentID.String()
 	}
 
-	for {
-		// Check if total timeout exceeded or transfer already claimed
-		if totalCtx.Err() != nil {
-			break
-		}
+	for totalCtx.Err() == nil {
 		session.mu.Lock()
 		status := session.TransferStatus
 		session.mu.Unlock()
@@ -750,9 +747,7 @@ func (m *Manager) runTransferRotation(session *CallSession, transfer models.Call
 
 		// Notify this specific agent
 		agentPayload := make(map[string]any)
-		for k, v := range basePayload {
-			agentPayload[k] = v
-		}
+		maps.Copy(agentPayload, basePayload)
 		agentPayload["assigned_to_you"] = true
 		agentPayload["agent_id"] = agentID.String()
 		m.wsHub.BroadcastToUser(orgID, *agentID, websocket.WSMessage{
@@ -835,9 +830,7 @@ func (m *Manager) runTransferRotation(session *CallSession, transfer models.Call
 		Update("agent_id", nil)
 
 	fallbackPayload := make(map[string]any)
-	for k, v := range basePayload {
-		fallbackPayload[k] = v
-	}
+	maps.Copy(fallbackPayload, basePayload)
 	fallbackPayload["broadcast_fallback"] = true
 	m.wsHub.BroadcastToUsers(orgID, remaining, websocket.WSMessage{
 		Type:    websocket.TypeCallTransferWaiting,
@@ -1023,7 +1016,7 @@ func (m *Manager) findSessionByTransferID(transferID uuid.UUID) *CallSession {
 }
 
 // parseTransferCallbacks extracts HTTP callback configs from a transfer IVR node's config map.
-func parseTransferCallbacks(config map[string]interface{}) *TransferCallbacks {
+func parseTransferCallbacks(config map[string]any) *TransferCallbacks {
 	cb := &TransferCallbacks{}
 	cb.OnWaiting = parseOneCallback(config, "on_waiting")
 	cb.OnConnect = parseOneCallback(config, "on_connect")
@@ -1033,8 +1026,8 @@ func parseTransferCallbacks(config map[string]interface{}) *TransferCallbacks {
 	return cb
 }
 
-func parseOneCallback(config map[string]interface{}, key string) *TransferHTTPCallback {
-	raw, ok := config[key].(map[string]interface{})
+func parseOneCallback(config map[string]any, key string) *TransferHTTPCallback {
+	raw, ok := config[key].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1046,7 +1039,7 @@ func parseOneCallback(config map[string]interface{}, key string) *TransferHTTPCa
 	bodyTemplate, _ := raw["body_template"].(string)
 
 	headers := make(map[string]string)
-	if hdrs, ok := raw["headers"].(map[string]interface{}); ok {
+	if hdrs, ok := raw["headers"].(map[string]any); ok {
 		for k, v := range hdrs {
 			if s, ok := v.(string); ok {
 				headers[k] = s

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -49,7 +49,7 @@ func NewPostgres(cfg *config.DatabaseConfig, debug bool) (*gorm.DB, error) {
 // MigrationModel holds model info for migration progress
 type MigrationModel struct {
 	Name  string
-	Model interface{}
+	Model any
 }
 
 // GetMigrationModels returns all models to migrate with their names
@@ -703,7 +703,7 @@ func SeedDefaultWidgetsForOrg(db *gorm.DB, orgID, userID uuid.UUID) error {
 		{"Chatbot Sessions", "Active chatbot conversation sessions", "sessions", "number", "purple", nil, 3, 6, 0, 3, 3},
 		{"Total Campaigns", "Number of bulk message campaigns", "campaigns", "number", "orange", nil, 4, 9, 0, 3, 3},
 		{"Recent Messages", "Latest conversations from your contacts", "messages", "table", "", nil, 5, 0, 3, 6, 8},
-		{"Quick Actions", "Common tasks and shortcuts", "shortcuts", "shortcuts", "", models.JSONB{"shortcuts": []interface{}{"chat", "campaigns", "templates", "chatbot"}}, 6, 6, 3, 6, 8},
+		{"Quick Actions", "Common tasks and shortcuts", "shortcuts", "shortcuts", "", models.JSONB{"shortcuts": []any{"chat", "campaigns", "templates", "chatbot"}}, 6, 6, 3, 6, 8},
 	}
 
 	for _, wd := range defaultWidgetsData {

--- a/internal/database/redis_test.go
+++ b/internal/database/redis_test.go
@@ -69,7 +69,7 @@ func TestNewRedis_ConnectsWithDefaultOptions(t *testing.T) {
 	client, err := database.NewRedis(cfg)
 	require.NoError(t, err, "NewRedis should connect successfully")
 	require.NotNil(t, client)
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 }
 
 func TestNewRedis_EmptyUsernameUsesDefaultUser(t *testing.T) {
@@ -79,7 +79,7 @@ func TestNewRedis_EmptyUsernameUsesDefaultUser(t *testing.T) {
 	client, err := database.NewRedis(cfg)
 	require.NoError(t, err, "empty username should connect using the default ACL user")
 	require.NotNil(t, client)
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 }
 
 func TestNewRedis_TLSFalseDoesNotSetTLSConfig(t *testing.T) {
@@ -89,7 +89,7 @@ func TestNewRedis_TLSFalseDoesNotSetTLSConfig(t *testing.T) {
 	client, err := database.NewRedis(cfg)
 	require.NoError(t, err)
 	require.NotNil(t, client)
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 
 	// Connection must still be usable (PING succeeds)
 	ctx := t.Context()

--- a/internal/handlers/accounts.go
+++ b/internal/handlers/accounts.go
@@ -76,7 +76,7 @@ func (a *App) ListAccounts(r *fastglue.Request) error {
 		response[i] = accountToResponse(acc)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"accounts": response,
 	})
 }
@@ -345,7 +345,7 @@ func (a *App) TestAccountConnection(r *fastglue.Request) error {
 	// Use the comprehensive validation function
 	if err := a.validateAccountCredentials(account.PhoneID, account.BusinessID, account.AccessToken, account.APIVersion); err != nil {
 		a.Log.Error("Account test failed", "error", err, "account", account.Name)
-		return r.SendEnvelope(map[string]interface{}{
+		return r.SendEnvelope(map[string]any{
 			"success": false,
 			"error":   fmt.Sprintf("Account credential validation failed: %s", err.Error()),
 		})
@@ -365,7 +365,7 @@ func (a *App) TestAccountConnection(r *fastglue.Request) error {
 	resp, err := a.HTTPClient.Do(req)
 	if err != nil {
 		a.Log.Error("Failed to connect to WhatsApp API", "error", err)
-		return r.SendEnvelope(map[string]interface{}{
+		return r.SendEnvelope(map[string]any{
 			"success": false,
 			"error":   "Failed to connect to WhatsApp API",
 		})
@@ -375,16 +375,16 @@ func (a *App) TestAccountConnection(r *fastglue.Request) error {
 	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 200 {
-		var errorResp map[string]interface{}
+		var errorResp map[string]any
 		_ = json.Unmarshal(body, &errorResp)
-		return r.SendEnvelope(map[string]interface{}{
+		return r.SendEnvelope(map[string]any{
 			"success": false,
 			"error":   "API error",
 			"details": errorResp,
 		})
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	_ = json.Unmarshal(body, &result)
 
 	// Check if this is a test/sandbox number
@@ -392,7 +392,7 @@ func (a *App) TestAccountConnection(r *fastglue.Request) error {
 	isTestNumber := accountMode == "SANDBOX"
 
 	// Prepare response
-	response := map[string]interface{}{
+	response := map[string]any{
 		"success":                  true,
 		"display_phone_number":     result["display_phone_number"],
 		"verified_name":            result["verified_name"],
@@ -483,14 +483,14 @@ func (a *App) SubscribeApp(r *fastglue.Request) error {
 	ctx := context.Background()
 	if err := a.WhatsApp.SubscribeApp(ctx, a.toWhatsAppAccount(account)); err != nil {
 		a.Log.Error("Failed to subscribe app to webhooks", "error", err, "account", account.Name)
-		return r.SendEnvelope(map[string]interface{}{
+		return r.SendEnvelope(map[string]any{
 			"success": false,
 			"error":   "Failed to subscribe app to webhooks. Check your credentials.",
 		})
 	}
 
 	a.Log.Info("App subscribed to webhooks successfully", "account", account.Name, "business_id", account.BusinessID)
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"success": true,
 		"message": "App subscribed to webhooks successfully. You should now receive incoming messages.",
 	})

--- a/internal/handlers/analytics.go
+++ b/internal/handlers/analytics.go
@@ -154,7 +154,7 @@ func (a *App) GetDashboardStats(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"stats":           stats,
 		"recent_messages": recentMessages,
 	})

--- a/internal/handlers/app.go
+++ b/internal/handlers/app.go
@@ -157,7 +157,7 @@ func (a *App) StartCampaignStatsSubscriber() error {
 		// Broadcast to organization via WebSocket
 		a.WSHub.BroadcastToOrg(update.OrganizationID, websocket.WSMessage{
 			Type: websocket.TypeCampaignStatsUpdate,
-			Payload: map[string]interface{}{
+			Payload: map[string]any{
 				"campaign_id":     update.CampaignID,
 				"status":          update.Status,
 				"sent_count":      update.SentCount,
@@ -230,7 +230,7 @@ func (a *App) requirePermission(r *fastglue.Request, userID uuid.UUID, resource,
 
 // decodeRequest decodes a JSON request body into the provided struct.
 // Returns nil on success, otherwise sends a 400 error envelope and returns errEnvelopeSent.
-func (a *App) decodeRequest(r *fastglue.Request, v interface{}) error {
+func (a *App) decodeRequest(r *fastglue.Request, v any) error {
 	if err := r.Decode(v, "json"); err != nil {
 		_ = r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid request body", nil, "")
 		return errEnvelopeSent

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -278,7 +278,7 @@ func (a *App) RefreshToken(r *fastglue.Request) error {
 	}
 
 	// Parse and validate refresh token
-	token, err := jwt.ParseWithClaims(refreshTokenStr, &middleware.JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(refreshTokenStr, &middleware.JWTClaims{}, func(token *jwt.Token) (any, error) {
 		return []byte(a.Config.JWT.Secret), nil
 	})
 
@@ -497,7 +497,7 @@ func (a *App) Logout(r *fastglue.Request) error {
 
 	if refreshTokenStr != "" {
 		// Parse the token to extract JTI (don't need to fully validate — just extract claims)
-		token, _ := jwt.ParseWithClaims(refreshTokenStr, &middleware.JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+		token, _ := jwt.ParseWithClaims(refreshTokenStr, &middleware.JWTClaims{}, func(token *jwt.Token) (any, error) {
 			return []byte(a.Config.JWT.Secret), nil
 		})
 		if token != nil {

--- a/internal/handlers/call_webhook.go
+++ b/internal/handlers/call_webhook.go
@@ -12,7 +12,7 @@ import (
 
 // processCallWebhook handles a call webhook event for both incoming and outgoing calls.
 // It creates/updates the CallLog and delegates to the CallManager for WebRTC handling.
-func (a *App) processCallWebhook(phoneNumberID string, call interface{}) {
+func (a *App) processCallWebhook(phoneNumberID string, call any) {
 	// The webhook handler passes an anonymous struct. Convert via JSON round-trip.
 	type callEvent struct {
 		ID        string `json:"id"`

--- a/internal/handlers/campaigns.go
+++ b/internal/handlers/campaigns.go
@@ -59,7 +59,7 @@ type CampaignResponse struct {
 type RecipientRequest struct {
 	PhoneNumber    string                 `json:"phone_number" validate:"required"`
 	RecipientName  string                 `json:"recipient_name"`
-	TemplateParams map[string]interface{} `json:"template_params"`
+	TemplateParams map[string]any `json:"template_params"`
 }
 
 // ListCampaigns implements campaign listing
@@ -136,7 +136,7 @@ func (a *App) ListCampaigns(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"campaigns": response,
 		"total":     total,
 		"page":      pg.Page,
@@ -297,7 +297,7 @@ func (a *App) UpdateCampaign(r *fastglue.Request) error {
 	}
 
 	// Update fields
-	updates := map[string]interface{}{
+	updates := map[string]any{
 		"name":           req.Name,
 		"scheduled_at":   req.ScheduledAt,
 		"updated_by_id":  userID,
@@ -395,7 +395,7 @@ func (a *App) DeleteCampaign(r *fastglue.Request) error {
 
 	a.Log.Info("Campaign deleted", "campaign_id", id)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Campaign deleted successfully",
 	})
 }
@@ -443,7 +443,7 @@ func (a *App) StartCampaign(r *fastglue.Request) error {
 
 	// Update status to processing
 	now := time.Now()
-	updates := map[string]interface{}{
+	updates := map[string]any{
 		"status":     models.CampaignStatusProcessing,
 		"started_at": now,
 	}
@@ -477,7 +477,7 @@ func (a *App) StartCampaign(r *fastglue.Request) error {
 
 	a.Log.Info("Recipients enqueued for processing", "campaign_id", id, "count", len(jobs))
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Campaign started",
 		"status":  models.CampaignStatusProcessing,
 	})
@@ -511,7 +511,7 @@ func (a *App) PauseCampaign(r *fastglue.Request) error {
 
 	a.Log.Info("Campaign paused", "campaign_id", id)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Campaign paused",
 		"status":  models.CampaignStatusPaused,
 	})
@@ -545,7 +545,7 @@ func (a *App) CancelCampaign(r *fastglue.Request) error {
 
 	a.Log.Info("Campaign cancelled", "campaign_id", id)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Campaign cancelled",
 		"status":  models.CampaignStatusCancelled,
 	})
@@ -587,7 +587,7 @@ func (a *App) RetryFailed(r *fastglue.Request) error {
 	// Reset failed recipients to pending
 	if err := a.DB.Model(&models.BulkMessageRecipient{}).
 		Where("campaign_id = ? AND status = ?", id, models.MessageStatusFailed).
-		Updates(map[string]interface{}{
+		Updates(map[string]any{
 			"status":        models.MessageStatusPending,
 			"error_message": "",
 		}).Error; err != nil {
@@ -598,7 +598,7 @@ func (a *App) RetryFailed(r *fastglue.Request) error {
 	// Reset failed messages in messages table to pending
 	if err := a.DB.Model(&models.Message{}).
 		Where("metadata->>'campaign_id' = ? AND status = ?", id.String(), models.MessageStatusFailed).
-		Updates(map[string]interface{}{
+		Updates(map[string]any{
 			"status":        models.MessageStatusPending,
 			"error_message": "",
 		}).Error; err != nil {
@@ -636,7 +636,7 @@ func (a *App) RetryFailed(r *fastglue.Request) error {
 
 	a.Log.Info("Failed recipients enqueued for retry", "campaign_id", id, "count", len(jobs))
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message":     "Retrying failed messages",
 		"retry_count": len(failedRecipients),
 		"status":      models.CampaignStatusProcessing,
@@ -708,7 +708,7 @@ func (a *App) ImportRecipients(r *fastglue.Request) error {
 			"new_value": fmt.Sprintf("%d recipients added", len(req.Recipients)),
 		})
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message":          "Recipients added successfully",
 		"added_count":      len(req.Recipients),
 		"total_recipients": totalCount,
@@ -746,7 +746,7 @@ func (a *App) GetCampaignRecipients(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"recipients": recipients,
 		"total":      len(recipients),
 	})
@@ -805,7 +805,7 @@ func (a *App) DeleteCampaignRecipient(r *fastglue.Request) error {
 			"new_value": nil,
 		})
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Recipient deleted successfully",
 	})
 }
@@ -910,7 +910,7 @@ func (a *App) UploadCampaignMedia(r *fastglue.Request) error {
 	}
 
 	// Update campaign with media ID, filename, mime type, and local path
-	updates := map[string]interface{}{
+	updates := map[string]any{
 		"header_media_id":         mediaID,
 		"header_media_filename":   sanitizeFilename(fileHeader.Filename),
 		"header_media_mime_type":  mimeType,
@@ -923,7 +923,7 @@ func (a *App) UploadCampaignMedia(r *fastglue.Request) error {
 
 	a.Log.Info("Campaign media uploaded", "campaign_id", campaignUUID, "media_id", mediaID, "filename", fileHeader.Filename, "local_path", localPath)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"media_id":   mediaID,
 		"filename":   fileHeader.Filename,
 		"mime_type":  mimeType,
@@ -1093,7 +1093,7 @@ func (a *App) incrementCampaignStat(campaignID string, status string) {
 	if a.WSHub != nil && result.RowsAffected > 0 {
 		a.WSHub.BroadcastToOrg(campaign.OrganizationID, websocket.WSMessage{
 			Type: websocket.TypeCampaignStatsUpdate,
-			Payload: map[string]interface{}{
+			Payload: map[string]any{
 				"campaign_id":     campaignID,
 				"status":          campaign.Status,
 				"sent_count":      campaign.SentCount,
@@ -1127,7 +1127,7 @@ func (a *App) recalculateCampaignStats(campaignID uuid.UUID) {
 	}
 
 	if err := a.DB.Model(&models.BulkMessageCampaign{}).Where("id = ?", campaignID).
-		Updates(map[string]interface{}{
+		Updates(map[string]any{
 			"sent_count":      stats.Sent,
 			"delivered_count": stats.Delivered,
 			"read_count":      stats.Read,

--- a/internal/handlers/catalog.go
+++ b/internal/handlers/catalog.go
@@ -89,7 +89,7 @@ func (a *App) ListCatalogs(r *fastglue.Request) error {
 		result[i] = catalogToResponse(c, int(productCount))
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"catalogs": result,
 	})
 }
@@ -273,7 +273,7 @@ func (a *App) SyncCatalogs(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Catalogs synced",
 		"synced":  synced,
 		"total":   len(metaCatalogs),
@@ -310,7 +310,7 @@ func (a *App) ListCatalogProducts(r *fastglue.Request) error {
 		result[i] = productToResponse(p)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"products": result,
 	})
 }

--- a/internal/handlers/chatbot.go
+++ b/internal/handlers/chatbot.go
@@ -18,12 +18,12 @@ import (
 type ChatbotSettingsResponse struct {
 	Enabled               bool                     `json:"enabled"`
 	GreetingMessage       string                   `json:"greeting_message"`
-	GreetingButtons       []map[string]interface{} `json:"greeting_buttons"`
+	GreetingButtons       []map[string]any `json:"greeting_buttons"`
 	FallbackMessage       string                   `json:"fallback_message"`
-	FallbackButtons       []map[string]interface{} `json:"fallback_buttons"`
+	FallbackButtons       []map[string]any `json:"fallback_buttons"`
 	SessionTimeoutMinutes int                      `json:"session_timeout_minutes"`
 	BusinessHoursEnabled       bool                     `json:"business_hours_enabled"`
-	BusinessHours              []map[string]interface{} `json:"business_hours"`
+	BusinessHours              []map[string]any `json:"business_hours"`
 	OutOfHoursMessage          string                   `json:"out_of_hours_message"`
 	AllowAutomatedOutsideHours bool                     `json:"allow_automated_outside_hours"`
 	AllowAgentQueuePickup        bool                     `json:"allow_agent_queue_pickup"`
@@ -130,29 +130,29 @@ func (a *App) GetChatbotSettings(r *fastglue.Request) error {
 	stats := a.getChatbotStats(orgID)
 
 	// Convert button arrays
-	greetingButtons := make([]map[string]interface{}, 0)
+	greetingButtons := make([]map[string]any, 0)
 	if settings.GreetingButtons != nil {
 		for _, btn := range settings.GreetingButtons {
-			if btnMap, ok := btn.(map[string]interface{}); ok {
+			if btnMap, ok := btn.(map[string]any); ok {
 				greetingButtons = append(greetingButtons, btnMap)
 			}
 		}
 	}
 
-	fallbackButtons := make([]map[string]interface{}, 0)
+	fallbackButtons := make([]map[string]any, 0)
 	if settings.FallbackButtons != nil {
 		for _, btn := range settings.FallbackButtons {
-			if btnMap, ok := btn.(map[string]interface{}); ok {
+			if btnMap, ok := btn.(map[string]any); ok {
 				fallbackButtons = append(fallbackButtons, btnMap)
 			}
 		}
 	}
 
 	// Convert business hours array
-	businessHours := make([]map[string]interface{}, 0)
+	businessHours := make([]map[string]any, 0)
 	if settings.BusinessHours.Hours != nil {
 		for _, bh := range settings.BusinessHours.Hours {
-			if bhMap, ok := bh.(map[string]interface{}); ok {
+			if bhMap, ok := bh.(map[string]any); ok {
 				businessHours = append(businessHours, bhMap)
 			}
 		}
@@ -197,7 +197,7 @@ func (a *App) GetChatbotSettings(r *fastglue.Request) error {
 		ClientAutoCloseMessage: settings.ClientInactivity.AutoCloseMessage,
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"settings": settingsResp,
 		"stats":    stats,
 	})
@@ -213,12 +213,12 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 	var req struct {
 		Enabled                    *bool                      `json:"enabled"`
 		GreetingMessage            *string                    `json:"greeting_message"`
-		GreetingButtons            *[]map[string]interface{}  `json:"greeting_buttons"`
+		GreetingButtons            *[]map[string]any  `json:"greeting_buttons"`
 		FallbackMessage            *string                    `json:"fallback_message"`
-		FallbackButtons            *[]map[string]interface{}  `json:"fallback_buttons"`
+		FallbackButtons            *[]map[string]any  `json:"fallback_buttons"`
 		SessionTimeoutMinutes      *int                       `json:"session_timeout_minutes"`
 		BusinessHoursEnabled       *bool                      `json:"business_hours_enabled"`
-		BusinessHours              *[]map[string]interface{}  `json:"business_hours"`
+		BusinessHours              *[]map[string]any  `json:"business_hours"`
 		OutOfHoursMessage          *string                    `json:"out_of_hours_message"`
 		AllowAutomatedOutsideHours *bool                      `json:"allow_automated_outside_hours"`
 		AllowAgentQueuePickup        *bool                      `json:"allow_agent_queue_pickup"`
@@ -272,7 +272,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 		settings.DefaultResponse = *req.GreetingMessage
 	}
 	if req.GreetingButtons != nil {
-		buttons := make([]interface{}, len(*req.GreetingButtons))
+		buttons := make([]any, len(*req.GreetingButtons))
 		for i, btn := range *req.GreetingButtons {
 			buttons[i] = btn
 		}
@@ -282,7 +282,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 		settings.FallbackMessage = *req.FallbackMessage
 	}
 	if req.FallbackButtons != nil {
-		buttons := make([]interface{}, len(*req.FallbackButtons))
+		buttons := make([]any, len(*req.FallbackButtons))
 		for i, btn := range *req.FallbackButtons {
 			buttons[i] = btn
 		}
@@ -296,7 +296,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 		settings.BusinessHours.Enabled = *req.BusinessHoursEnabled
 	}
 	if req.BusinessHours != nil {
-		hours := make([]interface{}, len(*req.BusinessHours))
+		hours := make([]any, len(*req.BusinessHours))
 		for i, bh := range *req.BusinessHours {
 			hours[i] = bh
 		}
@@ -393,7 +393,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 	// row we explicitly set any default:true bool columns that were requested
 	// as false.
 	if isNew {
-		zeroOverrides := map[string]interface{}{}
+		zeroOverrides := map[string]any{}
 		if req.AllowAutomatedOutsideHours != nil && !*req.AllowAutomatedOutsideHours {
 			zeroOverrides["allow_automated_outside_hours"] = false
 		}
@@ -415,7 +415,7 @@ func (a *App) UpdateChatbotSettings(r *fastglue.Request) error {
 	a.InvalidateChatbotSettingsCache(orgID)
 	a.InvalidateSLASettingsCache() // SLA settings are part of chatbot settings
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Settings updated successfully",
 	})
 }
@@ -493,7 +493,7 @@ func (a *App) CreateKeywordRule(r *fastglue.Request) error {
 		Keywords        []string               `json:"keywords"`
 		MatchType       models.MatchType       `json:"match_type"`
 		ResponseType    models.ResponseType    `json:"response_type"`
-		ResponseContent map[string]interface{} `json:"response_content"`
+		ResponseContent map[string]any `json:"response_content"`
 		Priority        int                    `json:"priority"`
 		Enabled         bool                   `json:"enabled"`
 	}
@@ -541,7 +541,7 @@ func (a *App) CreateKeywordRule(r *fastglue.Request) error {
 
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID), "keyword_rule", rule.ID, models.AuditActionCreated, nil, &rule)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"id":      rule.ID.String(),
 		"message": "Keyword rule created successfully",
 	})
@@ -614,7 +614,7 @@ func (a *App) UpdateKeywordRule(r *fastglue.Request) error {
 		Keywords        []string                `json:"keywords"`
 		MatchType       *models.MatchType       `json:"match_type"`
 		ResponseType    *models.ResponseType    `json:"response_type"`
-		ResponseContent map[string]interface{}  `json:"response_content"`
+		ResponseContent map[string]any  `json:"response_content"`
 		Priority        *int                    `json:"priority"`
 		Enabled         *bool                   `json:"enabled"`
 	}
@@ -657,7 +657,7 @@ func (a *App) UpdateKeywordRule(r *fastglue.Request) error {
 
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID), "keyword_rule", rule.ID, models.AuditActionUpdated, &oldRule, rule)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Keyword rule updated successfully",
 	})
 }
@@ -690,7 +690,7 @@ func (a *App) DeleteKeywordRule(r *fastglue.Request) error {
 
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID), "keyword_rule", id, models.AuditActionDeleted, &rule, nil)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Keyword rule deleted successfully",
 	})
 }
@@ -755,15 +755,15 @@ type FlowStepRequest struct {
 	Message         string                   `json:"message"`
 	MessageType     models.FlowStepType      `json:"message_type"`
 	InputType       models.InputType         `json:"input_type"`
-	InputConfig     map[string]interface{}   `json:"input_config"`
-	ApiConfig       map[string]interface{}   `json:"api_config"`
-	Buttons         []map[string]interface{} `json:"buttons"`
-	TransferConfig  map[string]interface{}   `json:"transfer_config"`
+	InputConfig     map[string]any   `json:"input_config"`
+	ApiConfig       map[string]any   `json:"api_config"`
+	Buttons         []map[string]any `json:"buttons"`
+	TransferConfig  map[string]any   `json:"transfer_config"`
 	ValidationRegex string                   `json:"validation_regex"`
 	ValidationError string                   `json:"validation_error"`
 	StoreAs         string                   `json:"store_as"`
 	NextStep        string                   `json:"next_step"`
-	ConditionalNext map[string]interface{}   `json:"conditional_next"`
+	ConditionalNext map[string]any   `json:"conditional_next"`
 	SkipCondition   string                   `json:"skip_condition"`
 	RetryOnInvalid  bool                     `json:"retry_on_invalid"`
 	MaxRetries      int                      `json:"max_retries"`
@@ -787,9 +787,9 @@ func (a *App) CreateChatbotFlow(r *fastglue.Request) error {
 		InitialMessage    string                 `json:"initial_message"`
 		CompletionMessage string                 `json:"completion_message"`
 		OnCompleteAction  string                 `json:"on_complete_action"`
-		CompletionConfig  map[string]interface{} `json:"completion_config"`
-		PanelConfig       map[string]interface{} `json:"panel_config"`
-		CanvasLayout      map[string]interface{} `json:"canvas_layout"`
+		CompletionConfig  map[string]any `json:"completion_config"`
+		PanelConfig       map[string]any `json:"panel_config"`
+		CanvasLayout      map[string]any `json:"canvas_layout"`
 		Enabled           bool                   `json:"enabled"`
 		Steps             []FlowStepRequest      `json:"steps"`
 	}
@@ -879,7 +879,7 @@ func (a *App) CreateChatbotFlow(r *fastglue.Request) error {
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
 		"chatbot_flow", flow.ID, models.AuditActionCreated, nil, &flow)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"id":      flow.ID.String(),
 		"message": "Flow created successfully",
 	})
@@ -944,9 +944,9 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 		InitialMessage    *string                `json:"initial_message"`
 		CompletionMessage *string                `json:"completion_message"`
 		OnCompleteAction  *string                `json:"on_complete_action"`
-		CompletionConfig  map[string]interface{} `json:"completion_config"`
-		PanelConfig       map[string]interface{} `json:"panel_config"`
-		CanvasLayout      map[string]interface{} `json:"canvas_layout"`
+		CompletionConfig  map[string]any `json:"completion_config"`
+		PanelConfig       map[string]any `json:"panel_config"`
+		CanvasLayout      map[string]any `json:"canvas_layout"`
 		Enabled           *bool                  `json:"enabled"`
 		Steps             []FlowStepRequest      `json:"steps"`
 	}
@@ -1138,7 +1138,7 @@ func (a *App) UpdateChatbotFlow(r *fastglue.Request) error {
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
 		"chatbot_flow", flow.ID, models.AuditActionUpdated, &oldFlow, flow, extraChanges...)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Flow updated successfully",
 	})
 }
@@ -1193,7 +1193,7 @@ func (a *App) DeleteChatbotFlow(r *fastglue.Request) error {
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
 		"chatbot_flow", id, models.AuditActionDeleted, &flowForAudit, nil)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Flow deleted successfully",
 	})
 }
@@ -1307,7 +1307,7 @@ func (a *App) CreateAIContext(r *fastglue.Request) error {
 
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID), "ai_context", ctx.ID, models.AuditActionCreated, nil, &ctx)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"id":      ctx.ID.String(),
 		"message": "AI context created successfully",
 	})
@@ -1417,7 +1417,7 @@ func (a *App) UpdateAIContext(r *fastglue.Request) error {
 
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID), "ai_context", aiCtx.ID, models.AuditActionUpdated, &oldCtx, aiCtx)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "AI context updated successfully",
 	})
 }
@@ -1450,7 +1450,7 @@ func (a *App) DeleteAIContext(r *fastglue.Request) error {
 
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID), "ai_context", id, models.AuditActionDeleted, &aiCtx, nil)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "AI context deleted successfully",
 	})
 }
@@ -1478,7 +1478,7 @@ func (a *App) ListChatbotSessions(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch sessions", nil, "")
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"sessions": sessions,
 	})
 }

--- a/internal/handlers/chatbot_processor.go
+++ b/internal/handlers/chatbot_processor.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"regexp"
 	"strings"
@@ -145,7 +146,7 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 	var mediaInfo *MediaInfo
 
 	// Track flow response data for WhatsApp Flow forms
-	var flowResponseData map[string]interface{}
+	var flowResponseData map[string]any
 
 	if msg.Type == "text" && msg.Text != nil {
 		messageText = msg.Text.Body
@@ -173,7 +174,7 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 			messageType = "nfm_reply"
 			// Parse the response JSON to extract form data
 			if msg.Interactive.NFMReply.ResponseJSON != "" {
-				var responseData map[string]interface{}
+				var responseData map[string]any
 				if err := json.Unmarshal([]byte(msg.Interactive.NFMReply.ResponseJSON), &responseData); err != nil {
 					a.Log.Error("Failed to parse flow response JSON", "error", err, "response_json", msg.Interactive.NFMReply.ResponseJSON)
 				} else {
@@ -388,9 +389,9 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 	if isNewSession && settings.DefaultResponse != "" {
 		a.Log.Info("New session - sending greeting message", "contact", contact.PhoneNumber)
 		if len(settings.GreetingButtons) > 0 {
-			greetingButtons := make([]map[string]interface{}, 0)
+			greetingButtons := make([]map[string]any, 0)
 			for _, btn := range settings.GreetingButtons {
-				if btnMap, ok := btn.(map[string]interface{}); ok {
+				if btnMap, ok := btn.(map[string]any); ok {
 					greetingButtons = append(greetingButtons, btnMap)
 				}
 			}
@@ -457,9 +458,9 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 	if settings.FallbackMessage != "" && !isNewSession {
 		a.Log.Info("Sending fallback message", "response", settings.FallbackMessage)
 		if len(settings.FallbackButtons) > 0 {
-			fallbackButtons := make([]map[string]interface{}, 0)
+			fallbackButtons := make([]map[string]any, 0)
 			for _, btn := range settings.FallbackButtons {
-				if btnMap, ok := btn.(map[string]interface{}); ok {
+				if btnMap, ok := btn.(map[string]any); ok {
 					fallbackButtons = append(fallbackButtons, btnMap)
 				}
 			}
@@ -486,7 +487,7 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 // KeywordResponse holds the response content and optional buttons
 type KeywordResponse struct {
 	Body         string
-	Buttons      []map[string]interface{}
+	Buttons      []map[string]any
 	ResponseType models.ResponseType // text, transfer
 }
 
@@ -554,10 +555,10 @@ func (a *App) matchKeywordRules(orgID uuid.UUID, accountName, messageText string
 				}
 
 				// Get buttons if present
-				if buttons, ok := rule.ResponseContent["buttons"].([]interface{}); ok && len(buttons) > 0 {
-					response.Buttons = make([]map[string]interface{}, 0, len(buttons))
+				if buttons, ok := rule.ResponseContent["buttons"].([]any); ok && len(buttons) > 0 {
+					response.Buttons = make([]map[string]any, 0, len(buttons))
 					for _, btn := range buttons {
-						if btnMap, ok := btn.(map[string]interface{}); ok {
+						if btnMap, ok := btn.(map[string]any); ok {
 							response.Buttons = append(response.Buttons, btnMap)
 						}
 					}
@@ -589,10 +590,10 @@ func (a *App) sendAndSaveTextMessage(account *models.WhatsAppAccount, contact *m
 // sendAndSaveInteractiveButtons sends an interactive button message and saves it to the database.
 // Buttons with type "url" are automatically separated and sent as CTA URL messages,
 // since WhatsApp doesn't allow mixing reply buttons and URL buttons in the same message.
-func (a *App) sendAndSaveInteractiveButtons(account *models.WhatsAppAccount, contact *models.Contact, bodyText string, buttons []map[string]interface{}) error {
+func (a *App) sendAndSaveInteractiveButtons(account *models.WhatsAppAccount, contact *models.Contact, bodyText string, buttons []map[string]any) error {
 	// Separate reply buttons from CTA buttons (url / phone)
-	replyButtons := make([]map[string]interface{}, 0, len(buttons))
-	ctaButtons := make([]map[string]interface{}, 0)
+	replyButtons := make([]map[string]any, 0, len(buttons))
+	ctaButtons := make([]map[string]any, 0)
 	for _, btn := range buttons {
 		btnType, _ := btn["type"].(string)
 		switch btnType {
@@ -602,7 +603,7 @@ func (a *App) sendAndSaveInteractiveButtons(account *models.WhatsAppAccount, con
 			// Convert phone button to CTA URL with tel: scheme
 			phoneNumber, _ := btn["phone_number"].(string)
 			if phoneNumber != "" {
-				ctaButtons = append(ctaButtons, map[string]interface{}{
+				ctaButtons = append(ctaButtons, map[string]any{
 					"title": btn["title"],
 					"url":   "tel:" + phoneNumber,
 				})
@@ -833,7 +834,7 @@ func (a *App) startFlow(account *models.WhatsAppAccount, session *models.Chatbot
 }
 
 // processFlowResponse handles user response within a flow
-func (a *App) processFlowResponse(account *models.WhatsAppAccount, session *models.ChatbotSession, contact *models.Contact, userInput string, buttonID string, flowResponseData map[string]interface{}) {
+func (a *App) processFlowResponse(account *models.WhatsAppAccount, session *models.ChatbotSession, contact *models.Contact, userInput string, buttonID string, flowResponseData map[string]any) {
 	// Load the current flow from cache
 	flow, err := a.getChatbotFlowByIDCached(account.OrganizationID, *session.CurrentFlowID)
 	if err != nil {
@@ -906,7 +907,7 @@ func (a *App) processFlowResponse(account *models.WhatsAppAccount, session *mode
 
 		// Check if buttonID or userInput matches any configured button
 		for i, btn := range currentStep.Buttons {
-			if btnMap, ok := btn.(map[string]interface{}); ok {
+			if btnMap, ok := btn.(map[string]any); ok {
 				btnID, _ := btnMap["id"].(string)
 				btnTitle, _ := btnMap["title"].(string)
 
@@ -1043,7 +1044,7 @@ func (a *App) processFlowResponse(account *models.WhatsAppAccount, session *mode
 	}
 
 	// Update session and send next step message (with skip check)
-	a.DB.Model(session).Updates(map[string]interface{}{
+	a.DB.Model(session).Updates(map[string]any{
 		"current_step": nextStep.StepName,
 		"step_retries": 0,
 	})
@@ -1072,7 +1073,7 @@ func (a *App) completeFlow(account *models.WhatsAppAccount, session *models.Chat
 
 	// Update session (keep current_flow_id for panel config reference)
 	now := time.Now()
-	a.DB.Model(session).Updates(map[string]interface{}{
+	a.DB.Model(session).Updates(map[string]any{
 		"current_step": "",
 		"status":       models.SessionStatusCompleted,
 		"completed_at": now,
@@ -1103,7 +1104,7 @@ func (a *App) sendFlowCompletionWebhook(flow *models.ChatbotFlow, session *model
 	}
 
 	// Build the payload
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"flow_id":      flow.ID.String(),
 		"flow_name":    flow.Name,
 		"session_id":   session.ID.String(),
@@ -1142,7 +1143,7 @@ func (a *App) sendFlowCompletionWebhook(flow *models.ChatbotFlow, session *model
 	req.Header.Set("User-Agent", "Whatomate-Webhook/1.0")
 
 	// Add custom headers if configured
-	if headers, ok := config["headers"].(map[string]interface{}); ok {
+	if headers, ok := config["headers"].(map[string]any); ok {
 		for key, value := range headers {
 			if strVal, ok := value.(string); ok {
 				req.Header.Set(key, processTemplate(strVal, session.SessionData))
@@ -1179,7 +1180,7 @@ func (a *App) sendFlowCompletionWebhook(flow *models.ChatbotFlow, session *model
 // exitFlow ends a flow session (transfer, cancel, or error)
 func (a *App) exitFlow(session *models.ChatbotSession) {
 	now := time.Now()
-	a.DB.Model(session).Updates(map[string]interface{}{
+	a.DB.Model(session).Updates(map[string]any{
 		"current_step": "",
 		"step_retries": 0,
 		"status":       models.SessionStatusCompleted,
@@ -1192,7 +1193,7 @@ func (a *App) exitFlow(session *models.ChatbotSession) {
 
 // closeSession ends the chatbot session and clears contact tracking
 func (a *App) closeSession(session *models.ChatbotSession) {
-	a.DB.Model(session).Updates(map[string]interface{}{
+	a.DB.Model(session).Updates(map[string]any{
 		"status":       models.SessionStatusCompleted,
 		"completed_at": time.Now(),
 	})
@@ -1343,9 +1344,7 @@ func (a *App) sendStepMessage(account *models.WhatsAppAccount, session *models.C
 
 			// Save mapped data to session for future steps
 			if apiResp.MappedData != nil {
-				for k, v := range apiResp.MappedData {
-					session.SessionData[k] = v
-				}
+				maps.Copy(session.SessionData, apiResp.MappedData)
 				a.DB.Model(session).Update("session_data", session.SessionData)
 			}
 
@@ -1366,9 +1365,9 @@ func (a *App) sendStepMessage(account *models.WhatsAppAccount, session *models.C
 		// Send interactive buttons message
 		message = processTemplate(step.Message, session.SessionData)
 		if len(step.Buttons) > 0 {
-			buttons := make([]map[string]interface{}, 0, len(step.Buttons))
+			buttons := make([]map[string]any, 0, len(step.Buttons))
 			for _, btn := range step.Buttons {
-				if btnMap, ok := btn.(map[string]interface{}); ok {
+				if btnMap, ok := btn.(map[string]any); ok {
 					buttons = append(buttons, btnMap)
 				}
 			}
@@ -1454,7 +1453,7 @@ func (a *App) sendStepMessage(account *models.WhatsAppAccount, session *models.C
 			} else {
 				// Extract first screen name from screens array
 				if len(waFlow.Screens) > 0 {
-					if screenMap, ok := waFlow.Screens[0].(map[string]interface{}); ok {
+					if screenMap, ok := waFlow.Screens[0].(map[string]any); ok {
 						if screenID, ok := screenMap["id"].(string); ok {
 							firstScreen = screenID
 							a.Log.Debug("Found first screen from flow", "first_screen", firstScreen)
@@ -1463,8 +1462,8 @@ func (a *App) sendStepMessage(account *models.WhatsAppAccount, session *models.C
 				}
 				// If screens array is empty, try to get from flow_json
 				if firstScreen == "" && waFlow.FlowJSON != nil {
-					if screens, ok := waFlow.FlowJSON["screens"].([]interface{}); ok && len(screens) > 0 {
-						if screenMap, ok := screens[0].(map[string]interface{}); ok {
+					if screens, ok := waFlow.FlowJSON["screens"].([]any); ok && len(screens) > 0 {
+						if screenMap, ok := screens[0].(map[string]any); ok {
 							if screenID, ok := screenMap["id"].(string); ok {
 								firstScreen = screenID
 								a.Log.Debug("Found first screen from flow_json", "first_screen", firstScreen)
@@ -1524,7 +1523,7 @@ func (a *App) executeConfiguredAPI(apiConfig models.JSONB, replaceVar func(strin
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	if headers, ok := apiConfig["headers"].(map[string]interface{}); ok {
+	if headers, ok := apiConfig["headers"].(map[string]any); ok {
 		for key, value := range headers {
 			if strVal, ok := value.(string); ok {
 				req.Header.Set(key, replaceVar(strVal))
@@ -1549,9 +1548,9 @@ func (a *App) executeConfiguredAPI(apiConfig models.JSONB, replaceVar func(strin
 
 type ApiResponse struct {
 	Message      string
-	Buttons      []map[string]interface{}
-	MappedData   map[string]interface{} // Data extracted via response_mapping
-	ResponseData map[string]interface{} // Full API response data
+	Buttons      []map[string]any
+	MappedData   map[string]any // Data extracted via response_mapping
+	ResponseData map[string]any // Full API response data
 }
 
 // fetchApiResponse fetches a response from an external API, supporting message + buttons
@@ -1572,7 +1571,7 @@ func (a *App) fetchApiResponse(apiConfig models.JSONB, sessionData models.JSONB,
 	}
 
 	// Parse JSON response
-	var jsonResp map[string]interface{}
+	var jsonResp map[string]any
 	if err := json.Unmarshal(respBody, &jsonResp); err != nil {
 		// If not JSON, return raw response as message
 		return &ApiResponse{Message: string(respBody)}, nil
@@ -1584,7 +1583,7 @@ func (a *App) fetchApiResponse(apiConfig models.JSONB, sessionData models.JSONB,
 
 	// Process response_mapping if configured
 	// This maps API response fields to session variables for use in templates
-	if responseMapping, ok := apiConfig["response_mapping"].(map[string]interface{}); ok {
+	if responseMapping, ok := apiConfig["response_mapping"].(map[string]any); ok {
 		mappingStrings := make(map[string]string)
 		for varName, path := range responseMapping {
 			if pathStr, ok := path.(string); ok {
@@ -1594,9 +1593,7 @@ func (a *App) fetchApiResponse(apiConfig models.JSONB, sessionData models.JSONB,
 		result.MappedData = extractResponseMapping(jsonResp, mappingStrings)
 
 		// Merge mapped data into sessionData for template processing
-		for k, v := range result.MappedData {
-			sessionData[k] = v
-		}
+		maps.Copy(sessionData, result.MappedData)
 	}
 
 	// Process the message template with all available data (including mapped data)
@@ -1611,12 +1608,12 @@ func (a *App) fetchApiResponse(apiConfig models.JSONB, sessionData models.JSONB,
 	}
 
 	// Extract buttons if present - format: [{"id": "test", "value": "Test"}, ...]
-	if buttons, ok := jsonResp["buttons"].([]interface{}); ok && len(buttons) > 0 {
-		result.Buttons = make([]map[string]interface{}, 0, len(buttons))
+	if buttons, ok := jsonResp["buttons"].([]any); ok && len(buttons) > 0 {
+		result.Buttons = make([]map[string]any, 0, len(buttons))
 		for _, btn := range buttons {
-			if btnMap, ok := btn.(map[string]interface{}); ok {
+			if btnMap, ok := btn.(map[string]any); ok {
 				// Normalize button format: ensure we have "id" and "title"
-				normalizedBtn := make(map[string]interface{})
+				normalizedBtn := make(map[string]any)
 
 				// Handle "id" field
 				if id, ok := btnMap["id"].(string); ok {
@@ -1739,7 +1736,7 @@ func (a *App) fetchAPIContext(apiConfig models.JSONB, session *models.ChatbotSes
 
 	// Check for response_path to extract specific field
 	if responsePath, ok := apiConfig["response_path"].(string); ok && responsePath != "" {
-		var jsonResp map[string]interface{}
+		var jsonResp map[string]any
 		if err := json.Unmarshal(respBody, &jsonResp); err == nil {
 			if value := getNestedValue(jsonResp, responsePath); value != nil {
 				return formatValue(value), nil
@@ -1796,7 +1793,7 @@ func (a *App) generateOpenAIResponse(settings *models.ChatbotSettings, session *
 		"content": userMessage,
 	})
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"model":      settings.AI.Model,
 		"messages":   messages,
 		"max_tokens": settings.AI.MaxTokens,
@@ -1883,7 +1880,7 @@ func (a *App) generateAnthropicResponse(settings *models.ChatbotSettings, sessio
 		"content": userMessage,
 	})
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"model":      settings.AI.Model,
 		"messages":   messages,
 		"max_tokens": settings.AI.MaxTokens,
@@ -1965,7 +1962,7 @@ func (a *App) generateGoogleResponse(settings *models.ChatbotSettings, session *
 		settings.AI.Model, settings.AI.APIKey)
 
 	// Build contents array
-	contents := []map[string]interface{}{}
+	contents := []map[string]any{}
 
 	// Add conversation history if enabled
 	if settings.AI.IncludeHistory && session != nil {
@@ -1975,7 +1972,7 @@ func (a *App) generateGoogleResponse(settings *models.ChatbotSettings, session *
 			if msg.Direction == models.DirectionOutgoing {
 				role = "model"
 			}
-			contents = append(contents, map[string]interface{}{
+			contents = append(contents, map[string]any{
 				"role": role,
 				"parts": []map[string]string{
 					{"text": msg.Message},
@@ -1985,16 +1982,16 @@ func (a *App) generateGoogleResponse(settings *models.ChatbotSettings, session *
 	}
 
 	// Add current user message
-	contents = append(contents, map[string]interface{}{
+	contents = append(contents, map[string]any{
 		"role": "user",
 		"parts": []map[string]string{
 			{"text": userMessage},
 		},
 	})
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"contents": contents,
-		"generationConfig": map[string]interface{}{
+		"generationConfig": map[string]any{
 			"maxOutputTokens": settings.AI.MaxTokens,
 		},
 	}
@@ -2011,7 +2008,7 @@ func (a *App) generateGoogleResponse(settings *models.ChatbotSettings, session *
 
 	// Add system instruction if configured
 	if systemPrompt != "" {
-		payload["systemInstruction"] = map[string]interface{}{
+		payload["systemInstruction"] = map[string]any{
 			"parts": []map[string]string{
 				{"text": systemPrompt},
 			},
@@ -2019,7 +2016,7 @@ func (a *App) generateGoogleResponse(settings *models.ChatbotSettings, session *
 	}
 
 	if settings.AI.Temperature > 0 {
-		payload["generationConfig"].(map[string]interface{})["temperature"] = settings.AI.Temperature
+		payload["generationConfig"].(map[string]any)["temperature"] = settings.AI.Temperature
 	}
 
 	jsonPayload, err := json.Marshal(payload)
@@ -2133,19 +2130,19 @@ func (a *App) handleIncomingReaction(account *models.WhatsAppAccount, fromPhone,
 	contact, _, _ := contactutil.GetOrCreateContact(a.DB, account.OrganizationID, fromPhone, profileName)
 
 	// Parse existing reactions from Metadata
-	var metadata map[string]interface{}
+	var metadata map[string]any
 	if message.Metadata != nil {
 		metadata = message.Metadata
 	} else {
-		metadata = make(map[string]interface{})
+		metadata = make(map[string]any)
 	}
 
 	// Get or initialize reactions array
 	var reactions []Reaction
 	if reactionsRaw, ok := metadata["reactions"]; ok {
-		if reactionsArray, ok := reactionsRaw.([]interface{}); ok {
+		if reactionsArray, ok := reactionsRaw.([]any); ok {
 			for _, r := range reactionsArray {
-				if rMap, ok := r.(map[string]interface{}); ok {
+				if rMap, ok := r.(map[string]any); ok {
 					emoji, _ := rMap["emoji"].(string)
 					reactions = append(reactions, Reaction{
 						Emoji:     emoji,
@@ -2189,7 +2186,7 @@ func (a *App) handleIncomingReaction(account *models.WhatsAppAccount, fromPhone,
 }
 
 // Helper function to safely get string from map
-func getStringFromMap(m map[string]interface{}, key string) string {
+func getStringFromMap(m map[string]any, key string) string {
 	if v, ok := m[key]; ok {
 		if s, ok := v.(string); ok {
 			return s
@@ -2253,7 +2250,7 @@ func (a *App) saveIncomingMessage(account *models.WhatsAppAccount, contact *mode
 		preview = "[" + msgType + "]"
 	}
 
-	a.DB.Model(contact).Updates(map[string]interface{}{
+	a.DB.Model(contact).Updates(map[string]any{
 		"last_message_at":      now,
 		"last_message_preview": preview,
 		"is_read":              false,
@@ -2286,7 +2283,7 @@ func (a *App) isWithinBusinessHours(businessHours models.JSONBArray) bool {
 	currentTime := now.Format("15:04")
 
 	for _, bh := range businessHours {
-		bhMap, ok := bh.(map[string]interface{})
+		bhMap, ok := bh.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2329,7 +2326,7 @@ func (a *App) isWithinBusinessHours(businessHours models.JSONBArray) bool {
 }
 
 // shouldSkipStep evaluates a text expression like "(status == 'vip' OR amount > 100) AND name != ”"
-func (a *App) shouldSkipStep(step *models.ChatbotFlowStep, sessionData map[string]interface{}) bool {
+func (a *App) shouldSkipStep(step *models.ChatbotFlowStep, sessionData map[string]any) bool {
 	if step.SkipCondition == "" {
 		a.Log.Debug("No skip condition for step", "step", step.StepName)
 		return false
@@ -2341,7 +2338,7 @@ func (a *App) shouldSkipStep(step *models.ChatbotFlowStep, sessionData map[strin
 }
 
 // evaluateExpression handles parentheses, AND, OR, and single conditions
-func evaluateExpression(expr string, data map[string]interface{}) bool {
+func evaluateExpression(expr string, data map[string]any) bool {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		return false
@@ -2420,7 +2417,7 @@ func splitByLogicOperator(expr, op string) []string {
 }
 
 // evaluateSingleCondition handles: phone != ” or age > 18 or status == 'confirmed'
-func evaluateSingleCondition(expr string, data map[string]interface{}) bool {
+func evaluateSingleCondition(expr string, data map[string]any) bool {
 	expr = strings.TrimSpace(expr)
 
 	// Handle boolean literals

--- a/internal/handlers/contacts.go
+++ b/internal/handlers/contacts.go
@@ -441,9 +441,9 @@ func (a *App) buildMessagesResponse(messages []models.Message) []MessageResponse
 
 		if m.Metadata != nil {
 			if reactionsRaw, ok := m.Metadata["reactions"]; ok {
-				if reactionsArray, ok := reactionsRaw.([]interface{}); ok {
+				if reactionsArray, ok := reactionsRaw.([]any); ok {
 					for _, r := range reactionsArray {
-						if rMap, ok := r.(map[string]interface{}); ok {
+						if rMap, ok := r.(map[string]any); ok {
 							emoji, _ := rMap["emoji"].(string)
 							fromPhone, _ := rMap["from_phone"].(string)
 							fromUser, _ := rMap["from_user"].(string)
@@ -928,11 +928,11 @@ func (a *App) SendReaction(r *fastglue.Request) error {
 	}
 
 	// Parse existing reactions from Metadata
-	var metadata map[string]interface{}
+	var metadata map[string]any
 	if message.Metadata != nil {
 		metadata = message.Metadata
 	} else {
-		metadata = make(map[string]interface{})
+		metadata = make(map[string]any)
 	}
 
 	// Get or initialize reactions array
@@ -943,9 +943,9 @@ func (a *App) SendReaction(r *fastglue.Request) error {
 	}
 	var reactions []Reaction
 	if reactionsRaw, ok := metadata["reactions"]; ok {
-		if reactionsArray, ok := reactionsRaw.([]interface{}); ok {
+		if reactionsArray, ok := reactionsRaw.([]any); ok {
 			for _, r := range reactionsArray {
-				if rMap, ok := r.(map[string]interface{}); ok {
+				if rMap, ok := r.(map[string]any); ok {
 					emoji, _ := rMap["emoji"].(string)
 					fromPhone, _ := rMap["from_phone"].(string)
 					fromUser, _ := rMap["from_user"].(string)

--- a/internal/handlers/custom_actions.go
+++ b/internal/handlers/custom_actions.go
@@ -26,7 +26,7 @@ type CustomActionRequest struct {
 	Name         string                 `json:"name"`
 	Icon         string                 `json:"icon"`
 	ActionType   models.ActionType      `json:"action_type"` // webhook, url, javascript
-	Config       map[string]interface{} `json:"config"`
+	Config       map[string]any `json:"config"`
 	IsActive     bool                   `json:"is_active"`
 	DisplayOrder int                    `json:"display_order"`
 }
@@ -37,7 +37,7 @@ type CustomActionResponse struct {
 	Name         string                 `json:"name"`
 	Icon         string                 `json:"icon"`
 	ActionType   models.ActionType      `json:"action_type"`
-	Config       map[string]interface{} `json:"config"`
+	Config       map[string]any `json:"config"`
 	IsActive     bool                   `json:"is_active"`
 	DisplayOrder int                    `json:"display_order"`
 	CreatedAt    string                 `json:"created_at"`
@@ -56,7 +56,7 @@ type ActionResult struct {
 	RedirectURL string                 `json:"redirect_url,omitempty"`
 	Clipboard   string                 `json:"clipboard,omitempty"`
 	Toast       *ToastConfig           `json:"toast,omitempty"`
-	Data        map[string]interface{} `json:"data,omitempty"`
+	Data        map[string]any `json:"data,omitempty"`
 }
 
 // ToastConfig represents a toast notification configuration
@@ -207,7 +207,7 @@ func (a *App) UpdateCustomAction(r *fastglue.Request) error {
 	}
 
 	// Build updates
-	updates := map[string]interface{}{}
+	updates := map[string]any{}
 	if req.Name != "" {
 		updates["name"] = req.Name
 	}
@@ -377,7 +377,7 @@ func (a *App) CustomActionRedirect(r *fastglue.Request) error {
 }
 
 // executeWebhookAction executes a webhook action
-func (a *App) executeWebhookAction(action models.CustomAction, context map[string]interface{}) (*ActionResult, error) {
+func (a *App) executeWebhookAction(action models.CustomAction, context map[string]any) (*ActionResult, error) {
 	// Parse config from JSONB (already a map)
 	configBytes, err := json.Marshal(action.Config)
 	if err != nil {
@@ -437,7 +437,7 @@ func (a *App) executeWebhookAction(action models.CustomAction, context map[strin
 	respBody, _ := io.ReadAll(resp.Body)
 
 	// Parse response
-	var responseData map[string]interface{}
+	var responseData map[string]any
 	_ = json.Unmarshal(respBody, &responseData) // Ignore parse errors for optional response data
 
 	success := resp.StatusCode >= 200 && resp.StatusCode < 300
@@ -455,7 +455,7 @@ func (a *App) executeWebhookAction(action models.CustomAction, context map[strin
 }
 
 // executeURLAction executes a URL action by creating a redirect token
-func (a *App) executeURLAction(action models.CustomAction, context map[string]interface{}) (*ActionResult, error) {
+func (a *App) executeURLAction(action models.CustomAction, context map[string]any) (*ActionResult, error) {
 	// Parse config from JSONB (already a map)
 	configBytes, err := json.Marshal(action.Config)
 	if err != nil {
@@ -497,7 +497,7 @@ func (a *App) executeURLAction(action models.CustomAction, context map[string]in
 
 // executeJavaScriptAction executes a JavaScript action server-side using goja.
 // The code runs in a sandboxed VM with no access to filesystem, network, or globals.
-func (a *App) executeJavaScriptAction(action models.CustomAction, context map[string]interface{}) (*ActionResult, error) {
+func (a *App) executeJavaScriptAction(action models.CustomAction, context map[string]any) (*ActionResult, error) {
 	configBytes, err := json.Marshal(action.Config)
 	if err != nil {
 		return nil, err
@@ -546,8 +546,8 @@ func (a *App) executeJavaScriptAction(action models.CustomAction, context map[st
 	// Extract structured result from the JS return value
 	if val != nil && !goja.IsUndefined(val) && !goja.IsNull(val) {
 		exported := val.Export()
-		if jsResult, ok := exported.(map[string]interface{}); ok {
-			if t, ok := jsResult["toast"].(map[string]interface{}); ok {
+		if jsResult, ok := exported.(map[string]any); ok {
+			if t, ok := jsResult["toast"].(map[string]any); ok {
 				result.Toast = &ToastConfig{
 					Message: fmt.Sprintf("%v", t["message"]),
 					Type:    fmt.Sprintf("%v", t["type"]),
@@ -569,9 +569,9 @@ func (a *App) executeJavaScriptAction(action models.CustomAction, context map[st
 }
 
 // buildActionContext builds the context object for variable replacement
-func buildActionContext(contact models.Contact, user models.User, org models.Organization) map[string]interface{} {
-	return map[string]interface{}{
-		"contact": map[string]interface{}{
+func buildActionContext(contact models.Contact, user models.User, org models.Organization) map[string]any {
+	return map[string]any{
+		"contact": map[string]any{
 			"id":           contact.ID.String(),
 			"phone_number": contact.PhoneNumber,
 			"name":         contact.ProfileName,
@@ -579,13 +579,13 @@ func buildActionContext(contact models.Contact, user models.User, org models.Org
 			"tags":         contact.Tags,
 			"metadata":     contact.Metadata,
 		},
-		"user": map[string]interface{}{
+		"user": map[string]any{
 			"id":    user.ID.String(),
 			"name":  user.FullName,
 			"email": user.Email,
 			"role":  user.Role,
 		},
-		"organization": map[string]interface{}{
+		"organization": map[string]any{
 			"id":   org.ID.String(),
 			"name": org.Name,
 		},
@@ -593,7 +593,7 @@ func buildActionContext(contact models.Contact, user models.User, org models.Org
 }
 
 // replaceVariables replaces {{variable}} placeholders with context values
-func replaceVariables(template string, context map[string]interface{}) string {
+func replaceVariables(template string, context map[string]any) string {
 	re := regexp.MustCompile(`\{\{([^}]+)\}\}`)
 	return re.ReplaceAllStringFunc(template, func(match string) string {
 		// Extract variable path (e.g., "contact.phone_number")
@@ -601,10 +601,10 @@ func replaceVariables(template string, context map[string]interface{}) string {
 		path = strings.TrimSpace(path)
 
 		parts := strings.Split(path, ".")
-		var value interface{} = context
+		var value any = context
 
 		for _, part := range parts {
-			if m, ok := value.(map[string]interface{}); ok {
+			if m, ok := value.(map[string]any); ok {
 				value = m[part]
 			} else {
 				return match // Return original if path not found
@@ -628,7 +628,7 @@ func replaceVariables(template string, context map[string]interface{}) string {
 }
 
 // validateActionConfig validates the config based on action type
-func validateActionConfig(actionType models.ActionType, config map[string]interface{}) error {
+func validateActionConfig(actionType models.ActionType, config map[string]any) error {
 	switch actionType {
 	case models.ActionTypeWebhook:
 		urlVal, ok := config["url"]
@@ -654,8 +654,8 @@ func validateActionConfig(actionType models.ActionType, config map[string]interf
 
 // customActionToResponse converts a CustomAction model to response
 func customActionToResponse(action models.CustomAction) CustomActionResponse {
-	// Config is already a map[string]interface{}, just use it directly
-	config := map[string]interface{}(action.Config)
+	// Config is already a map[string]any, just use it directly
+	config := map[string]any(action.Config)
 
 	return CustomActionResponse{
 		ID:           action.ID,

--- a/internal/handlers/flows.go
+++ b/internal/handlers/flows.go
@@ -18,8 +18,8 @@ type FlowRequest struct {
 	Name            string                 `json:"name" validate:"required"`
 	Category        string                 `json:"category"`
 	JSONVersion     string                 `json:"json_version"`
-	FlowJSON        map[string]interface{} `json:"flow_json"`
-	Screens         []interface{}          `json:"screens"`
+	FlowJSON        map[string]any `json:"flow_json"`
+	Screens         []any          `json:"screens"`
 }
 
 // FlowResponse represents the response for a flow
@@ -31,8 +31,8 @@ type FlowResponse struct {
 	Status          string                 `json:"status"`
 	Category        string                 `json:"category"`
 	JSONVersion     string                 `json:"json_version"`
-	FlowJSON        map[string]interface{} `json:"flow_json"`
-	Screens         []interface{}          `json:"screens"`
+	FlowJSON        map[string]any `json:"flow_json"`
+	Screens         []any          `json:"screens"`
 	PreviewURL      string                 `json:"preview_url"`
 	HasLocalChanges bool                   `json:"has_local_changes"`
 	CreatedAt       string                 `json:"created_at"`
@@ -139,7 +139,7 @@ func (a *App) CreateFlow(r *fastglue.Request) error {
 
 	a.Log.Info("Flow created", "flow_id", flow.ID, "name", flow.Name)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"flow": flowToResponse(flow),
 	})
 }
@@ -161,7 +161,7 @@ func (a *App) GetFlow(r *fastglue.Request) error {
 		return nil
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"flow": flowToResponse(*flow),
 	})
 }
@@ -189,7 +189,7 @@ func (a *App) UpdateFlow(r *fastglue.Request) error {
 	}
 
 	// Update fields
-	updates := map[string]interface{}{}
+	updates := map[string]any{}
 	if req.Name != "" {
 		updates["name"] = req.Name
 	}
@@ -220,7 +220,7 @@ func (a *App) UpdateFlow(r *fastglue.Request) error {
 
 	a.Log.Info("Flow updated", "flow_id", flow.ID)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"flow": flowToResponse(*flow),
 	})
 }
@@ -250,7 +250,7 @@ func (a *App) DeleteFlow(r *fastglue.Request) error {
 
 	a.Log.Info("Flow deleted", "flow_id", id)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Flow deleted successfully",
 	})
 }
@@ -318,12 +318,12 @@ func (a *App) SaveFlowToMeta(r *fastglue.Request) error {
 	// Step 2: Upload flow JSON if we have screens
 	if len(flow.Screens) > 0 {
 		// Validate flow structure before sending to Meta
-		if err := validateFlowStructure([]interface{}(flow.Screens)); err != nil {
+		if err := validateFlowStructure([]any(flow.Screens)); err != nil {
 			return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
 		}
 
 		// Sanitize screens before sending to Meta
-		sanitizedScreens := sanitizeScreensForMeta([]interface{}(flow.Screens))
+		sanitizedScreens := sanitizeScreensForMeta([]any(flow.Screens))
 
 		flowJSON := &whatsapp.FlowJSON{
 			Version: flow.JSONVersion,
@@ -333,7 +333,7 @@ func (a *App) SaveFlowToMeta(r *fastglue.Request) error {
 		if err := waClient.UpdateFlowJSON(ctx, waAccount, metaFlowID, flowJSON); err != nil {
 			a.Log.Error("Failed to update flow JSON in Meta", "error", err, "flow_id", id, "meta_flow_id", metaFlowID)
 			// Save the meta flow ID even if JSON update fails
-			a.DB.Model(flow).Updates(map[string]interface{}{
+			a.DB.Model(flow).Updates(map[string]any{
 				"meta_flow_id": metaFlowID,
 			})
 			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update flow JSON", nil, "")
@@ -342,7 +342,7 @@ func (a *App) SaveFlowToMeta(r *fastglue.Request) error {
 
 	// Update local database with meta flow ID and set status to DRAFT
 	// (updating on Meta creates a new draft version that needs to be published)
-	if err := a.DB.Model(flow).Updates(map[string]interface{}{
+	if err := a.DB.Model(flow).Updates(map[string]any{
 		"meta_flow_id":      metaFlowID,
 		"status":            "DRAFT",
 		"has_local_changes": false,
@@ -356,7 +356,7 @@ func (a *App) SaveFlowToMeta(r *fastglue.Request) error {
 
 	a.Log.Info("Flow saved to Meta", "flow_id", flow.ID, "meta_flow_id", metaFlowID)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"flow":    flowToResponse(*flow),
 		"message": "Flow saved to Meta successfully",
 	})
@@ -415,7 +415,7 @@ func (a *App) PublishFlow(r *fastglue.Request) error {
 	}
 
 	// Update local database
-	if err := a.DB.Model(flow).Updates(map[string]interface{}{
+	if err := a.DB.Model(flow).Updates(map[string]any{
 		"status":      "PUBLISHED",
 		"preview_url": previewURL,
 	}).Error; err != nil {
@@ -428,7 +428,7 @@ func (a *App) PublishFlow(r *fastglue.Request) error {
 
 	a.Log.Info("Flow published to Meta", "flow_id", flow.ID, "meta_flow_id", flow.MetaFlowID)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"flow":    flowToResponse(*flow),
 		"message": "Flow published successfully",
 	})
@@ -474,7 +474,7 @@ func (a *App) DeprecateFlow(r *fastglue.Request) error {
 		}
 	}
 
-	if err := a.DB.Model(flow).Updates(map[string]interface{}{
+	if err := a.DB.Model(flow).Updates(map[string]any{
 		"status": "DEPRECATED",
 	}).Error; err != nil {
 		a.Log.Error("Failed to deprecate flow", "error", err, "flow_id", id)
@@ -486,7 +486,7 @@ func (a *App) DeprecateFlow(r *fastglue.Request) error {
 
 	a.Log.Info("Flow deprecated", "flow_id", flow.ID)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"flow":    flowToResponse(*flow),
 		"message": "Flow deprecated successfully",
 	})
@@ -530,7 +530,7 @@ func (a *App) DuplicateFlow(r *fastglue.Request) error {
 
 	a.Log.Info("Flow duplicated", "original_flow_id", id, "new_flow_id", newFlow.ID)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"flow":    flowToResponse(newFlow),
 		"message": "Flow duplicated successfully. You can now edit and publish the new flow.",
 	})
@@ -630,7 +630,7 @@ func (a *App) SyncFlows(r *fastglue.Request) error {
 			created++
 		} else {
 			// Flow exists, update it
-			updates := map[string]interface{}{
+			updates := map[string]any{
 				"name":        mf.Name,
 				"status":      mf.Status,
 				"category":    category,
@@ -653,7 +653,7 @@ func (a *App) SyncFlows(r *fastglue.Request) error {
 
 	a.Log.Info("Flows synced from Meta", "total", synced, "created", created, "updated", updated)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Flows synced successfully",
 		"synced":  synced,
 		"created": created,
@@ -664,7 +664,7 @@ func (a *App) SyncFlows(r *fastglue.Request) error {
 // validateFlowStructure validates the flow structure before sending to Meta
 // - Ensures at least one screen has a Footer with "complete" action
 // - If multiple screens, only the last screen should have "complete" action
-func validateFlowStructure(screens []interface{}) error {
+func validateFlowStructure(screens []any) error {
 	if len(screens) == 0 {
 		return fmt.Errorf("flow must have at least one screen")
 	}
@@ -672,17 +672,17 @@ func validateFlowStructure(screens []interface{}) error {
 	// Find which screens have complete action
 	screensWithComplete := []int{}
 	for i, screen := range screens {
-		screenMap, ok := screen.(map[string]interface{})
+		screenMap, ok := screen.(map[string]any)
 		if !ok {
 			continue
 		}
 
-		layout, ok := screenMap["layout"].(map[string]interface{})
+		layout, ok := screenMap["layout"].(map[string]any)
 		if !ok {
 			continue
 		}
 
-		children, ok := layout["children"].([]interface{})
+		children, ok := layout["children"].([]any)
 		if !ok {
 			continue
 		}
@@ -730,25 +730,25 @@ var componentsWithoutID = map[string]bool{
 // - Removes 'id' property from components that don't support it
 // - Marks screens with 'complete' action as terminal screens
 // - Auto-populates the complete action's payload with all form field values
-func sanitizeScreensForMeta(screens []interface{}) []interface{} {
+func sanitizeScreensForMeta(screens []any) []any {
 	// First pass: collect form field names per screen
 	screenFields := collectFormFieldsPerScreen(screens)
 	allFieldNames := collectFormFieldNames(screens)
 
-	result := make([]interface{}, len(screens))
+	result := make([]any, len(screens))
 
 	// Track cumulative fields from previous screens
 	var fieldsFromPreviousScreens []string
 
 	for i, screen := range screens {
-		screenMap, ok := screen.(map[string]interface{})
+		screenMap, ok := screen.(map[string]any)
 		if !ok {
 			result[i] = screen
 			continue
 		}
 
 		// Create a new screen map
-		newScreen := make(map[string]interface{})
+		newScreen := make(map[string]any)
 		for k, v := range screenMap {
 			newScreen[k] = v
 		}
@@ -760,16 +760,16 @@ func sanitizeScreensForMeta(screens []interface{}) []interface{} {
 
 		// Add data model for fields from previous screens (required for multi-screen flows)
 		if i > 0 && len(fieldsFromPreviousScreens) > 0 {
-			dataModel := make(map[string]interface{})
+			dataModel := make(map[string]any)
 			// Copy existing data model if present
-			if existingData, ok := newScreen["data"].(map[string]interface{}); ok {
+			if existingData, ok := newScreen["data"].(map[string]any); ok {
 				for k, v := range existingData {
 					dataModel[k] = v
 				}
 			}
 			// Add entries for fields from previous screens
 			for _, fieldName := range fieldsFromPreviousScreens {
-				dataModel[fieldName] = map[string]interface{}{
+				dataModel[fieldName] = map[string]any{
 					"type":        "string",
 					"__example__": "",
 				}
@@ -779,13 +779,13 @@ func sanitizeScreensForMeta(screens []interface{}) []interface{} {
 
 		// Sanitize layout children and check for terminal action
 		isTerminal := false
-		if layout, ok := newScreen["layout"].(map[string]interface{}); ok {
-			newLayout := make(map[string]interface{})
+		if layout, ok := newScreen["layout"].(map[string]any); ok {
+			newLayout := make(map[string]any)
 			for k, v := range layout {
 				newLayout[k] = v
 			}
 
-			if children, ok := layout["children"].([]interface{}); ok {
+			if children, ok := layout["children"].([]any); ok {
 				// Sanitize and auto-populate action payloads
 				sanitizedChildren := sanitizeComponentsWithPayload(children, allFieldNames, fieldsFromPreviousScreens)
 				newLayout["children"] = sanitizedChildren
@@ -815,27 +815,27 @@ func sanitizeScreensForMeta(screens []interface{}) []interface{} {
 
 // collectFormFieldNames collects all form field names from all screens
 // These are components that have a "name" attribute (TextInput, TextArea, Dropdown, etc.)
-func collectFormFieldNames(screens []interface{}) []string {
+func collectFormFieldNames(screens []any) []string {
 	var fieldNames []string
 
 	for _, screen := range screens {
-		screenMap, ok := screen.(map[string]interface{})
+		screenMap, ok := screen.(map[string]any)
 		if !ok {
 			continue
 		}
 
-		layout, ok := screenMap["layout"].(map[string]interface{})
+		layout, ok := screenMap["layout"].(map[string]any)
 		if !ok {
 			continue
 		}
 
-		children, ok := layout["children"].([]interface{})
+		children, ok := layout["children"].([]any)
 		if !ok {
 			continue
 		}
 
 		for _, child := range children {
-			compMap, ok := child.(map[string]interface{})
+			compMap, ok := child.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -853,28 +853,28 @@ func collectFormFieldNames(screens []interface{}) []string {
 }
 
 // collectFormFieldsPerScreen collects form field names for each screen by index
-func collectFormFieldsPerScreen(screens []interface{}) map[int][]string {
+func collectFormFieldsPerScreen(screens []any) map[int][]string {
 	result := make(map[int][]string)
 
 	for i, screen := range screens {
-		screenMap, ok := screen.(map[string]interface{})
+		screenMap, ok := screen.(map[string]any)
 		if !ok {
 			continue
 		}
 
-		layout, ok := screenMap["layout"].(map[string]interface{})
+		layout, ok := screenMap["layout"].(map[string]any)
 		if !ok {
 			continue
 		}
 
-		children, ok := layout["children"].([]interface{})
+		children, ok := layout["children"].([]any)
 		if !ok {
 			continue
 		}
 
 		var fieldNames []string
 		for _, child := range children {
-			compMap, ok := child.(map[string]interface{})
+			compMap, ok := child.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -896,14 +896,14 @@ func collectFormFieldsPerScreen(screens []interface{}) map[int][]string {
 }
 
 // hasCompleteAction checks if any component has an on-click-action with name "complete"
-func hasCompleteAction(children []interface{}) bool {
+func hasCompleteAction(children []any) bool {
 	for _, child := range children {
-		compMap, ok := child.(map[string]interface{})
+		compMap, ok := child.(map[string]any)
 		if !ok {
 			continue
 		}
 
-		if action, ok := compMap["on-click-action"].(map[string]interface{}); ok {
+		if action, ok := compMap["on-click-action"].(map[string]any); ok {
 			if name, ok := action["name"].(string); ok && name == "complete" {
 				return true
 			}
@@ -945,13 +945,13 @@ func sanitizeID(id string) string {
 // sanitizeComponentsWithPayload sanitizes components and auto-populates action payloads
 // - For navigate actions: passes current screen's form fields using ${form.fieldName}
 // - For complete actions: uses ${data.fieldName} for previous screens, ${form.fieldName} for current
-func sanitizeComponentsWithPayload(children []interface{}, allFieldNames []string, fieldsFromPreviousScreens []string) []interface{} {
-	result := make([]interface{}, len(children))
+func sanitizeComponentsWithPayload(children []any, allFieldNames []string, fieldsFromPreviousScreens []string) []any {
+	result := make([]any, len(children))
 
 	// Collect this screen's field names
 	var thisScreenFields []string
 	for _, child := range children {
-		compMap, ok := child.(map[string]interface{})
+		compMap, ok := child.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -967,14 +967,14 @@ func sanitizeComponentsWithPayload(children []interface{}, allFieldNames []strin
 	}
 
 	for i, child := range children {
-		compMap, ok := child.(map[string]interface{})
+		compMap, ok := child.(map[string]any)
 		if !ok {
 			result[i] = child
 			continue
 		}
 
 		// Create a new component map
-		newComp := make(map[string]interface{})
+		newComp := make(map[string]any)
 		for k, v := range compMap {
 			newComp[k] = v
 		}
@@ -991,11 +991,11 @@ func sanitizeComponentsWithPayload(children []interface{}, allFieldNames []strin
 		}
 
 		// Sanitize data-source option IDs
-		if dataSource, ok := newComp["data-source"].([]interface{}); ok {
-			newDataSource := make([]interface{}, len(dataSource))
+		if dataSource, ok := newComp["data-source"].([]any); ok {
+			newDataSource := make([]any, len(dataSource))
 			for j, opt := range dataSource {
-				if optMap, ok := opt.(map[string]interface{}); ok {
-					newOpt := make(map[string]interface{})
+				if optMap, ok := opt.(map[string]any); ok {
+					newOpt := make(map[string]any)
 					for k, v := range optMap {
 						newOpt[k] = v
 					}
@@ -1011,10 +1011,10 @@ func sanitizeComponentsWithPayload(children []interface{}, allFieldNames []strin
 		}
 
 		// Auto-populate action payloads
-		if action, ok := newComp["on-click-action"].(map[string]interface{}); ok {
+		if action, ok := newComp["on-click-action"].(map[string]any); ok {
 			actionName, _ := action["name"].(string)
 
-			newAction := make(map[string]interface{})
+			newAction := make(map[string]any)
 			for k, v := range action {
 				newAction[k] = v
 			}
@@ -1024,7 +1024,7 @@ func sanitizeComponentsWithPayload(children []interface{}, allFieldNames []strin
 				// Complete action: include all form fields from all screens
 				// - Fields from previous screens: use ${data.fieldName} (passed via data model)
 				// - Fields on current screen: use ${form.fieldName} (form input)
-				payload := make(map[string]interface{})
+				payload := make(map[string]any)
 				for _, fieldName := range allFieldNames {
 					if thisScreenFieldSet[fieldName] {
 						// Current screen's field - use form reference
@@ -1039,7 +1039,7 @@ func sanitizeComponentsWithPayload(children []interface{}, allFieldNames []strin
 				// Navigate action: pass current screen's form fields to next screen
 				// Use ${form.fieldName} for current screen's fields
 				if len(thisScreenFields) > 0 {
-					payload := make(map[string]interface{})
+					payload := make(map[string]any)
 					// Pass previous screen data through
 					for _, fieldName := range fieldsFromPreviousScreens {
 						payload[fieldName] = "${data." + fieldName + "}"
@@ -1071,8 +1071,8 @@ func flowToResponse(f models.WhatsAppFlow) FlowResponse {
 		Status:          f.Status,
 		Category:        f.Category,
 		JSONVersion:     f.JSONVersion,
-		FlowJSON:        map[string]interface{}(f.FlowJSON),
-		Screens:         []interface{}(f.Screens),
+		FlowJSON:        map[string]any(f.FlowJSON),
+		Screens:         []any(f.Screens),
 		PreviewURL:      f.PreviewURL,
 		HasLocalChanges: f.HasLocalChanges,
 		CreatedAt:       f.CreatedAt.Format("2006-01-02T15:04:05Z"),

--- a/internal/handlers/import_export.go
+++ b/internal/handlers/import_export.go
@@ -19,23 +19,23 @@ import (
 
 // ExportConfig defines allowed tables and their exportable columns
 type ExportConfig struct {
-	Model           interface{}
+	Model           any
 	Resource        string // For permission check
 	AllowedColumns  []string
 	DefaultColumns  []string
 	ColumnLabels    map[string]string // Column name -> CSV header label
-	ColumnTransform map[string]func(interface{}) string
+	ColumnTransform map[string]func(any) string
 }
 
 // ImportConfig defines allowed tables and their importable columns
 type ImportConfig struct {
-	Model            interface{}
+	Model            any
 	Resource         string // For permission check
 	RequiredColumns  []string
 	OptionalColumns  []string
-	ColumnTransform  map[string]func(string) (interface{}, error)
+	ColumnTransform  map[string]func(string) (any, error)
 	UniqueColumn     string // Column to check for duplicates (e.g., "phone_number")
-	BeforeCreate     func(db *gorm.DB, orgID uuid.UUID, record map[string]interface{}) error
+	BeforeCreate     func(db *gorm.DB, orgID uuid.UUID, record map[string]any) error
 }
 
 // Supported export/import configurations
@@ -58,8 +58,8 @@ var exportConfigs = map[string]ExportConfig{
 			"created_at":        "Created At",
 			"updated_at":        "Updated At",
 		},
-		ColumnTransform: map[string]func(interface{}) string{
-			"tags": func(v interface{}) string {
+		ColumnTransform: map[string]func(any) string{
+			"tags": func(v any) string {
 				if v == nil {
 					return ""
 				}
@@ -74,7 +74,7 @@ var exportConfigs = map[string]ExportConfig{
 				}
 				return ""
 			},
-			"last_message_at": func(v interface{}) string {
+			"last_message_at": func(v any) string {
 				if v == nil {
 					return ""
 				}
@@ -83,19 +83,19 @@ var exportConfigs = map[string]ExportConfig{
 				}
 				return ""
 			},
-			"created_at": func(v interface{}) string {
+			"created_at": func(v any) string {
 				if t, ok := v.(time.Time); ok {
 					return t.Format(time.RFC3339)
 				}
 				return ""
 			},
-			"updated_at": func(v interface{}) string {
+			"updated_at": func(v any) string {
 				if t, ok := v.(time.Time); ok {
 					return t.Format(time.RFC3339)
 				}
 				return ""
 			},
-			"assigned_user_id": func(v interface{}) string {
+			"assigned_user_id": func(v any) string {
 				if v == nil {
 					return ""
 				}
@@ -127,8 +127,8 @@ var importConfigs = map[string]ImportConfig{
 		RequiredColumns: []string{"phone_number"},
 		OptionalColumns: []string{"profile_name", "whats_app_account", "tags"},
 		UniqueColumn:    "phone_number",
-		ColumnTransform: map[string]func(string) (interface{}, error){
-			"phone_number": func(s string) (interface{}, error) {
+		ColumnTransform: map[string]func(string) (any, error){
+			"phone_number": func(s string) (any, error) {
 				// Normalize phone number - remove + prefix
 				phone := strings.TrimSpace(s)
 				if len(phone) > 0 && phone[0] == '+' {
@@ -139,7 +139,7 @@ var importConfigs = map[string]ImportConfig{
 				}
 				return phone, nil
 			},
-			"tags": func(s string) (interface{}, error) {
+			"tags": func(s string) (any, error) {
 				if s == "" {
 					return nil, nil
 				}
@@ -232,7 +232,7 @@ func (a *App) ExportData(r *fastglue.Request) error {
 	if tags, ok := req.Filters["tags"]; ok && tags != "" {
 		tagList := strings.Split(tags, ",")
 		conditions := make([]string, 0, len(tagList))
-		args := make([]interface{}, 0, len(tagList))
+		args := make([]any, 0, len(tagList))
 		for _, tag := range tagList {
 			tag = strings.TrimSpace(tag)
 			if tag != "" {
@@ -291,9 +291,9 @@ func (a *App) ExportData(r *fastglue.Request) error {
 
 	// Write rows
 	for rows.Next() {
-		// Create a slice of interface{} to scan into
-		values := make([]interface{}, len(selectCols))
-		valuePtrs := make([]interface{}, len(selectCols))
+		// Create a slice of any to scan into
+		values := make([]any, len(selectCols))
+		valuePtrs := make([]any, len(selectCols))
 		for i := range values {
 			valuePtrs[i] = &values[i]
 		}
@@ -488,7 +488,7 @@ func (a *App) ImportData(r *fastglue.Request) error {
 		}
 
 		// Build record map
-		recordMap := make(map[string]interface{})
+		recordMap := make(map[string]any)
 		recordMap["organization_id"] = orgID
 
 		hasError := false
@@ -543,7 +543,7 @@ func (a *App) ImportData(r *fastglue.Request) error {
 		// Check for duplicate based on unique column
 		if config.UniqueColumn != "" {
 			uniqueVal := recordMap[config.UniqueColumn]
-			var existing interface{}
+			var existing any
 
 			// Use reflection to create a new instance of the model type
 			modelType := reflect.TypeOf(config.Model).Elem()
@@ -619,7 +619,7 @@ func (a *App) ImportData(r *fastglue.Request) error {
 		created++
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"created":  created,
 		"updated":  updated,
 		"skipped":  skipped,
@@ -660,7 +660,7 @@ func (a *App) GetExportConfig(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"table":           tableName,
 		"columns":         columns,
 		"default_columns": config.DefaultColumns,
@@ -721,7 +721,7 @@ func (a *App) GetImportConfig(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"table":            tableName,
 		"required_columns": requiredCols,
 		"optional_columns": optionalCols,
@@ -757,7 +757,7 @@ func snakeToPascal(s string) string {
 }
 
 // Helper function to format values for CSV export
-func formatExportValue(v interface{}, colType interface{}) string {
+func formatExportValue(v any, colType any) string {
 	if v == nil {
 		return ""
 	}

--- a/internal/handlers/ivr_flows.go
+++ b/internal/handlers/ivr_flows.go
@@ -795,7 +795,7 @@ func (a *App) generateIVRAudio(menu models.JSONB) error {
 	}
 
 	for i, nodeRaw := range nodesSlice {
-		nodeMap, ok := nodeRaw.(map[string]interface{})
+		nodeMap, ok := nodeRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -803,7 +803,7 @@ func (a *App) generateIVRAudio(menu models.JSONB) error {
 		if !ok {
 			continue
 		}
-		config, ok := configRaw.(map[string]interface{})
+		config, ok := configRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -837,7 +837,7 @@ func menuHasGreetingText(menu models.JSONB) bool {
 	}
 
 	for _, nodeRaw := range nodesSlice {
-		nodeMap, ok := nodeRaw.(map[string]interface{})
+		nodeMap, ok := nodeRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -845,7 +845,7 @@ func menuHasGreetingText(menu models.JSONB) bool {
 		if !ok {
 			continue
 		}
-		config, ok := configRaw.(map[string]interface{})
+		config, ok := configRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -856,9 +856,9 @@ func menuHasGreetingText(menu models.JSONB) bool {
 	return false
 }
 
-// toSlice converts an interface{} to []interface{}, handling JSON re-marshal if needed.
-func toSlice(v interface{}) ([]interface{}, bool) {
-	if s, ok := v.([]interface{}); ok {
+// toSlice converts an any to []any, handling JSON re-marshal if needed.
+func toSlice(v any) ([]any, bool) {
+	if s, ok := v.([]any); ok {
 		return s, true
 	}
 	// Handle case where JSONB was deserialized differently
@@ -866,7 +866,7 @@ func toSlice(v interface{}) ([]interface{}, bool) {
 	if err != nil {
 		return nil, false
 	}
-	var s []interface{}
+	var s []any
 	if json.Unmarshal(b, &s) == nil {
 		return s, true
 	}
@@ -912,7 +912,7 @@ func validateFlowGraph(menu models.JSONB) error {
 	terminalTypes := map[string]bool{"goto_flow": true, "hangup": true}
 
 	for _, nodeRaw := range nodesSlice {
-		nodeMap, ok := nodeRaw.(map[string]interface{})
+		nodeMap, ok := nodeRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -943,7 +943,7 @@ func validateFlowGraph(menu models.JSONB) error {
 			return fmt.Errorf("edges must be an array")
 		}
 		for _, edgeRaw := range edgesSlice {
-			edgeMap, ok := edgeRaw.(map[string]interface{})
+			edgeMap, ok := edgeRaw.(map[string]any)
 			if !ok {
 				continue
 			}

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -311,17 +312,15 @@ func (a *App) buildInteractiveData(req OutgoingMessageRequest) models.JSONB {
 	// Template buttons: stored as JSONBArray on Template.Buttons
 	// Resolve dynamic URL params (e.g., {{1}}) before storing
 	if req.Template != nil && len(req.Template.Buttons) > 0 {
-		buttons := make([]interface{}, len(req.Template.Buttons))
+		buttons := make([]any, len(req.Template.Buttons))
 		for i, btn := range req.Template.Buttons {
-			btnMap, ok := btn.(map[string]interface{})
+			btnMap, ok := btn.(map[string]any)
 			if !ok {
 				buttons[i] = btn
 				continue
 			}
-			resolved := make(map[string]interface{})
-			for k, v := range btnMap {
-				resolved[k] = v
-			}
+			resolved := make(map[string]any, len(btnMap))
+			maps.Copy(resolved, btnMap)
 			if resolved["type"] == "URL" {
 				if urlStr, ok := resolved["url"].(string); ok {
 					idx := fmt.Sprintf("%d", i)
@@ -347,7 +346,7 @@ func (a *App) buildInteractiveData(req OutgoingMessageRequest) models.JSONB {
 			"url":         req.URL,
 		}
 	case "list":
-		rows := make([]interface{}, len(req.Buttons))
+		rows := make([]any, len(req.Buttons))
 		for i, btn := range req.Buttons {
 			rows[i] = map[string]string{"id": btn.ID, "title": btn.Title}
 		}
@@ -357,7 +356,7 @@ func (a *App) buildInteractiveData(req OutgoingMessageRequest) models.JSONB {
 			"rows": rows,
 		}
 	default: // "button"
-		buttons := make([]interface{}, len(req.Buttons))
+		buttons := make([]any, len(req.Buttons))
 		for i, btn := range req.Buttons {
 			buttons[i] = map[string]string{"id": btn.ID, "title": btn.Title}
 		}
@@ -635,7 +634,7 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 			if err != nil {
 				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Failed to read header file", nil, "")
 			}
-			defer f.Close()
+			defer f.Close() //nolint:errcheck
 			headerFileData, err = io.ReadAll(f)
 			if err != nil {
 				a.Log.Error("Failed to read header file", "error", err)
@@ -767,7 +766,7 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 			if err != nil {
 				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Failed to download header media from URL", nil, "")
 			}
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck
 			if resp.StatusCode != http.StatusOK {
 				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, fmt.Sprintf("Header media URL returned status %d", resp.StatusCode), nil, "")
 			}

--- a/internal/handlers/meta_analytics.go
+++ b/internal/handlers/meta_analytics.go
@@ -141,7 +141,7 @@ func (a *App) GetMetaAnalytics(r *fastglue.Request) error {
 	}
 
 	if len(accounts) == 0 {
-		return r.SendEnvelope(map[string]interface{}{
+		return r.SendEnvelope(map[string]any{
 			"accounts": []MetaAnalyticsResponse{},
 			"message":  "No WhatsApp accounts found",
 		})
@@ -157,7 +157,7 @@ func (a *App) GetMetaAnalytics(r *fastglue.Request) error {
 		var cachedResponse []MetaAnalyticsResponse
 		if err := json.Unmarshal([]byte(cached), &cachedResponse); err == nil {
 			a.Log.Debug("Meta analytics cache hit", "cache_key", cacheKey)
-			return r.SendEnvelope(map[string]interface{}{
+			return r.SendEnvelope(map[string]any{
 				"accounts": cachedResponse,
 				"cached":   true,
 			})
@@ -326,7 +326,7 @@ func (a *App) GetMetaAnalytics(r *fastglue.Request) error {
 		a.Redis.Set(ctx, cacheKey, cacheData, cacheTTL)
 	}
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"accounts": results,
 		"cached":   false,
 	}
@@ -373,7 +373,7 @@ func (a *App) ListMetaAccountsForAnalytics(r *fastglue.Request) error {
 		})
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"accounts": result,
 	})
 }
@@ -395,7 +395,7 @@ func (a *App) RefreshMetaAnalyticsCache(r *fastglue.Request) error {
 	pattern := fmt.Sprintf("%s%s:*", metaAnalyticsCachePrefix, orgID.String())
 	a.deleteKeysByPattern(ctx, pattern)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Analytics cache cleared successfully",
 	})
 }

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -75,7 +75,7 @@ func (a *App) GetOrganizationSettings(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"settings": settings,
 		"name":     org.Name,
 	})
@@ -151,14 +151,14 @@ func (a *App) UpdateOrganizationSettings(r *fastglue.Request) error {
 		a.CallManager.InvalidateOrgCallingSettingsCache(orgID)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": "Settings updated successfully",
 	})
 }
 
 // IsCallingEnabledForOrg checks if calling is enabled for an organization.
 // Both the global CallManager and the per-org setting must be active.
-func (a *App) IsCallingEnabledForOrg(orgID interface{}) bool {
+func (a *App) IsCallingEnabledForOrg(orgID any) bool {
 	if a.CallManager == nil {
 		return false
 	}
@@ -184,7 +184,7 @@ func (a *App) requireCallingEnabled(r *fastglue.Request, orgID uuid.UUID) error 
 }
 
 // GetOrgCallingConfig returns org-level calling config values, falling back to global defaults.
-func (a *App) GetOrgCallingConfig(orgID interface{}) (maxDuration, transferTimeout int) {
+func (a *App) GetOrgCallingConfig(orgID any) (maxDuration, transferTimeout int) {
 	maxDuration = callingConfigDefault(a.Config.Calling.MaxCallDuration, 3600)
 	transferTimeout = callingConfigDefault(a.Config.Calling.TransferTimeoutSecs, 60)
 
@@ -213,7 +213,7 @@ func callingConfigDefault(val, fallback int) int {
 
 // MaskContactFields conditionally masks a profile name and phone number
 // if phone masking is enabled for the given organization.
-func (a *App) MaskContactFields(orgID interface{}, profileName, phoneNumber string) (string, string) {
+func (a *App) MaskContactFields(orgID any, profileName, phoneNumber string) (string, string) {
 	if a.ShouldMaskPhoneNumbers(orgID) {
 		return utils.MaskIfPhoneNumber(profileName), utils.MaskPhoneNumber(phoneNumber)
 	}
@@ -221,7 +221,7 @@ func (a *App) MaskContactFields(orgID interface{}, profileName, phoneNumber stri
 }
 
 // ShouldMaskPhoneNumbers checks if phone masking is enabled for the organization
-func (a *App) ShouldMaskPhoneNumbers(orgID interface{}) bool {
+func (a *App) ShouldMaskPhoneNumbers(orgID any) bool {
 	var org models.Organization
 	if err := a.DB.Where("id = ?", orgID).First(&org).Error; err != nil {
 		return false
@@ -453,7 +453,7 @@ func (a *App) ListOrganizationMembers(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to list members", nil, "")
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"members": response,
 		"total":   total,
 		"page":    pg.Page,

--- a/internal/handlers/roles.go
+++ b/internal/handlers/roles.go
@@ -83,7 +83,7 @@ func (a *App) ListRoles(r *fastglue.Request) error {
 		response[i] = roleToResponse(role, userCount)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"roles": response,
 		"total": total,
 		"page":  pg.Page,
@@ -362,7 +362,7 @@ func (a *App) ListPermissions(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"permissions": response,
 	})
 }

--- a/internal/handlers/sla_processor.go
+++ b/internal/handlers/sla_processor.go
@@ -136,7 +136,7 @@ func (p *SLAProcessor) autoCloseExpiredTransfers(orgID uuid.UUID, settings model
 		}
 
 		// Update transfer status
-		if err := p.app.DB.Model(&transfer).Updates(map[string]interface{}{
+		if err := p.app.DB.Model(&transfer).Updates(map[string]any{
 			"status":     models.TransferStatusExpired,
 			"resumed_at": now,
 			"notes":      transfer.Notes + "\n[Auto-closed: No agent response within SLA]",
@@ -198,7 +198,7 @@ func (p *SLAProcessor) escalateTransfers(orgID uuid.UUID, settings models.Chatbo
 		newLevel := transfer.SLA.EscalationLevel + 1
 
 		// Update transfer
-		updates := map[string]interface{}{
+		updates := map[string]any{
 			"escalation_level": newLevel,
 			"escalated_at":     now,
 		}
@@ -244,7 +244,7 @@ func (p *SLAProcessor) markSLABreached(orgID uuid.UUID, settings models.ChatbotS
 	result := p.app.DB.Model(&models.AgentTransfer{}).Where(
 		"organization_id = ? AND status = ? AND sla_breached = ? AND sla_response_deadline IS NOT NULL AND sla_response_deadline < ? AND agent_id IS NULL",
 		orgID, models.TransferStatusActive, false, now,
-	).Updates(map[string]interface{}{
+	).Updates(map[string]any{
 		"sla_breached":    true,
 		"sla_breached_at": now,
 	})
@@ -282,7 +282,7 @@ func (p *SLAProcessor) notifyEscalation(transfer models.AgentTransfer, settings 
 	// Escalation contacts will receive this via the org-wide broadcast
 	contactName, phoneNumber := p.app.MaskContactFields(transfer.OrganizationID, contact.ProfileName, contact.PhoneNumber)
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"id":                    transfer.ID.String(),
 		"contact_id":            transfer.ContactID.String(),
 		"contact_name":          contactName,
@@ -347,7 +347,7 @@ func (p *SLAProcessor) broadcastTransferUpdate(transfer models.AgentTransfer, ws
 
 	p.app.WSHub.BroadcastToOrg(transfer.OrganizationID, websocket.WSMessage{
 		Type: wsType,
-		Payload: map[string]interface{}{
+		Payload: map[string]any{
 			"id":               transfer.ID.String(),
 			"contact_id":       transfer.ContactID.String(),
 			"contact_name":     contactName,
@@ -567,7 +567,7 @@ func (a *App) UpdateContactChatbotMessage(contactID uuid.UUID) {
 	now := time.Now()
 	a.DB.Model(&models.Contact{}).
 		Where("id = ?", contactID).
-		Updates(map[string]interface{}{
+		Updates(map[string]any{
 			"chatbot_last_message_at": now,
 			"chatbot_reminder_sent":   false, // Reset reminder when chatbot sends a new message
 		})
@@ -577,7 +577,7 @@ func (a *App) UpdateContactChatbotMessage(contactID uuid.UUID) {
 func (a *App) ClearContactChatbotTracking(contactID uuid.UUID) {
 	a.DB.Model(&models.Contact{}).
 		Where("id = ?", contactID).
-		Updates(map[string]interface{}{
+		Updates(map[string]any{
 			"chatbot_last_message_at": nil,
 			"chatbot_reminder_sent":   false,
 		})

--- a/internal/handlers/sso.go
+++ b/internal/handlers/sso.go
@@ -594,7 +594,7 @@ func (a *App) fetchUserInfo(provider string, ssoConfig *models.SSOProvider, toke
 
 	// Parse based on provider
 	var userInfo UserInfo
-	var rawData map[string]interface{}
+	var rawData map[string]any
 	if err := json.Unmarshal(body, &rawData); err != nil {
 		return nil, err
 	}
@@ -724,7 +724,7 @@ func generateRandomString(n int) string {
 	return base64.URLEncoding.EncodeToString(b)[:n]
 }
 
-func getString(data map[string]interface{}, key string) string {
+func getString(data map[string]any, key string) string {
 	if val, ok := data[key]; ok {
 		if str, ok := val.(string); ok {
 			return str

--- a/internal/handlers/teams.go
+++ b/internal/handlers/teams.go
@@ -101,7 +101,7 @@ func (a *App) ListTeams(r *fastglue.Request) error {
 		response[i] = buildTeamResponse(&t, false)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"teams": response,
 		"total": total,
 		"page":  pg.Page,
@@ -143,7 +143,7 @@ func (a *App) GetTeam(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{"team": buildTeamResponse(&team, true)})
+	return r.SendEnvelope(map[string]any{"team": buildTeamResponse(&team, true)})
 }
 
 // CreateTeam creates a new team
@@ -197,7 +197,7 @@ func (a *App) CreateTeam(r *fastglue.Request) error {
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
 		"team", team.ID, models.AuditActionCreated, nil, &team)
 
-	return r.SendEnvelope(map[string]interface{}{"team": buildTeamResponse(&team, false)})
+	return r.SendEnvelope(map[string]any{"team": buildTeamResponse(&team, false)})
 }
 
 // UpdateTeam updates a team
@@ -270,7 +270,7 @@ func (a *App) UpdateTeam(r *fastglue.Request) error {
 	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
 		"team", team.ID, models.AuditActionUpdated, &oldTeam, &team)
 
-	return r.SendEnvelope(map[string]interface{}{"team": buildTeamResponse(&team, false)})
+	return r.SendEnvelope(map[string]any{"team": buildTeamResponse(&team, false)})
 }
 
 // DeleteTeam deletes a team
@@ -367,7 +367,7 @@ func (a *App) ListTeamMembers(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{"members": members})
+	return r.SendEnvelope(map[string]any{"members": members})
 }
 
 // AddTeamMember adds a member to a team
@@ -456,7 +456,7 @@ func (a *App) AddTeamMember(r *fastglue.Request) error {
 		a.Assigner.InvalidateTeamCache(teamID)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{"member": TeamMemberResponse{
+	return r.SendEnvelope(map[string]any{"member": TeamMemberResponse{
 		ID:          member.ID,
 		UserID:      member.UserID,
 		FullName:    user.FullName,

--- a/internal/handlers/template_engine.go
+++ b/internal/handlers/template_engine.go
@@ -25,9 +25,9 @@ var (
 const maxLoopIterations = 50
 
 // processTemplate processes a template string with variables, conditionals, and loops
-func processTemplate(template string, data map[string]interface{}) string {
+func processTemplate(template string, data map[string]any) string {
 	if data == nil {
-		data = make(map[string]interface{})
+		data = make(map[string]any)
 	}
 
 	result := template
@@ -45,7 +45,7 @@ func processTemplate(template string, data map[string]interface{}) string {
 }
 
 // processForLoops handles {{for item in items}}...{{endfor}} blocks
-func processForLoops(template string, data map[string]interface{}) string {
+func processForLoops(template string, data map[string]any) string {
 	result := template
 
 	for {
@@ -67,7 +67,7 @@ func processForLoops(template string, data map[string]interface{}) string {
 
 		// Process each item in the array
 		switch arr := arrayValue.(type) {
-		case []interface{}:
+		case []any:
 			iterations := len(arr)
 			if iterations > maxLoopIterations {
 				iterations = maxLoopIterations
@@ -84,7 +84,7 @@ func processForLoops(template string, data map[string]interface{}) string {
 				output.WriteString(processedBody)
 			}
 
-		case []map[string]interface{}:
+		case []map[string]any:
 			iterations := len(arr)
 			if iterations > maxLoopIterations {
 				iterations = maxLoopIterations
@@ -111,7 +111,7 @@ func processForLoops(template string, data map[string]interface{}) string {
 }
 
 // processConditionals handles {{if condition}}...{{else}}...{{endif}} blocks
-func processConditionals(template string, data map[string]interface{}) string {
+func processConditionals(template string, data map[string]any) string {
 	result := template
 
 	for {
@@ -150,7 +150,7 @@ func processConditionals(template string, data map[string]interface{}) string {
 }
 
 // processVariables replaces {{variable}} and {{object.path}} with values
-func processVariables(template string, data map[string]interface{}) string {
+func processVariables(template string, data map[string]any) string {
 	return variablePattern.ReplaceAllStringFunc(template, func(match string) string {
 		// Remove {{ and }}
 		path := match[2 : len(match)-2]
@@ -162,13 +162,13 @@ func processVariables(template string, data map[string]interface{}) string {
 
 // getNestedValue extracts a value from nested maps/arrays using dot notation
 // Supports: "name", "user.profile.name", "items[0].name", "data.items[2].value"
-func getNestedValue(data map[string]interface{}, path string) interface{} {
+func getNestedValue(data map[string]any, path string) any {
 	if data == nil || path == "" {
 		return nil
 	}
 
 	parts := splitPath(path)
-	var current interface{} = data
+	var current any = data
 
 	for _, part := range parts {
 		if current == nil {
@@ -187,7 +187,7 @@ func getNestedValue(data map[string]interface{}, path string) interface{} {
 			// Get the field first
 			if field != "" {
 				switch v := current.(type) {
-				case map[string]interface{}:
+				case map[string]any:
 					current = v[field]
 				default:
 					return nil
@@ -196,13 +196,13 @@ func getNestedValue(data map[string]interface{}, path string) interface{} {
 
 			// Then index into the array
 			switch arr := current.(type) {
-			case []interface{}:
+			case []any:
 				if index >= 0 && index < len(arr) {
 					current = arr[index]
 				} else {
 					return nil
 				}
-			case []map[string]interface{}:
+			case []map[string]any:
 				if index >= 0 && index < len(arr) {
 					current = arr[index]
 				} else {
@@ -214,7 +214,7 @@ func getNestedValue(data map[string]interface{}, path string) interface{} {
 		} else {
 			// Regular field access
 			switch v := current.(type) {
-			case map[string]interface{}:
+			case map[string]any:
 				current = v[part]
 			default:
 				return nil
@@ -266,7 +266,7 @@ func splitPath(path string) []string {
 // evaluateCondition evaluates a condition string against data
 // Supports: "variable" (truthy), "variable == 'value'", "variable != 'value'",
 // "variable > 100", "variable < 100", "variable >= 100", "variable <= 100"
-func evaluateCondition(condition string, data map[string]interface{}) bool {
+func evaluateCondition(condition string, data map[string]any) bool {
 	condition = strings.TrimSpace(condition)
 
 	// Parse the condition
@@ -315,7 +315,7 @@ func evaluateCondition(condition string, data map[string]interface{}) bool {
 }
 
 // isTruthy checks if a value is "truthy"
-func isTruthy(value interface{}) bool {
+func isTruthy(value any) bool {
 	if value == nil {
 		return false
 	}
@@ -331,11 +331,11 @@ func isTruthy(value interface{}) bool {
 		return v != 0
 	case float64:
 		return v != 0
-	case []interface{}:
+	case []any:
 		return len(v) > 0
-	case []map[string]interface{}:
+	case []map[string]any:
 		return len(v) > 0
-	case map[string]interface{}:
+	case map[string]any:
 		return len(v) > 0
 	}
 
@@ -343,7 +343,7 @@ func isTruthy(value interface{}) bool {
 }
 
 // compareEqual compares a value with a string for equality
-func compareEqual(value interface{}, compareValue string) bool {
+func compareEqual(value any, compareValue string) bool {
 	if value == nil {
 		return compareValue == "" || compareValue == "null" || compareValue == "nil"
 	}
@@ -370,7 +370,7 @@ func compareEqual(value interface{}, compareValue string) bool {
 
 // compareNumeric compares a value with a string numerically
 // Returns: -1 if value < compare, 0 if equal, 1 if value > compare
-func compareNumeric(value interface{}, compareValue string) int {
+func compareNumeric(value any, compareValue string) int {
 	// Convert value to float64
 	var numValue float64
 	switch v := value.(type) {
@@ -405,7 +405,7 @@ func compareNumeric(value interface{}, compareValue string) int {
 }
 
 // formatValue converts a value to a string for template output
-func formatValue(value interface{}) string {
+func formatValue(value any) string {
 	if value == nil {
 		return ""
 	}
@@ -434,8 +434,8 @@ func formatValue(value interface{}) string {
 }
 
 // copyMap creates a shallow copy of a map
-func copyMap(m map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{}, len(m))
+func copyMap(m map[string]any) map[string]any {
+	result := make(map[string]any, len(m))
 	for k, v := range m {
 		result[k] = v
 	}
@@ -443,8 +443,8 @@ func copyMap(m map[string]interface{}) map[string]interface{} {
 }
 
 // extractResponseMapping extracts values from API response and maps them to session variables
-func extractResponseMapping(responseData map[string]interface{}, mapping map[string]string) map[string]interface{} {
-	result := make(map[string]interface{})
+func extractResponseMapping(responseData map[string]any, mapping map[string]string) map[string]any {
+	result := make(map[string]any)
 
 	for varName, jsonPath := range mapping {
 		value := getNestedValue(responseData, jsonPath)

--- a/internal/handlers/templates.go
+++ b/internal/handlers/templates.go
@@ -24,8 +24,8 @@ type TemplateRequest struct {
 	HeaderContent   string        `json:"header_content"`
 	BodyContent     string        `json:"body_content" validate:"required"`
 	FooterContent   string        `json:"footer_content"`
-	Buttons         []interface{} `json:"buttons"`
-	SampleValues    []interface{} `json:"sample_values"`
+	Buttons         []any `json:"buttons"`
+	SampleValues    []any `json:"sample_values"`
 }
 
 // TemplateResponse represents the response for a template
@@ -42,8 +42,8 @@ type TemplateResponse struct {
 	HeaderContent   string        `json:"header_content"`
 	BodyContent     string        `json:"body_content"`
 	FooterContent   string        `json:"footer_content"`
-	Buttons         []interface{} `json:"buttons"`
-	SampleValues    []interface{} `json:"sample_values"`
+	Buttons         []any `json:"buttons"`
+	SampleValues    []any `json:"sample_values"`
 	CreatedByName   string        `json:"created_by_name,omitempty"`
 	UpdatedByName   string        `json:"updated_by_name,omitempty"`
 	CreatedAt       string        `json:"created_at"`
@@ -370,7 +370,7 @@ func (a *App) SubmitTemplate(r *fastglue.Request) error {
 		map[string]any{"field": "published", "old_value": oldStatus, "new_value": "PENDING"},
 	)
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message":          message,
 		"meta_template_id": metaTemplateID,
 		"status":           template.Status,
@@ -459,8 +459,8 @@ func (a *App) SyncTemplates(r *fastglue.Request) error {
 			case "FOOTER":
 				template.FooterContent = comp.Text
 			case "BUTTONS":
-				// Convert []TemplateButton to []interface{}
-				buttons := make([]interface{}, len(comp.Buttons))
+				// Convert []TemplateButton to []any
+				buttons := make([]any, len(comp.Buttons))
 				for i, btn := range comp.Buttons {
 					buttons[i] = btn
 				}
@@ -474,7 +474,7 @@ func (a *App) SyncTemplates(r *fastglue.Request) error {
 			orgID, account.Name, template.Name, template.Language).First(&existing).Error; err == nil {
 			// Update existing and restore if soft-deleted (explicitly set deleted_at to NULL)
 			template.ID = existing.ID
-			a.DB.Unscoped().Model(&template).Updates(map[string]interface{}{
+			a.DB.Unscoped().Model(&template).Updates(map[string]any{
 				"meta_template_id": template.MetaTemplateID,
 				"display_name":     template.DisplayName,
 				"category":         template.Category,
@@ -493,7 +493,7 @@ func (a *App) SyncTemplates(r *fastglue.Request) error {
 		synced++
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message": fmt.Sprintf("Synced %d templates", synced),
 		"count":   synced,
 	})
@@ -553,18 +553,18 @@ func normalizeTemplateName(name string) string {
 	return result.String()
 }
 
-func convertToJSONBArray(arr []interface{}) models.JSONBArray {
+func convertToJSONBArray(arr []any) models.JSONBArray {
 	if arr == nil {
 		return models.JSONBArray{}
 	}
 	return models.JSONBArray(arr)
 }
 
-func convertFromJSONBArray(arr models.JSONBArray) []interface{} {
+func convertFromJSONBArray(arr models.JSONBArray) []any {
 	if arr == nil {
-		return []interface{}{}
+		return []any{}
 	}
-	return []interface{}(arr)
+	return []any(arr)
 }
 
 // UploadTemplateMedia uploads a media file for use as template header sample
@@ -645,7 +645,7 @@ func (a *App) UploadTemplateMedia(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadGateway, "Failed to upload media to Meta", nil, "")
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"handle":    handle,
 		"filename":  fileHeader.Filename,
 		"mime_type": mimeType,

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -163,7 +163,7 @@ func (a *App) ListUsers(r *fastglue.Request) error {
 		response[i] = resp
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"users": response,
 		"total": total,
 		"page":  pg.Page,
@@ -276,7 +276,7 @@ func (a *App) CreateUser(r *fastglue.Request) error {
 	var softDeleted models.User
 	if err := a.DB.Unscoped().Where("email = ? AND deleted_at IS NOT NULL", req.Email).First(&softDeleted).Error; err == nil {
 		// Restore the soft-deleted user with new details
-		if err := a.DB.Unscoped().Model(&softDeleted).Updates(map[string]interface{}{
+		if err := a.DB.Unscoped().Model(&softDeleted).Updates(map[string]any{
 			"deleted_at":      nil,
 			"organization_id": orgID,
 			"password_hash":   string(hashedPassword),
@@ -292,7 +292,7 @@ func (a *App) CreateUser(r *fastglue.Request) error {
 		// Restore or create UserOrganization entry
 		var existingOrg models.UserOrganization
 		if err := a.DB.Unscoped().Where("user_id = ? AND organization_id = ?", softDeleted.ID, orgID).First(&existingOrg).Error; err == nil {
-			a.DB.Unscoped().Model(&existingOrg).Updates(map[string]interface{}{
+			a.DB.Unscoped().Model(&existingOrg).Updates(map[string]any{
 				"deleted_at": nil,
 				"role_id":    roleID,
 				"is_default": true,
@@ -691,7 +691,7 @@ func (a *App) UpdateCurrentUserSettings(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update settings", nil, "")
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message":  "Settings updated successfully",
 		"settings": user.Settings,
 	})
@@ -830,7 +830,7 @@ func (a *App) ListMyOrganizations(r *fastglue.Request) error {
 		response = append(response, item)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"organizations": response,
 	})
 }
@@ -904,7 +904,7 @@ func (a *App) UpdateAvailability(r *fastglue.Request) error {
 		}
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"message":             "Availability updated successfully",
 		"is_available":        user.IsAvailable,
 		"status":              status,

--- a/internal/handlers/webhook.go
+++ b/internal/handlers/webhook.go
@@ -356,7 +356,7 @@ func (a *App) WebhookHandler(r *fastglue.Request) error {
 	return r.SendEnvelope(map[string]string{"status": "ok"})
 }
 
-func (a *App) processIncomingMessage(phoneNumberID string, msg interface{}, profileName string) {
+func (a *App) processIncomingMessage(phoneNumberID string, msg any, profileName string) {
 	// Convert msg interface to the message struct
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {
@@ -434,7 +434,7 @@ func (a *App) updateMessageStatus(whatsappMsgID, statusValue string, errors []We
 		return
 	}
 
-	updates := map[string]interface{}{}
+	updates := map[string]any{}
 
 	switch newStatus {
 	case models.MessageStatusSent:
@@ -475,7 +475,7 @@ func (a *App) updateMessageStatus(whatsappMsgID, statusValue string, errors []We
 			a.incrementCampaignStat(campaignID, statusValue)
 
 			// Update the BulkMessageRecipient status and timestamps
-			recipientUpdates := map[string]interface{}{
+			recipientUpdates := map[string]any{
 				"status": newStatus,
 			}
 			switch newStatus {

--- a/internal/handlers/webhook_dispatch.go
+++ b/internal/handlers/webhook_dispatch.go
@@ -20,7 +20,7 @@ import (
 type OutboundWebhookPayload struct {
 	Event     string      `json:"event"`
 	Timestamp time.Time   `json:"timestamp"`
-	Data      interface{} `json:"data"`
+	Data      any `json:"data"`
 }
 
 // MessageEventData represents data for message events
@@ -61,7 +61,7 @@ type TransferEventData struct {
 const maxConcurrentWebhooks = 10
 
 // DispatchWebhook sends an event to all matching webhooks for the organization
-func (a *App) DispatchWebhook(orgID uuid.UUID, eventType models.WebhookEvent, data interface{}) {
+func (a *App) DispatchWebhook(orgID uuid.UUID, eventType models.WebhookEvent, data any) {
 	a.wg.Add(1)
 	go func() {
 		defer a.wg.Done()
@@ -72,7 +72,7 @@ func (a *App) DispatchWebhook(orgID uuid.UUID, eventType models.WebhookEvent, da
 	}()
 }
 
-func (a *App) dispatchWebhookAsync(ctx context.Context, orgID uuid.UUID, eventType string, data interface{}) {
+func (a *App) dispatchWebhookAsync(ctx context.Context, orgID uuid.UUID, eventType string, data any) {
 	// Find all active webhooks for this org that subscribe to this event (use cache)
 	webhooks, err := a.getWebhooksCached(orgID)
 	if err != nil {
@@ -118,7 +118,7 @@ func containsEvent(events models.StringArray, event string) bool {
 	return false
 }
 
-func (a *App) sendWebhook(ctx context.Context, webhook models.Webhook, eventType string, data interface{}) {
+func (a *App) sendWebhook(ctx context.Context, webhook models.Webhook, eventType string, data any) {
 	payload := OutboundWebhookPayload{
 		Event:     eventType,
 		Timestamp: time.Now().UTC(),

--- a/internal/handlers/webhooks.go
+++ b/internal/handlers/webhooks.go
@@ -342,7 +342,7 @@ func (a *App) TestWebhook(r *fastglue.Request) error {
 	}
 
 	// Send a test event synchronously
-	testData := map[string]interface{}{
+	testData := map[string]any{
 		"test":      true,
 		"message":   "This is a test webhook from Whatomate",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),

--- a/internal/handlers/websocket.go
+++ b/internal/handlers/websocket.go
@@ -57,7 +57,7 @@ func (a *App) WebSocketHandler(r *fastglue.Request) error {
 // and returns user ID and organization ID.
 func (a *App) validateWSTokenFn() ws.AuthenticateFn {
 	return func(tokenString string) (uuid.UUID, uuid.UUID, error) {
-		token, err := jwt.ParseWithClaims(tokenString, &middleware.JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+		token, err := jwt.ParseWithClaims(tokenString, &middleware.JWTClaims{}, func(token *jwt.Token) (any, error) {
 			return []byte(a.Config.JWT.Secret), nil
 		})
 

--- a/internal/handlers/widgets.go
+++ b/internal/handlers/widgets.go
@@ -26,7 +26,7 @@ type WidgetRequest struct {
 	ShowChange   *bool         `json:"show_change"`
 	Color       string        `json:"color"`
 	Size        string        `json:"size"` // small, medium, large
-	Config      map[string]interface{} `json:"config"`
+	Config      map[string]any `json:"config"`
 	IsShared    *bool         `json:"is_shared"`
 	GridX       *int          `json:"grid_x"`
 	GridY       *int          `json:"grid_y"`
@@ -61,7 +61,7 @@ type WidgetResponse struct {
 	GridY        int           `json:"grid_y"`
 	GridW        int           `json:"grid_w"`
 	GridH        int           `json:"grid_h"`
-	Config       map[string]interface{} `json:"config"`
+	Config       map[string]any `json:"config"`
 	IsShared     bool          `json:"is_shared"`
 	IsDefault    bool          `json:"is_default"`
 	IsOwner      bool          `json:"is_owner"` // True if current user created this widget
@@ -165,7 +165,7 @@ func (a *App) ListWidgets(r *fastglue.Request) error {
 		response[i] = widgetToResponse(w, userID)
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"widgets": response,
 	})
 }
@@ -262,7 +262,7 @@ func (a *App) CreateWidget(r *fastglue.Request) error {
 	// Convert filters to JSONBArray
 	filters := make(models.JSONBArray, len(req.Filters))
 	for i, f := range req.Filters {
-		filters[i] = map[string]interface{}{
+		filters[i] = map[string]any{
 			"field":    f.Field,
 			"operator": f.Operator,
 			"value":    f.Value,
@@ -414,7 +414,7 @@ func (a *App) UpdateWidget(r *fastglue.Request) error {
 	if req.Filters != nil {
 		filters := make(models.JSONBArray, len(req.Filters))
 		for i, f := range req.Filters {
-			filters[i] = map[string]interface{}{
+			filters[i] = map[string]any{
 				"field":    f.Field,
 				"operator": f.Operator,
 				"value":    f.Value,
@@ -544,7 +544,7 @@ func (a *App) SaveWidgetLayout(r *fastglue.Request) error {
 		for i, item := range req.Layout {
 			result := tx.Model(&models.Widget{}).
 				Where("id = ? AND organization_id = ? AND (user_id = ? OR is_shared = true)", item.ID, orgID, userID).
-				Updates(map[string]interface{}{
+				Updates(map[string]any{
 					"grid_x":        item.GridX,
 					"grid_y":        item.GridY,
 					"grid_w":        item.GridW,
@@ -568,16 +568,16 @@ func (a *App) SaveWidgetLayout(r *fastglue.Request) error {
 
 // GetWidgetDataSources returns available data sources and their filterable fields
 func (a *App) GetWidgetDataSources(r *fastglue.Request) error {
-	sources := make([]map[string]interface{}, 0)
+	sources := make([]map[string]any, 0)
 	for source, fields := range widgetDataSources {
-		sources = append(sources, map[string]interface{}{
+		sources = append(sources, map[string]any{
 			"name":   source,
 			"label":  formatLabel(source),
 			"fields": fields,
 		})
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"data_sources":  sources,
 		"metrics":       widgetMetrics,
 		"display_types": widgetDisplayTypes,
@@ -599,7 +599,7 @@ func widgetToResponse(w models.Widget, currentUserID uuid.UUID) WidgetResponse {
 	// Parse filters from JSONBArray
 	filters := make([]FilterInput, 0)
 	for _, f := range w.Filters {
-		if filterMap, ok := f.(map[string]interface{}); ok {
+		if filterMap, ok := f.(map[string]any); ok {
 			filters = append(filters, FilterInput{
 				Field:    widgetGetString(filterMap, "field"),
 				Operator: widgetGetString(filterMap, "operator"),
@@ -608,9 +608,9 @@ func widgetToResponse(w models.Widget, currentUserID uuid.UUID) WidgetResponse {
 		}
 	}
 
-	config := map[string]interface{}(w.Config)
+	config := map[string]any(w.Config)
 	if config == nil {
-		config = map[string]interface{}{}
+		config = map[string]any{}
 	}
 
 	return WidgetResponse{
@@ -641,7 +641,7 @@ func widgetToResponse(w models.Widget, currentUserID uuid.UUID) WidgetResponse {
 	}
 }
 
-func widgetGetString(m map[string]interface{}, key string) string {
+func widgetGetString(m map[string]any, key string) string {
 	if v, ok := m[key]; ok {
 		if s, ok := v.(string); ok {
 			return s
@@ -736,7 +736,7 @@ func (a *App) GetAllWidgetsData(r *fastglue.Request) error {
 		results[widget.ID.String()] = data
 	}
 
-	return r.SendEnvelope(map[string]interface{}{
+	return r.SendEnvelope(map[string]any{
 		"data": results,
 	})
 }
@@ -776,7 +776,7 @@ func (a *App) executeWidgetQuery(orgID uuid.UUID, widget models.Widget, fromStr,
 	// Parse filters
 	filters := make([]FilterInput, 0)
 	for _, f := range widget.Filters {
-		if filterMap, ok := f.(map[string]interface{}); ok {
+		if filterMap, ok := f.(map[string]any); ok {
 			filters = append(filters, FilterInput{
 				Field:    widgetGetString(filterMap, "field"),
 				Operator: widgetGetString(filterMap, "operator"),
@@ -952,7 +952,7 @@ func (a *App) getChartData(orgID uuid.UUID, widget models.Widget, filters []Filt
 		WHERE organization_id = ? AND %s >= ? AND %s <= ?
 	`, dateField, tableName, dateField, dateField)
 
-	args := []interface{}{orgID, start, end}
+	args := []any{orgID, start, end}
 	query, args = appendFilterSQL(query, args, filters)
 
 	query += fmt.Sprintf(" GROUP BY DATE_TRUNC('day', %s) ORDER BY date ASC", dateField)
@@ -994,7 +994,7 @@ func resolveDataSourceTable(dataSource string) (tableName, dateField string, ok 
 }
 
 // appendFilterSQL appends filter conditions to a raw SQL query string and args slice
-func appendFilterSQL(query string, args []interface{}, filters []FilterInput) (string, []interface{}) {
+func appendFilterSQL(query string, args []any, filters []FilterInput) (string, []any) {
 	for _, f := range filters {
 		condition, value := buildFilterSQL(f)
 		query += " AND " + condition
@@ -1035,7 +1035,7 @@ func (a *App) getGroupedData(orgID uuid.UUID, widget models.Widget, filters []Fi
 		WHERE organization_id = ? AND %s >= ? AND %s <= ?
 	`, widget.GroupByField, tableName, dateField, dateField)
 
-	args := []interface{}{orgID, start, end}
+	args := []any{orgID, start, end}
 	query, args = appendFilterSQL(query, args, filters)
 
 	query += fmt.Sprintf(" GROUP BY %s ORDER BY value DESC", widget.GroupByField)
@@ -1074,7 +1074,7 @@ func (a *App) getCampaignMessageStatusData(orgID uuid.UUID, filters []FilterInpu
 		WHERE organization_id = ? AND created_at >= ? AND created_at <= ?
 	`
 
-	args := []interface{}{orgID, start, end}
+	args := []any{orgID, start, end}
 	query, args = appendFilterSQL(query, args, filters)
 
 	type CampaignCounts struct {
@@ -1118,7 +1118,7 @@ func (a *App) getGroupedTimeSeriesData(orgID uuid.UUID, widget models.Widget, fi
 		WHERE organization_id = ? AND %s >= ? AND %s <= ?
 	`, dateField, widget.GroupByField, tableName, dateField, dateField)
 
-	args := []interface{}{orgID, start, end}
+	args := []any{orgID, start, end}
 	query, args = appendFilterSQL(query, args, filters)
 
 	query += fmt.Sprintf(" GROUP BY DATE_TRUNC('day', %s), %s ORDER BY date ASC", dateField, widget.GroupByField)
@@ -1202,7 +1202,7 @@ func (a *App) getCampaignMessageStatusTimeSeries(orgID uuid.UUID, filters []Filt
 		WHERE organization_id = ? AND created_at >= ? AND created_at <= ?
 	`
 
-	args := []interface{}{orgID, start, end}
+	args := []any{orgID, start, end}
 	query, args = appendFilterSQL(query, args, filters)
 
 	query += " GROUP BY DATE_TRUNC('day', created_at) ORDER BY date ASC"
@@ -1248,7 +1248,7 @@ func applyFilter(query *gorm.DB, filter FilterInput) *gorm.DB {
 	return query.Where(condition, value)
 }
 
-func buildFilterSQL(filter FilterInput) (string, interface{}) {
+func buildFilterSQL(filter FilterInput) (string, any) {
 	field := filter.Field
 	value := filter.Value
 
@@ -1320,7 +1320,7 @@ func (a *App) getTableRows(orgID uuid.UUID, widget models.Widget, filters []Filt
 	}
 
 	query := sql.base
-	args := []interface{}{orgID, periodStart, periodEnd}
+	args := []any{orgID, periodStart, periodEnd}
 	query, args = appendFilterSQL(query, args, filters)
 	query += sql.orderBy
 

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -164,7 +164,7 @@ func AuthWithDB(secret string, db *gorm.DB) fastglue.FastMiddleware {
 		}
 
 		// Parse and validate token
-		token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+		token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (any, error) {
 			return []byte(secret), nil
 		})
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -13,7 +13,7 @@ import (
 )
 
 // JSONB is a custom type for PostgreSQL JSONB columns
-type JSONB map[string]interface{}
+type JSONB map[string]any
 
 func (j JSONB) Value() (driver.Value, error) {
 	if j == nil {
@@ -22,7 +22,7 @@ func (j JSONB) Value() (driver.Value, error) {
 	return json.Marshal(j)
 }
 
-func (j *JSONB) Scan(value interface{}) error {
+func (j *JSONB) Scan(value any) error {
 	if value == nil {
 		*j = nil
 		return nil
@@ -35,7 +35,7 @@ func (j *JSONB) Scan(value interface{}) error {
 }
 
 // JSONBArray is a custom type for JSONB arrays
-type JSONBArray []interface{}
+type JSONBArray []any
 
 func (j JSONBArray) Value() (driver.Value, error) {
 	if j == nil {
@@ -44,7 +44,7 @@ func (j JSONBArray) Value() (driver.Value, error) {
 	return json.Marshal(j)
 }
 
-func (j *JSONBArray) Scan(value interface{}) error {
+func (j *JSONBArray) Scan(value any) error {
 	if value == nil {
 		*j = nil
 		return nil
@@ -66,7 +66,7 @@ func (s StringArray) Value() (driver.Value, error) {
 	return json.Marshal(s)
 }
 
-func (s *StringArray) Scan(value interface{}) error {
+func (s *StringArray) Scan(value any) error {
 	if value == nil {
 		*s = nil
 		return nil

--- a/internal/queue/redis.go
+++ b/internal/queue/redis.go
@@ -52,7 +52,7 @@ func (q *RedisQueue) EnqueueRecipient(ctx context.Context, job *RecipientJob) er
 
 	_, err = q.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: StreamName,
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"type":    string(JobTypeRecipient),
 			"payload": string(payload),
 		},
@@ -86,7 +86,7 @@ func (q *RedisQueue) EnqueueRecipients(ctx context.Context, jobs []*RecipientJob
 
 		pipe.XAdd(ctx, &redis.XAddArgs{
 			Stream: StreamName,
-			Values: map[string]interface{}{
+			Values: map[string]any{
 				"type":    string(JobTypeRecipient),
 				"payload": string(payload),
 			},

--- a/internal/templateutil/templateutil.go
+++ b/internal/templateutil/templateutil.go
@@ -59,8 +59,8 @@ func ResolveParamsFromMap(paramNames []string, params map[string]string) []strin
 }
 
 // ResolveParams resolves both positional and named parameters to ordered values
-// using a map[string]interface{} parameter source (e.g. models.JSONB).
-func ResolveParams(bodyContent string, params map[string]interface{}) []string {
+// using a map[string]any parameter source (e.g. models.JSONB).
+func ResolveParams(bodyContent string, params map[string]any) []string {
 	if len(params) == 0 {
 		return nil
 	}
@@ -114,10 +114,10 @@ func ReplaceWithStringParams(content string, params map[string]string) string {
 }
 
 // ReplaceWithJSONBParams replaces both positional ({{1}}) and named ({{name}}) placeholders
-// using a map[string]interface{} parameter source. bodyContent is used to extract parameter
+// using a map[string]any parameter source. bodyContent is used to extract parameter
 // names (typically the template's body content), and content is the string to perform
 // replacements on.
-func ReplaceWithJSONBParams(bodyContent, content string, params map[string]interface{}) string {
+func ReplaceWithJSONBParams(bodyContent, content string, params map[string]any) string {
 	if len(params) == 0 {
 		return content
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -160,7 +160,7 @@ func (w *Worker) HandleRecipientJob(ctx context.Context, job *queue.RecipientJob
 
 // updateRecipientStatus updates the recipient's status in the database
 func (w *Worker) updateRecipientStatus(recipientID uuid.UUID, status models.MessageStatus, waMessageID, errorMsg string) {
-	updates := map[string]interface{}{
+	updates := map[string]any{
 		"status":               status,
 		"whats_app_message_id": waMessageID,
 	}
@@ -219,7 +219,7 @@ func (w *Worker) checkCampaignCompletion(ctx context.Context, campaignID, organi
 		}
 
 		now := time.Now()
-		w.DB.Model(&campaign).Updates(map[string]interface{}{
+		w.DB.Model(&campaign).Updates(map[string]any{
 			"status":       models.CampaignStatusCompleted,
 			"completed_at": now,
 		})

--- a/pkg/whatsapp/call.go
+++ b/pkg/whatsapp/call.go
@@ -16,7 +16,7 @@ func (c *Client) buildCallsURL(account *Account) string {
 // Per the WhatsApp Business Calling API, pre_accept requires the session object
 // with the SDP answer to keep the call alive while WebRTC is finalized.
 func (c *Client) PreAcceptCall(ctx context.Context, account *Account, callID, sdpAnswer string) error {
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"call_id":           callID,
 		"action":            "pre_accept",
@@ -42,7 +42,7 @@ func (c *Client) PreAcceptCall(ctx context.Context, account *Account, callID, sd
 // Per the WhatsApp Business Calling API, accept uses the same session object format.
 // The API returns { success: true } on success.
 func (c *Client) AcceptCall(ctx context.Context, account *Account, callID, sdpAnswer string) error {
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"call_id":           callID,
 		"action":            "accept",
@@ -92,12 +92,12 @@ func (c *Client) SendCallPermissionRequest(ctx context.Context, account *Account
 		bodyText = "We'd like to call you to assist with your query."
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"recipient_type":    "individual",
 		"to":                phoneNumber,
 		"type":              "interactive",
-		"interactive": map[string]interface{}{
+		"interactive": map[string]any{
 			"type": "call_permission_request",
 			"action": map[string]string{
 				"name": "call_permission_request",
@@ -156,7 +156,7 @@ func (c *Client) GetCallPermission(ctx context.Context, account *Account, userPh
 // InitiateCall places an outgoing call to a WhatsApp user with an SDP offer.
 // Returns the call_id assigned by WhatsApp on success.
 func (c *Client) InitiateCall(ctx context.Context, account *Account, phoneNumber, sdpOffer string) (string, error) {
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"to":                phoneNumber,
 		"action":            "connect",

--- a/pkg/whatsapp/client.go
+++ b/pkg/whatsapp/client.go
@@ -68,7 +68,7 @@ func (c *Client) getBaseURL() string {
 }
 
 // doRequest performs an HTTP request to the Meta API
-func (c *Client) doRequest(ctx context.Context, method, url string, body interface{}, accessToken string) ([]byte, error) {
+func (c *Client) doRequest(ctx context.Context, method, url string, body any, accessToken string) ([]byte, error) {
 	var reqBody io.Reader
 	if body != nil {
 		jsonBody, err := json.Marshal(body)
@@ -325,8 +325,8 @@ func (c *Client) UploadMedia(ctx context.Context, account *Account, data []byte,
 }
 
 // sendMediaMessage is the shared implementation for all media message types.
-func (c *Client) sendMediaMessage(ctx context.Context, account *Account, phoneNumber, mediaType string, mediaFields map[string]interface{}) (string, error) {
-	payload := map[string]interface{}{
+func (c *Client) sendMediaMessage(ctx context.Context, account *Account, phoneNumber, mediaType string, mediaFields map[string]any) (string, error) {
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"recipient_type":    "individual",
 		"to":                phoneNumber,
@@ -358,35 +358,35 @@ func (c *Client) sendMediaMessage(ctx context.Context, account *Account, phoneNu
 
 // SendImageMessage sends an image message using a media ID
 func (c *Client) SendImageMessage(ctx context.Context, account *Account, phoneNumber, mediaID, caption string) (string, error) {
-	return c.sendMediaMessage(ctx, account, phoneNumber, "image", map[string]interface{}{
+	return c.sendMediaMessage(ctx, account, phoneNumber, "image", map[string]any{
 		"id": mediaID, "caption": caption,
 	})
 }
 
 // SendDocumentMessage sends a document message using a media ID
 func (c *Client) SendDocumentMessage(ctx context.Context, account *Account, phoneNumber, mediaID, filename, caption string) (string, error) {
-	return c.sendMediaMessage(ctx, account, phoneNumber, "document", map[string]interface{}{
+	return c.sendMediaMessage(ctx, account, phoneNumber, "document", map[string]any{
 		"id": mediaID, "filename": filename, "caption": caption,
 	})
 }
 
 // SendVideoMessage sends a video message using a media ID
 func (c *Client) SendVideoMessage(ctx context.Context, account *Account, phoneNumber, mediaID, caption string) (string, error) {
-	return c.sendMediaMessage(ctx, account, phoneNumber, "video", map[string]interface{}{
+	return c.sendMediaMessage(ctx, account, phoneNumber, "video", map[string]any{
 		"id": mediaID, "caption": caption,
 	})
 }
 
 // SendAudioMessage sends an audio message using a media ID
 func (c *Client) SendAudioMessage(ctx context.Context, account *Account, phoneNumber, mediaID string) (string, error) {
-	return c.sendMediaMessage(ctx, account, phoneNumber, "audio", map[string]interface{}{
+	return c.sendMediaMessage(ctx, account, phoneNumber, "audio", map[string]any{
 		"id": mediaID,
 	})
 }
 
 // MarkMessageRead sends a read receipt for a message
 func (c *Client) MarkMessageRead(ctx context.Context, account *Account, messageID string) error {
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"status":            "read",
 		"message_id":        messageID,
@@ -425,7 +425,7 @@ func (c *Client) ResumableUpload(ctx context.Context, account *Account, data []b
 	// Step 1: Create upload session
 	sessionURL := fmt.Sprintf("%s/%s/%s/uploads", c.getBaseURL(), account.APIVersion, account.AppID)
 
-	sessionPayload := map[string]interface{}{
+	sessionPayload := map[string]any{
 		"file_length": len(data),
 		"file_type":   mimeType,
 		"file_name":   filename,

--- a/pkg/whatsapp/flow.go
+++ b/pkg/whatsapp/flow.go
@@ -25,7 +25,7 @@ type FlowCreateResponse struct {
 // FlowUpdateResponse represents the response from updating flow assets
 type FlowUpdateResponse struct {
 	Success          bool        `json:"success"`
-	ValidationErrors interface{} `json:"validation_errors,omitempty"`
+	ValidationErrors any `json:"validation_errors,omitempty"`
 }
 
 // FlowPublishResponse represents the response from publishing a flow
@@ -57,8 +57,8 @@ type FlowListResponse struct {
 type FlowJSON struct {
 	Version       string        `json:"version"`
 	DataAPIVersion string       `json:"data_api_version,omitempty"`
-	RoutingModel  map[string]interface{} `json:"routing_model,omitempty"`
-	Screens       []interface{} `json:"screens"`
+	RoutingModel  map[string]any `json:"routing_model,omitempty"`
+	Screens       []any `json:"screens"`
 }
 
 // CreateFlow creates a new flow in Meta

--- a/pkg/whatsapp/message.go
+++ b/pkg/whatsapp/message.go
@@ -63,56 +63,56 @@ func (c *Client) SendInteractiveButtons(ctx context.Context, account *Account, p
 		return "", fmt.Errorf("maximum 10 buttons allowed")
 	}
 
-	var interactive map[string]interface{}
+	var interactive map[string]any
 
 	if len(buttons) <= 3 {
 		// Use button format
-		buttonsList := make([]map[string]interface{}, 0, len(buttons))
+		buttonsList := make([]map[string]any, 0, len(buttons))
 		for _, btn := range buttons {
 			title := btn.Title
 			if len(title) > 20 {
 				title = title[:20]
 			}
-			buttonsList = append(buttonsList, map[string]interface{}{
+			buttonsList = append(buttonsList, map[string]any{
 				"type": "reply",
-				"reply": map[string]interface{}{
+				"reply": map[string]any{
 					"id":    btn.ID,
 					"title": title,
 				},
 			})
 		}
 
-		interactive = map[string]interface{}{
+		interactive = map[string]any{
 			"type": "button",
-			"body": map[string]interface{}{
+			"body": map[string]any{
 				"text": bodyText,
 			},
-			"action": map[string]interface{}{
+			"action": map[string]any{
 				"buttons": buttonsList,
 			},
 		}
 	} else {
 		// Use list format for 4-10 items
-		rows := make([]map[string]interface{}, 0, len(buttons))
+		rows := make([]map[string]any, 0, len(buttons))
 		for _, btn := range buttons {
 			title := btn.Title
 			if len(title) > 24 {
 				title = title[:24]
 			}
-			rows = append(rows, map[string]interface{}{
+			rows = append(rows, map[string]any{
 				"id":    btn.ID,
 				"title": title,
 			})
 		}
 
-		interactive = map[string]interface{}{
+		interactive = map[string]any{
 			"type": "list",
-			"body": map[string]interface{}{
+			"body": map[string]any{
 				"text": bodyText,
 			},
-			"action": map[string]interface{}{
+			"action": map[string]any{
 				"button": "Select an option",
-				"sections": []map[string]interface{}{
+				"sections": []map[string]any{
 					{
 						"title": "Options",
 						"rows":  rows,
@@ -122,7 +122,7 @@ func (c *Client) SendInteractiveButtons(ctx context.Context, account *Account, p
 		}
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"recipient_type":    "individual",
 		"to":                phoneNumber,
@@ -165,21 +165,21 @@ func (c *Client) SendCTAURLButton(ctx context.Context, account *Account, phoneNu
 		buttonText = buttonText[:20]
 	}
 
-	interactive := map[string]interface{}{
+	interactive := map[string]any{
 		"type": "cta_url",
-		"body": map[string]interface{}{
+		"body": map[string]any{
 			"text": bodyText,
 		},
-		"action": map[string]interface{}{
+		"action": map[string]any{
 			"name": "cta_url",
-			"parameters": map[string]interface{}{
+			"parameters": map[string]any{
 				"display_text": buttonText,
 				"url":          url,
 			},
 		},
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"recipient_type":    "individual",
 		"to":                phoneNumber,
@@ -229,7 +229,7 @@ type TemplateParam struct {
 // SendTemplateMessage sends a template message
 // BodyParamsToComponents converts a bodyParams map into WhatsApp template components.
 // Supports both positional (numeric keys) and named parameters.
-func BodyParamsToComponents(bodyParams map[string]string) []map[string]interface{} {
+func BodyParamsToComponents(bodyParams map[string]string) []map[string]any {
 	if len(bodyParams) == 0 {
 		return nil
 	}
@@ -250,9 +250,9 @@ func BodyParamsToComponents(bodyParams map[string]string) []map[string]interface
 	}
 	sort.Strings(keys)
 
-	params := make([]map[string]interface{}, 0, len(bodyParams))
+	params := make([]map[string]any, 0, len(bodyParams))
 	for _, key := range keys {
-		param := map[string]interface{}{
+		param := map[string]any{
 			"type": "text",
 			"text": bodyParams[key],
 		}
@@ -262,7 +262,7 @@ func BodyParamsToComponents(bodyParams map[string]string) []map[string]interface
 		params = append(params, param)
 	}
 
-	return []map[string]interface{}{
+	return []map[string]any{
 		{
 			"type":       "body",
 			"parameters": params,
@@ -272,21 +272,21 @@ func BodyParamsToComponents(bodyParams map[string]string) []map[string]interface
 
 // BuildTemplateComponents builds the full WhatsApp template components array,
 // including an optional header component (for IMAGE/VIDEO/DOCUMENT) and body parameters.
-func BuildTemplateComponents(bodyParams map[string]string, headerType string, headerMediaID string) []map[string]interface{} {
-	var components []map[string]interface{}
+func BuildTemplateComponents(bodyParams map[string]string, headerType string, headerMediaID string) []map[string]any {
+	var components []map[string]any
 
 	// Add header component if media is provided
 	if headerMediaID != "" {
 		mediaType := strings.ToLower(headerType) // "image", "video", "document"
-		headerParam := map[string]interface{}{
+		headerParam := map[string]any{
 			"type": mediaType,
-			mediaType: map[string]interface{}{
+			mediaType: map[string]any{
 				"id": headerMediaID,
 			},
 		}
-		components = append(components, map[string]interface{}{
+		components = append(components, map[string]any{
 			"type":       "header",
-			"parameters": []map[string]interface{}{headerParam},
+			"parameters": []map[string]any{headerParam},
 		})
 	}
 
@@ -305,7 +305,7 @@ func BuildTemplateComponents(bodyParams map[string]string, headerType string, he
 // templateButtons is the JSONB buttons array from the template, used to determine button type.
 // URL buttons produce: {"type": "button", "sub_type": "url", "index": "0", "parameters": [{"type": "text", "text": "value"}]}
 // COPY_CODE buttons produce: {"type": "button", "sub_type": "copy_code", "index": "0", "parameters": [{"type": "coupon_code", "coupon_code": "value"}]}
-func ButtonURLParamsToComponents(buttonParams map[string]string, templateButtons ...[]interface{}) []map[string]interface{} {
+func ButtonURLParamsToComponents(buttonParams map[string]string, templateButtons ...[]any) []map[string]any {
 	if len(buttonParams) == 0 {
 		return nil
 	}
@@ -314,7 +314,7 @@ func ButtonURLParamsToComponents(buttonParams map[string]string, templateButtons
 	btnTypes := map[string]string{}
 	if len(templateButtons) > 0 {
 		for i, raw := range templateButtons[0] {
-			if btn, ok := raw.(map[string]interface{}); ok {
+			if btn, ok := raw.(map[string]any); ok {
 				if t, ok := btn["type"].(string); ok {
 					btnTypes[fmt.Sprintf("%d", i)] = strings.ToUpper(t)
 				}
@@ -328,24 +328,24 @@ func ButtonURLParamsToComponents(buttonParams map[string]string, templateButtons
 	}
 	sort.Strings(keys)
 
-	components := make([]map[string]interface{}, 0, len(buttonParams))
+	components := make([]map[string]any, 0, len(buttonParams))
 	for _, index := range keys {
 		value := buttonParams[index]
 		if btnTypes[index] == "COPY_CODE" {
-			components = append(components, map[string]interface{}{
+			components = append(components, map[string]any{
 				"type":     "button",
 				"sub_type": "copy_code",
 				"index":    index,
-				"parameters": []map[string]interface{}{
+				"parameters": []map[string]any{
 					{"type": "coupon_code", "coupon_code": value},
 				},
 			})
 		} else {
-			components = append(components, map[string]interface{}{
+			components = append(components, map[string]any{
 				"type":     "button",
 				"sub_type": "url",
 				"index":    index,
-				"parameters": []map[string]interface{}{
+				"parameters": []map[string]any{
 					{"type": "text", "text": value},
 				},
 			})
@@ -380,20 +380,20 @@ func (c *Client) SendFlowMessage(ctx context.Context, account *Account, phoneNum
 		ctaText = ctaText[:20]
 	}
 
-	interactive := map[string]interface{}{
+	interactive := map[string]any{
 		"type": "flow",
-		"body": map[string]interface{}{
+		"body": map[string]any{
 			"text": bodyText,
 		},
-		"action": map[string]interface{}{
+		"action": map[string]any{
 			"name": "flow",
-			"parameters": map[string]interface{}{
+			"parameters": map[string]any{
 				"flow_message_version": "3",
 				"flow_token":           flowToken,
 				"flow_id":              flowID,
 				"flow_cta":             ctaText,
 				"flow_action":          "navigate",
-				"flow_action_payload": map[string]interface{}{
+				"flow_action_payload": map[string]any{
 					"screen": firstScreen,
 				},
 			},
@@ -402,13 +402,13 @@ func (c *Client) SendFlowMessage(ctx context.Context, account *Account, phoneNum
 
 	// Add header if provided
 	if headerText != "" {
-		interactive["header"] = map[string]interface{}{
+		interactive["header"] = map[string]any{
 			"type": "text",
 			"text": headerText,
 		}
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"recipient_type":    "individual",
 		"to":                phoneNumber,
@@ -440,10 +440,10 @@ func (c *Client) SendFlowMessage(ctx context.Context, account *Account, phoneNum
 }
 
 // SendTemplateMessage sends a template message with optional components (header, body, buttons, etc.)
-func (c *Client) SendTemplateMessage(ctx context.Context, account *Account, phoneNumber, templateName, languageCode string, components []map[string]interface{}) (string, error) {
-	template := map[string]interface{}{
+func (c *Client) SendTemplateMessage(ctx context.Context, account *Account, phoneNumber, templateName, languageCode string, components []map[string]any) (string, error) {
+	template := map[string]any{
 		"name": templateName,
-		"language": map[string]interface{}{
+		"language": map[string]any{
 			"code": languageCode,
 		},
 	}
@@ -452,7 +452,7 @@ func (c *Client) SendTemplateMessage(ctx context.Context, account *Account, phon
 		template["components"] = components
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"messaging_product": "whatsapp",
 		"to":                phoneNumber,
 		"type":              "template",

--- a/pkg/whatsapp/template.go
+++ b/pkg/whatsapp/template.go
@@ -19,8 +19,8 @@ type TemplateSubmission struct {
 	HeaderContent   string
 	BodyContent     string
 	FooterContent   string
-	Buttons         []interface{}
-	SampleValues    []interface{} // For named: [{param_name: "name", value: "John"}, ...]
+	Buttons         []any
+	SampleValues    []any // For named: [{param_name: "name", value: "John"}, ...]
 }
 
 // SubmitTemplate submits a template to Meta's API (creates new or updates existing)
@@ -35,14 +35,14 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 	}
 
 	// Build components array
-	components := []map[string]interface{}{}
+	components := []map[string]any{}
 
 	// Check if using named parameters
 	isNamedParams := template.ParameterFormat == "named" || hasNamedParams(template.BodyContent)
 
 	// Header component (must come before BODY)
 	if template.HeaderType != "" && template.HeaderType != "NONE" {
-		header := map[string]interface{}{
+		header := map[string]any{
 			"type":   "HEADER",
 			"format": template.HeaderType,
 		}
@@ -54,14 +54,14 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 				if isNamedParams {
 					namedExamples := extractNamedExamplesForComponent(template.SampleValues, "header")
 					if len(namedExamples) > 0 {
-						header["example"] = map[string]interface{}{
+						header["example"] = map[string]any{
 							"header_text_named_params": namedExamples,
 						}
 					}
 				} else {
 					headerExamples := extractExamplesForComponent(template.SampleValues, "header")
 					if len(headerExamples) > 0 {
-						header["example"] = map[string]interface{}{
+						header["example"] = map[string]any{
 							"header_text": headerExamples,
 						}
 					}
@@ -70,7 +70,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 		case "IMAGE", "VIDEO", "DOCUMENT":
 			// Media headers require a handle - skip if not provided
 			if template.HeaderContent != "" {
-				header["example"] = map[string]interface{}{
+				header["example"] = map[string]any{
 					"header_handle": []string{template.HeaderContent},
 				}
 			} else {
@@ -84,7 +84,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 	}
 
 	// Body component (required)
-	body := map[string]interface{}{
+	body := map[string]any{
 		"type": "BODY",
 		"text": template.BodyContent,
 	}
@@ -93,7 +93,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 		if isNamedParams {
 			namedExamples := extractNamedExamplesForComponent(template.SampleValues, "body")
 			if len(namedExamples) > 0 {
-				body["example"] = map[string]interface{}{
+				body["example"] = map[string]any{
 					"body_text_named_params": namedExamples,
 				}
 			} else {
@@ -105,7 +105,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 		} else {
 			bodyExamples := extractExamplesForComponent(template.SampleValues, "body")
 			if len(bodyExamples) > 0 {
-				body["example"] = map[string]interface{}{
+				body["example"] = map[string]any{
 					"body_text": [][]string{bodyExamples},
 				}
 			} else {
@@ -120,7 +120,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 
 	// Footer component
 	if template.FooterContent != "" {
-		components = append(components, map[string]interface{}{
+		components = append(components, map[string]any{
 			"type": "FOOTER",
 			"text": template.FooterContent,
 		})
@@ -128,9 +128,9 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 
 	// Buttons component
 	if len(template.Buttons) > 0 {
-		buttons := []map[string]interface{}{}
+		buttons := []map[string]any{}
 		for _, btn := range template.Buttons {
-			if btnMap, ok := btn.(map[string]interface{}); ok {
+			if btnMap, ok := btn.(map[string]any); ok {
 				btnType, _ := btnMap["type"].(string)
 				btnType = strings.ToUpper(btnType)
 				btnText, _ := btnMap["text"].(string)
@@ -139,7 +139,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 					continue
 				}
 
-				button := map[string]interface{}{}
+				button := map[string]any{}
 
 				switch btnType {
 				case "QUICK_REPLY":
@@ -159,7 +159,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 							if ex != "" {
 								button["example"] = []string{ex}
 							}
-						case []interface{}:
+						case []any:
 							if len(ex) > 0 {
 								if s, ok := ex[0].(string); ok && s != "" {
 									button["example"] = []string{s}
@@ -187,7 +187,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 						if ex != "" {
 							button["example"] = ex
 						}
-					case []interface{}:
+					case []any:
 						if len(ex) > 0 {
 							if s, ok := ex[0].(string); ok && s != "" {
 								button["example"] = s
@@ -209,7 +209,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 			}
 		}
 		if len(buttons) > 0 {
-			components = append(components, map[string]interface{}{
+			components = append(components, map[string]any{
 				"type":    "BUTTONS",
 				"buttons": buttons,
 			})
@@ -217,15 +217,15 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 	}
 
 	// Build request payload
-	var payload map[string]interface{}
+	var payload map[string]any
 	if isUpdate {
 		// Update only sends components (name, language, category are immutable)
-		payload = map[string]interface{}{
+		payload = map[string]any{
 			"components": components,
 		}
 	} else {
 		// Create sends full template
-		payload = map[string]interface{}{
+		payload = map[string]any{
 			"name":       template.Name,
 			"language":   template.Language,
 			"category":   template.Category,
@@ -300,7 +300,7 @@ func (c *Client) DeleteTemplate(ctx context.Context, account *Account, templateN
 }
 
 // extractExamplesForComponent extracts example values for a specific component from sample_values
-func extractExamplesForComponent(sampleValues []interface{}, componentType string) []string {
+func extractExamplesForComponent(sampleValues []any, componentType string) []string {
 	type indexedSample struct {
 		index int
 		value string
@@ -308,7 +308,7 @@ func extractExamplesForComponent(sampleValues []interface{}, componentType strin
 	samples := []indexedSample{}
 
 	for _, sv := range sampleValues {
-		if svMap, ok := sv.(map[string]interface{}); ok {
+		if svMap, ok := sv.(map[string]any); ok {
 			comp, _ := svMap["component"].(string)
 			if comp == componentType {
 				value, _ := svMap["value"].(string)
@@ -324,7 +324,7 @@ func extractExamplesForComponent(sampleValues []interface{}, componentType strin
 			}
 			// Also support legacy format with "values" array
 			if svMap["component"] == componentType {
-				if values, ok := svMap["values"].([]interface{}); ok {
+				if values, ok := svMap["values"].([]any); ok {
 					for i, v := range values {
 						if str, ok := v.(string); ok {
 							samples = append(samples, indexedSample{index: i + 1, value: str})
@@ -388,11 +388,11 @@ func hasNamedParams(content string) bool {
 
 // extractNamedExamplesForComponent extracts named example values for Meta API format
 // Returns: [{"param_name": "name", "example": "John"}, ...]
-func extractNamedExamplesForComponent(sampleValues []interface{}, componentType string) []map[string]string {
+func extractNamedExamplesForComponent(sampleValues []any, componentType string) []map[string]string {
 	results := []map[string]string{}
 
 	for _, sv := range sampleValues {
-		if svMap, ok := sv.(map[string]interface{}); ok {
+		if svMap, ok := sv.(map[string]any); ok {
 			comp, _ := svMap["component"].(string)
 			// Match component type or accept if not specified (for body)
 			if comp == componentType || (comp == "" && componentType == "body") {


### PR DESCRIPTION
- Replace all interface{} with any alias (Go 1.18+) across 43 files
- Replace manual map copy loops with maps.Copy
- Simplify loop condition in transfer rotation (staticcheck QF1006)
- Remove embedded Header field from RTP selector (staticcheck QF1008)
- Suppress errcheck for defer Close() on short-lived readers