### PR TITLE
fix: improve call recording reliability and error handling

### DIFF
--- a/internal/calling/recorder.go
+++ b/internal/calling/recorder.go
@@ -36,6 +36,7 @@ type CallRecorder struct {
 	pageSeqNo     uint32
 	packetCount   int
 	stopped       bool
+	writeErr      error // first disk write error (sticky)
 
 	// Buffer packets into OGG pages (flush every N packets)
 	pageBuf       [][]byte
@@ -92,13 +93,14 @@ func (r *CallRecorder) WritePacket(opusData []byte) {
 }
 
 // Stop finalizes the OGG file and returns the path to the recording.
-// After Stop, WritePacket calls are no-ops.
-func (r *CallRecorder) Stop() (string, int) {
+// After Stop, WritePacket calls are no-ops. A non-nil error indicates
+// a disk write failed during recording, so the file may be incomplete.
+func (r *CallRecorder) Stop() (string, int, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.stopped {
-		return r.path, r.packetCount
+		return r.path, r.packetCount, r.writeErr
 	}
 	r.stopped = true
 
@@ -108,7 +110,7 @@ func (r *CallRecorder) Stop() (string, int) {
 	}
 
 	_ = r.file.Close()
-	return r.path, r.packetCount
+	return r.path, r.packetCount, r.writeErr
 }
 
 // PacketCount returns the number of packets written so far.
@@ -202,6 +204,9 @@ func (r *CallRecorder) flushPage(lastPage bool) {
 	binary.LittleEndian.PutUint32(page[22:26], checksum)
 
 	if _, err := r.file.Write(page); err != nil {
+		if r.writeErr == nil {
+			r.writeErr = err
+		}
 		return
 	}
 	r.pageSeqNo++

--- a/internal/calling/session.go
+++ b/internal/calling/session.go
@@ -588,12 +588,20 @@ func (m *Manager) finalizeRecording(orgID, callLogID uuid.UUID, callerRec, agent
 	var callerCount, agentCount int
 
 	if callerRec != nil {
-		callerPath, callerCount = callerRec.Stop()
+		var err error
+		callerPath, callerCount, err = callerRec.Stop()
 		defer func() { _ = os.Remove(callerPath) }()
+		if err != nil {
+			m.log.Error("Caller recording had write errors", "error", err, "call_log_id", callLogID)
+		}
 	}
 	if agentRec != nil {
-		agentPath, agentCount = agentRec.Stop()
+		var err error
+		agentPath, agentCount, err = agentRec.Stop()
 		defer func() { _ = os.Remove(agentPath) }()
+		if err != nil {
+			m.log.Error("Agent recording had write errors", "error", err, "call_log_id", callLogID)
+		}
 	}
 
 	maxCount := callerCount
@@ -605,7 +613,10 @@ func (m *Manager) finalizeRecording(orgID, callLogID uuid.UUID, callerRec, agent
 	}
 
 	// Duration from the longer stream (each packet = 20ms)
-	durationSecs := (maxCount * 20) / 1000
+	durationSecs := maxCount * 20 / 1000
+	if durationSecs == 0 && maxCount > 0 {
+		durationSecs = 1
+	}
 
 	// Merge the two direction files into one using FFmpeg.
 	// If only one direction was recorded, use it directly.
@@ -641,15 +652,22 @@ func (m *Manager) finalizeRecording(orgID, callLogID uuid.UUID, callerRec, agent
 
 	if err := m.s3.Upload(ctx, s3Key, f, "audio/ogg"); err != nil {
 		m.log.Error("Failed to upload recording to S3", "error", err, "call_log_id", callLogID)
+		if dbErr := m.db.Model(&models.CallLog{}).
+			Where("id = ?", callLogID).
+			Update("recording_error", err.Error()).Error; dbErr != nil {
+			m.log.Error("Failed to update call log with recording error", "error", dbErr, "call_log_id", callLogID)
+		}
 		return
 	}
 
-	m.db.Model(&models.CallLog{}).
+	if err := m.db.Model(&models.CallLog{}).
 		Where("id = ?", callLogID).
 		Updates(map[string]any{
 			"recording_s3_key":    s3Key,
 			"recording_duration": durationSecs,
-		})
+		}).Error; err != nil {
+		m.log.Error("Failed to update call log with recording metadata", "error", err, "s3_key", s3Key, "call_log_id", callLogID)
+	}
 
 	m.log.Info("Recording uploaded",
 		"call_log_id", callLogID,
@@ -669,7 +687,7 @@ func mergeRecordings(file1, file2 string) (string, error) {
 	outPath := out.Name()
 	_ = out.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "ffmpeg",

--- a/internal/models/call.go
+++ b/internal/models/call.go
@@ -59,6 +59,7 @@ type CallLog struct {
 	ErrorMessage      string        `gorm:"type:text" json:"error_message,omitempty"`
 	RecordingS3Key    string        `gorm:"size:500" json:"recording_s3_key,omitempty"`
 	RecordingDuration int           `gorm:"default:0" json:"recording_duration,omitempty"`
+	RecordingError    string        `gorm:"type:text" json:"recording_error,omitempty"`
 
 	// Relations
 	Contact *Contact `gorm:"foreignKey:ContactID" json:"contact,omitempty"`


### PR DESCRIPTION
- Surface disk write errors from CallRecorder.Stop() instead of silently producing corrupted files
- Check DB update error after S3 upload so metadata isn't silently lost
- Record S3 upload failures in call_logs.recording_error so failed recordings are distinguishable from disabled recordings
- Round up sub-second recordings to 1s (integer division truncated to 0)
- Increase FFmpeg merge timeout from 30s to 90s for long calls