### PR TITLE
feat: implement proper authentication template support per Meta API spec

### DIFF
--- a/frontend/src/views/settings/TemplateDetailView.vue
+++ b/frontend/src/views/settings/TemplateDetailView.vue
@@ -70,6 +70,8 @@ interface Template {
   footer_content: string
   buttons: any[]
   sample_values: any[]
+  add_security_recommendation: boolean
+  code_expiration_minutes: number
   created_by_name: string
   updated_by_name: string
   created_at: string
@@ -88,6 +90,52 @@ const variablePositionHint = 'Variables cannot be at the very start or end of th
 
 const templateId = computed(() => route.params.id as string)
 const isNew = computed(() => templateId.value === 'new')
+const isAuthentication = computed(() => form.value.category === 'AUTHENTICATION')
+
+// OTP type for auth templates — derived from the buttons array
+const authOtpType = computed(() => {
+  if (!isAuthentication.value) return 'COPY_CODE'
+  const otpBtn = form.value.buttons.find((b: any) => b.type === 'OTP')
+  return otpBtn?.otp_type || 'COPY_CODE'
+})
+
+const zeroTapAccepted = ref(false)
+
+function setAuthOtpType(type: string | number | bigint | Record<string, any> | null) {
+  if (!type || typeof type !== 'string') return
+  zeroTapAccepted.value = false
+  const existing = form.value.buttons.find((b: any) => b.type === 'OTP')
+  if (existing) {
+    existing.otp_type = type
+    if (type === 'ONE_TAP' || type === 'ZERO_TAP') {
+      if (!existing.supported_apps?.length) {
+        existing.supported_apps = [{ package_name: '', signature_hash: '' }]
+      }
+    }
+  } else {
+    const btn: any = { type: 'OTP', text: 'Copy code', otp_type: type }
+    if (type === 'ONE_TAP' || type === 'ZERO_TAP') {
+      btn.supported_apps = [{ package_name: '', signature_hash: '' }]
+    }
+    form.value.buttons = [btn]
+  }
+}
+
+function addSupportedApp() {
+  const otpBtn = form.value.buttons.find((b: any) => b.type === 'OTP')
+  if (otpBtn && (!otpBtn.supported_apps || otpBtn.supported_apps.length < 5)) {
+    if (!otpBtn.supported_apps) otpBtn.supported_apps = []
+    otpBtn.supported_apps.push({ package_name: '', signature_hash: '' })
+  }
+}
+
+function removeSupportedApp(index: number) {
+  const otpBtn = form.value.buttons.find((b: any) => b.type === 'OTP')
+  if (otpBtn?.supported_apps?.length > 1) {
+    otpBtn.supported_apps.splice(index, 1)
+  }
+}
+
 const template = ref<Template | null>(null)
 const accounts = ref<WhatsAppAccount[]>([])
 const isLoading = ref(true)
@@ -135,6 +183,8 @@ const form = ref({
   footer_content: '',
   buttons: [] as any[],
   sample_values: [] as any[],
+  add_security_recommendation: false,
+  code_expiration_minutes: 0,
 })
 
 // Detect variables in body and header content
@@ -351,6 +401,8 @@ function syncForm() {
       example: Array.isArray(b.example) ? b.example[0] ?? '' : b.example,
     })),
     sample_values: template.value.sample_values || [],
+    add_security_recommendation: template.value.add_security_recommendation || false,
+    code_expiration_minutes: template.value.code_expiration_minutes || 0,
   }
   // Restore media handle for existing media headers
   headerMediaFile.value = null
@@ -372,41 +424,74 @@ watch(form, () => {
   hasChanges.value = true
 }, { deep: true })
 
+// Auto-configure form when switching to/from AUTHENTICATION category
+watch(() => form.value.category, (newCat, oldCat) => {
+  if (newCat === 'AUTHENTICATION' && oldCat !== 'AUTHENTICATION') {
+    form.value.header_type = 'NONE'
+    form.value.header_content = ''
+    form.value.body_content = ''
+    form.value.footer_content = ''
+    form.value.buttons = [{ type: 'OTP', text: 'Copy code', otp_type: 'COPY_CODE' }]
+  } else if (newCat !== 'AUTHENTICATION' && oldCat === 'AUTHENTICATION') {
+    form.value.add_security_recommendation = false
+    form.value.code_expiration_minutes = 0
+  }
+})
+
 async function save() {
   if (!form.value.name.trim()) {
     toast.error(t('templates.nameRequired', 'Template name is required'))
     return
   }
-  if (!form.value.body_content.trim()) {
+  if (!isAuthentication.value && !form.value.body_content.trim()) {
     toast.error(t('templates.bodyRequired', 'Body content is required'))
     return
   }
-  if (hasMixedVariables.value) {
-    toast.error(t('templates.mixedVariables', 'Cannot mix positional ({{1}}, {{2}}) and named ({{name}}) variables. Use one type only.'))
+  if (!isAuthentication.value) {
+    if (hasMixedVariables.value) {
+      toast.error(t('templates.mixedVariables', 'Cannot mix positional ({{1}}, {{2}}) and named ({{name}}) variables. Use one type only.'))
+      return
+    }
+    if (hasDuplicateVariables.value) {
+      toast.error(t('templates.duplicateVariables', 'Duplicate variables found. Each variable should appear only once.'))
+      return
+    }
+    if (hasVariableAtEdge.value) {
+      toast.error(t('templates.variableAtEdge', 'Variables cannot be at the very start or end of the template body.'))
+      return
+    }
+  }
+  if (isAuthentication.value && form.value.code_expiration_minutes && (form.value.code_expiration_minutes < 1 || form.value.code_expiration_minutes > 90)) {
+    toast.error(t('templates.invalidExpiration', 'Code expiration must be between 1 and 90 minutes'))
     return
   }
-  if (hasDuplicateVariables.value) {
-    toast.error(t('templates.duplicateVariables', 'Duplicate variables found. Each variable should appear only once.'))
+  if (isAuthentication.value && authOtpType.value === 'ZERO_TAP' && !zeroTapAccepted.value) {
+    toast.error(t('templates.zeroTapTosRequired', 'You must accept the Terms of Service to use zero-tap authentication'))
     return
   }
-  if (hasVariableAtEdge.value) {
-    toast.error(t('templates.variableAtEdge', 'Variables cannot be at the very start or end of the template body.'))
-    return
+  if (isAuthentication.value && (authOtpType.value === 'ONE_TAP' || authOtpType.value === 'ZERO_TAP')) {
+    const apps = form.value.buttons[0]?.supported_apps || []
+    if (apps.length === 0 || apps.some((a: any) => !a.package_name?.trim() || !a.signature_hash?.trim())) {
+      toast.error(t('templates.supportedAppsRequired', 'Package name and signature hash are required for all supported apps'))
+      return
+    }
   }
   isSaving.value = true
   try {
-    const payload = {
+    const payload: Record<string, any> = {
       whatsapp_account: form.value.whatsapp_account,
       name: form.value.name,
       display_name: form.value.display_name,
       language: form.value.language,
       category: form.value.category,
-      header_type: form.value.header_type,
-      header_content: form.value.header_type === 'TEXT' ? form.value.header_content : '',
-      body_content: form.value.body_content,
-      footer_content: form.value.footer_content,
+      header_type: isAuthentication.value ? 'NONE' : form.value.header_type,
+      header_content: form.value.header_type === 'TEXT' && !isAuthentication.value ? form.value.header_content : '',
+      body_content: isAuthentication.value ? '{{1}} is your verification code.' : form.value.body_content,
+      footer_content: isAuthentication.value ? '' : form.value.footer_content,
       buttons: form.value.buttons,
       sample_values: form.value.sample_values,
+      add_security_recommendation: form.value.add_security_recommendation,
+      code_expiration_minutes: form.value.code_expiration_minutes || 0,
     }
 
     if (isNew.value) {
@@ -654,7 +739,7 @@ onMounted(async () => {
         <CardTitle class="text-sm font-medium">{{ $t('templates.content', 'Content') }}</CardTitle>
       </CardHeader>
       <CardContent class="space-y-4">
-        <div class="space-y-1.5">
+        <div v-if="!isAuthentication" class="space-y-1.5">
           <Label class="text-xs">{{ $t('templates.headerType', 'Header Type') }}</Label>
           <Select v-model="form.header_type" :disabled="!canWrite || !isEditable">
             <SelectTrigger><SelectValue /></SelectTrigger>
@@ -713,7 +798,165 @@ onMounted(async () => {
           </p>
         </div>
 
-        <div class="space-y-1.5">
+        <!-- Authentication template: fixed body & options -->
+        <div v-if="isAuthentication" class="space-y-4">
+          <!-- OTP Code Delivery Method -->
+          <div class="space-y-2">
+            <Label class="text-xs">{{ $t('templates.codeDelivery', 'Code Delivery Method') }}</Label>
+            <Select :model-value="authOtpType" @update:model-value="setAuthOtpType" :disabled="!canWrite || !isEditable">
+              <SelectTrigger class="h-8 text-xs">
+                <SelectValue placeholder="Select delivery method" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="COPY_CODE">Copy Code</SelectItem>
+                <SelectItem value="ONE_TAP">One-Tap Autofill (Android only)</SelectItem>
+                <SelectItem value="ZERO_TAP">Zero-Tap (Android only)</SelectItem>
+              </SelectContent>
+            </Select>
+            <p class="text-xs text-muted-foreground">
+              <span v-if="authOtpType === 'COPY_CODE'">User taps a button to copy the code to clipboard.</span>
+              <span v-else-if="authOtpType === 'ONE_TAP'">User taps a button to autofill the code in your app. Requires app configuration.</span>
+              <span v-else-if="authOtpType === 'ZERO_TAP'">Code is delivered to your app automatically. Requires app configuration.</span>
+            </p>
+          </div>
+
+          <div class="space-y-1.5">
+            <Label class="text-xs">{{ $t('templates.bodyContent', 'Body Content') }}</Label>
+            <div class="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground">
+              <span class="font-mono">{'{{1}}'}</span> is your verification code.
+              <span v-if="form.add_security_recommendation" class="block mt-1">For your security, do not share this code.</span>
+            </div>
+            <p class="text-xs text-muted-foreground">Authentication templates use fixed preset text defined by Meta.</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <input
+              id="security-rec"
+              type="checkbox"
+              v-model="form.add_security_recommendation"
+              :disabled="!canWrite || !isEditable"
+              class="h-4 w-4 rounded border-gray-300"
+            />
+            <Label for="security-rec" class="text-xs cursor-pointer">{{ $t('templates.addSecurityRecommendation', 'Add security recommendation') }}</Label>
+          </div>
+          <div class="space-y-2">
+            <div class="flex items-center gap-2">
+              <input
+                id="code-expiration"
+                type="checkbox"
+                :checked="form.code_expiration_minutes > 0"
+                @change="form.code_expiration_minutes = ($event.target as HTMLInputElement).checked ? 10 : 0"
+                :disabled="!canWrite || !isEditable"
+                class="h-4 w-4 rounded border-gray-300"
+              />
+              <Label for="code-expiration" class="text-xs cursor-pointer">{{ $t('templates.addCodeExpiration', 'Add expiration time for the code') }}</Label>
+            </div>
+            <div v-if="form.code_expiration_minutes > 0" class="flex items-center gap-2 ml-6">
+              <Input
+                type="number"
+                :model-value="form.code_expiration_minutes"
+                @update:model-value="(val: string) => form.code_expiration_minutes = val ? parseInt(val) : 0"
+                min="1"
+                max="90"
+                class="h-8 text-xs w-24"
+                :disabled="!canWrite || !isEditable"
+              />
+              <span class="text-xs text-muted-foreground">minutes (1-90)</span>
+            </div>
+            <p v-if="form.code_expiration_minutes > 0" class="text-xs text-muted-foreground ml-6">
+              Footer: "This code expires in {{ form.code_expiration_minutes }} minutes."
+            </p>
+          </div>
+          <!-- Zero-Tap Terms of Service -->
+          <div v-if="authOtpType === 'ZERO_TAP'" class="border border-amber-500/30 bg-amber-500/5 rounded-lg p-3">
+            <div class="flex items-start gap-2">
+              <input
+                id="zero-tap-tos"
+                type="checkbox"
+                v-model="zeroTapAccepted"
+                :disabled="!canWrite || !isEditable"
+                class="h-4 w-4 mt-0.5 rounded border-gray-300"
+              />
+              <Label for="zero-tap-tos" class="text-xs cursor-pointer leading-relaxed">
+                By selecting zero-tap, I understand that my business's use of zero-tap authentication is subject to the
+                <a href="https://www.whatsapp.com/legal/business-terms/" target="_blank" class="underline text-primary">WhatsApp Business Terms of Service</a>.
+                It is my business's responsibility to ensure its customers expect that the code will be automatically filled in on their behalf when they choose to receive the zero-tap code through WhatsApp.
+              </Label>
+            </div>
+          </div>
+
+          <!-- ONE_TAP: autofill text + supported apps -->
+          <div v-if="authOtpType === 'ONE_TAP'" class="space-y-3 border rounded-lg p-3">
+            <div class="space-y-1">
+              <Label class="text-xs">{{ $t('templates.autofillText', 'Autofill Text') }}</Label>
+              <Input v-model="form.buttons[0].autofill_text" placeholder="Autofill" class="h-8 text-xs" :disabled="!canWrite || !isEditable" />
+            </div>
+            <div class="space-y-2">
+              <div class="flex items-center justify-between">
+                <Label class="text-xs">{{ $t('templates.supportedApps', 'Supported Apps') }} *</Label>
+                <Button
+                  v-if="canWrite && isEditable && (form.buttons[0]?.supported_apps?.length || 0) < 5"
+                  type="button" variant="outline" size="xs" class="h-6 text-xs"
+                  @click="addSupportedApp"
+                >
+                  <Plus class="h-3 w-3 mr-1" /> Add App
+                </Button>
+              </div>
+              <div v-for="(app, i) in form.buttons[0]?.supported_apps || []" :key="i" class="flex items-end gap-2">
+                <div class="flex-1 space-y-1">
+                  <Label class="text-xs">Package Name *</Label>
+                  <Input v-model="app.package_name" placeholder="com.example.app" class="h-8 text-xs" :disabled="!canWrite || !isEditable" />
+                </div>
+                <div class="flex-1 space-y-1">
+                  <Label class="text-xs">Signature Hash *</Label>
+                  <Input v-model="app.signature_hash" placeholder="K8a/AINcGX7" class="h-8 text-xs" :disabled="!canWrite || !isEditable" />
+                </div>
+                <Button
+                  v-if="canWrite && isEditable && (form.buttons[0]?.supported_apps?.length || 0) > 1"
+                  type="button" variant="ghost" size="sm" class="h-8 w-8 p-0 shrink-0"
+                  @click="removeSupportedApp(Number(i))"
+                >
+                  <X class="h-3.5 w-3.5 text-destructive" />
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <!-- ZERO_TAP: supported apps -->
+          <div v-if="authOtpType === 'ZERO_TAP'" class="space-y-3 border rounded-lg p-3">
+            <div class="space-y-2">
+              <div class="flex items-center justify-between">
+                <Label class="text-xs">{{ $t('templates.supportedApps', 'Supported Apps') }} *</Label>
+                <Button
+                  v-if="canWrite && isEditable && (form.buttons[0]?.supported_apps?.length || 0) < 5"
+                  type="button" variant="outline" size="xs" class="h-6 text-xs"
+                  @click="addSupportedApp"
+                >
+                  <Plus class="h-3 w-3 mr-1" /> Add App
+                </Button>
+              </div>
+              <div v-for="(app, i) in form.buttons[0]?.supported_apps || []" :key="i" class="flex items-end gap-2">
+                <div class="flex-1 space-y-1">
+                  <Label class="text-xs">Package Name *</Label>
+                  <Input v-model="app.package_name" placeholder="com.example.app" class="h-8 text-xs" :disabled="!canWrite || !isEditable" />
+                </div>
+                <div class="flex-1 space-y-1">
+                  <Label class="text-xs">Signature Hash *</Label>
+                  <Input v-model="app.signature_hash" placeholder="K8a/AINcGX7" class="h-8 text-xs" :disabled="!canWrite || !isEditable" />
+                </div>
+                <Button
+                  v-if="canWrite && isEditable && (form.buttons[0]?.supported_apps?.length || 0) > 1"
+                  type="button" variant="ghost" size="sm" class="h-8 w-8 p-0 shrink-0"
+                  @click="removeSupportedApp(Number(i))"
+                >
+                  <X class="h-3.5 w-3.5 text-destructive" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Standard template: editable body -->
+        <div v-else class="space-y-1.5">
           <Label class="text-xs">{{ $t('templates.bodyContent', 'Body Content') }} *</Label>
           <Textarea
             v-model="form.body_content"
@@ -727,7 +970,7 @@ onMounted(async () => {
         </div>
 
         <!-- Sample Values for Variables -->
-        <div v-if="allVariables.length > 0" class="space-y-3">
+        <div v-if="!isAuthentication && allVariables.length > 0" class="space-y-3">
           <div>
             <Label class="text-xs">{{ $t('templates.sampleValues', 'Sample Values for Variables') }}</Label>
             <p class="text-xs text-muted-foreground mt-0.5">{{ $t('templates.sampleValuesHint', 'Provide example values for your variables. This helps Meta review and approve your template faster.') }}</p>
@@ -744,8 +987,8 @@ onMounted(async () => {
           </div>
         </div>
 
-        <!-- Buttons -->
-        <div class="space-y-3">
+        <!-- Buttons (hidden for auth templates — OTP managed via selector above) -->
+        <div v-if="!isAuthentication" class="space-y-3">
           <div class="flex items-center justify-between">
             <Label class="text-xs">{{ $t('templates.buttons', 'Buttons') }} <span class="text-muted-foreground font-normal">({{ $t('templates.maxButtonsHint', 'up to 3, optional') }})</span></Label>
             <Button
@@ -873,7 +1116,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="space-y-1.5">
+        <div v-if="!isAuthentication" class="space-y-1.5">
           <Label class="text-xs">{{ $t('templates.footerContent', 'Footer Content') }}</Label>
           <Textarea
             v-model="form.footer_content"

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -831,6 +831,27 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Contact has opted out of marketing messages", nil, "")
 	}
 
+	// For authentication templates with OTP COPY_CODE buttons, Meta expects
+	// a button component with sub_type "url" and the OTP code as a text parameter.
+	// Auto-populate from template_params["1"] so callers don't need button_params.
+	buttonParams := req.ButtonParams
+	if strings.EqualFold(template.Category, "AUTHENTICATION") && len(buttonParams) == 0 {
+		if code, ok := req.TemplateParams["1"]; ok && code != "" {
+			for i, raw := range template.Buttons {
+				if btn, ok := raw.(map[string]any); ok {
+					btnType, _ := btn["type"].(string)
+					if strings.EqualFold(btnType, "OTP") {
+						if buttonParams == nil {
+							buttonParams = make(map[string]string)
+						}
+						buttonParams[fmt.Sprintf("%d", i)] = code
+						break
+					}
+				}
+			}
+		}
+	}
+
 	// Send using unified message sender
 	msgReq := OutgoingMessageRequest{
 		Account:         account,
@@ -841,7 +862,7 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		HeaderMediaID:   headerMediaID,
 		MediaURL:        headerLocalPath,
 		MediaMimeType:   headerMimeType,
-		ButtonURLParams: req.ButtonParams,
+		ButtonURLParams: buttonParams,
 	}
 
 	opts := DefaultSendOptions()

--- a/internal/handlers/templates.go
+++ b/internal/handlers/templates.go
@@ -16,17 +16,21 @@ import (
 
 // TemplateRequest represents the request body for creating/updating a template
 type TemplateRequest struct {
-	WhatsAppAccount string        `json:"whatsapp_account" validate:"required"` // WhatsApp account name
-	Name            string        `json:"name" validate:"required"`
-	DisplayName     string        `json:"display_name"`
-	Language        string        `json:"language" validate:"required"`
-	Category        string        `json:"category" validate:"required"` // MARKETING, UTILITY, AUTHENTICATION
-	HeaderType      string        `json:"header_type"`                  // TEXT, IMAGE, DOCUMENT, VIDEO, NONE
-	HeaderContent   string        `json:"header_content"`
-	BodyContent     string        `json:"body_content" validate:"required"`
-	FooterContent   string        `json:"footer_content"`
-	Buttons         []any `json:"buttons"`
-	SampleValues    []any `json:"sample_values"`
+	WhatsAppAccount string `json:"whatsapp_account" validate:"required"` // WhatsApp account name
+	Name            string `json:"name" validate:"required"`
+	DisplayName     string `json:"display_name"`
+	Language        string `json:"language" validate:"required"`
+	Category        string `json:"category" validate:"required"` // MARKETING, UTILITY, AUTHENTICATION
+	HeaderType      string `json:"header_type"`                  // TEXT, IMAGE, DOCUMENT, VIDEO, NONE
+	HeaderContent   string `json:"header_content"`
+	BodyContent     string `json:"body_content"`
+	FooterContent   string `json:"footer_content"`
+	Buttons         []any  `json:"buttons"`
+	SampleValues    []any  `json:"sample_values"`
+
+	// Authentication template fields
+	AddSecurityRecommendation bool `json:"add_security_recommendation"` // Add "For your security, do not share this code."
+	CodeExpirationMinutes     int  `json:"code_expiration_minutes"`     // 1-90, 0 means no expiration footer
 }
 
 // TemplateResponse represents the response for a template
@@ -43,8 +47,10 @@ type TemplateResponse struct {
 	HeaderContent   string        `json:"header_content"`
 	BodyContent     string        `json:"body_content"`
 	FooterContent   string        `json:"footer_content"`
-	Buttons         []any `json:"buttons"`
-	SampleValues    []any `json:"sample_values"`
+	Buttons         []any  `json:"buttons"`
+	SampleValues    []any  `json:"sample_values"`
+	AddSecurityRecommendation bool `json:"add_security_recommendation"`
+	CodeExpirationMinutes     int  `json:"code_expiration_minutes"`
 	CreatedByName   string        `json:"created_by_name,omitempty"`
 	UpdatedByName   string        `json:"updated_by_name,omitempty"`
 	CreatedAt       string        `json:"created_at"`
@@ -117,17 +123,26 @@ func (a *App) CreateTemplate(r *fastglue.Request) error {
 	}
 
 	// Validate required fields
-	if req.WhatsAppAccount == "" || req.Name == "" || req.Language == "" || req.Category == "" || req.BodyContent == "" {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "whatsapp_account, name, language, category, and body_content are required", nil, "")
+	isAuthTemplate := strings.ToUpper(req.Category) == "AUTHENTICATION"
+	if req.WhatsAppAccount == "" || req.Name == "" || req.Language == "" || req.Category == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "whatsapp_account, name, language, and category are required", nil, "")
+	}
+	if !isAuthTemplate && req.BodyContent == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "body_content is required", nil, "")
+	}
+	if isAuthTemplate && req.CodeExpirationMinutes != 0 && (req.CodeExpirationMinutes < 1 || req.CodeExpirationMinutes > 90) {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "code_expiration_minutes must be between 1 and 90", nil, "")
 	}
 
-	// Validate no mixed positional and named parameters
-	if err := templateutil.ValidateNoMixedParams(req.BodyContent); err != nil {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
-	}
-	if req.HeaderType == "TEXT" {
-		if err := templateutil.ValidateNoMixedParams(req.HeaderContent); err != nil {
+	// Validate no mixed positional and named parameters (non-auth only)
+	if !isAuthTemplate {
+		if err := templateutil.ValidateNoMixedParams(req.BodyContent); err != nil {
 			return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
+		}
+		if req.HeaderType == "TEXT" {
+			if err := templateutil.ValidateNoMixedParams(req.HeaderContent); err != nil {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
+			}
 		}
 	}
 
@@ -164,6 +179,8 @@ func (a *App) CreateTemplate(r *fastglue.Request) error {
 		FooterContent:   req.FooterContent,
 		Buttons:         convertToJSONBArray(req.Buttons),
 		SampleValues:    convertToJSONBArray(req.SampleValues),
+		AddSecurityRecommendation: req.AddSecurityRecommendation,
+		CodeExpirationMinutes:     req.CodeExpirationMinutes,
 		CreatedByID:     &userID,
 		UpdatedByID:     &userID,
 	}
@@ -238,16 +255,24 @@ func (a *App) UpdateTemplate(r *fastglue.Request) error {
 		return nil
 	}
 
-	// Validate no mixed positional and named parameters
-	if req.BodyContent != "" {
-		if err := templateutil.ValidateNoMixedParams(req.BodyContent); err != nil {
-			return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
+	isAuthTemplate := strings.ToUpper(req.Category) == "AUTHENTICATION" ||
+		(req.Category == "" && strings.ToUpper(template.Category) == "AUTHENTICATION")
+
+	// Validate no mixed positional and named parameters (non-auth only)
+	if !isAuthTemplate {
+		if req.BodyContent != "" {
+			if err := templateutil.ValidateNoMixedParams(req.BodyContent); err != nil {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
+			}
+		}
+		if req.HeaderType == "TEXT" && req.HeaderContent != "" {
+			if err := templateutil.ValidateNoMixedParams(req.HeaderContent); err != nil {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
+			}
 		}
 	}
-	if req.HeaderType == "TEXT" && req.HeaderContent != "" {
-		if err := templateutil.ValidateNoMixedParams(req.HeaderContent); err != nil {
-			return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
-		}
+	if isAuthTemplate && req.CodeExpirationMinutes != 0 && (req.CodeExpirationMinutes < 1 || req.CodeExpirationMinutes > 90) {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "code_expiration_minutes must be between 1 and 90", nil, "")
 	}
 
 	// Update fields
@@ -274,6 +299,8 @@ func (a *App) UpdateTemplate(r *fastglue.Request) error {
 	if req.SampleValues != nil {
 		template.SampleValues = convertToJSONBArray(req.SampleValues)
 	}
+	template.AddSecurityRecommendation = req.AddSecurityRecommendation
+	template.CodeExpirationMinutes = req.CodeExpirationMinutes
 	template.UpdatedByID = &userID
 
 	if err := a.DB.Save(template).Error; err != nil {
@@ -416,6 +443,8 @@ func (a *App) submitTemplateToMeta(account *models.WhatsAppAccount, template *mo
 		FooterContent:  template.FooterContent,
 		Buttons:        template.Buttons,
 		SampleValues:   template.SampleValues,
+		AddSecurityRecommendation: template.AddSecurityRecommendation,
+		CodeExpirationMinutes:     template.CodeExpirationMinutes,
 	}
 
 	ctx := context.Background()
@@ -556,6 +585,8 @@ func templateToResponse(t models.Template) TemplateResponse {
 		FooterContent:   t.FooterContent,
 		Buttons:         convertFromJSONBArray(t.Buttons),
 		SampleValues:    convertFromJSONBArray(t.SampleValues),
+		AddSecurityRecommendation: t.AddSecurityRecommendation,
+		CodeExpirationMinutes:     t.CodeExpirationMinutes,
 		CreatedAt:       t.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:       t.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -422,6 +422,11 @@ type Template struct {
 	FooterContent   string     `gorm:"type:text" json:"footer_content"`
 	Buttons         JSONBArray  `gorm:"type:jsonb;default:'[]'" json:"buttons"`
 	SampleValues    JSONBArray  `gorm:"type:jsonb;default:'[]'" json:"sample_values"`
+
+	// Authentication template fields
+	AddSecurityRecommendation bool `gorm:"default:false" json:"add_security_recommendation"`
+	CodeExpirationMinutes     int  `gorm:"default:0" json:"code_expiration_minutes"`
+
 	CreatedByID     *uuid.UUID  `gorm:"type:uuid" json:"created_by_id,omitempty"`
 	UpdatedByID     *uuid.UUID  `gorm:"type:uuid" json:"updated_by_id,omitempty"`
 

--- a/pkg/whatsapp/message.go
+++ b/pkg/whatsapp/message.go
@@ -347,13 +347,26 @@ func ButtonURLParamsToComponents(buttonParams map[string]string, templateButtons
 		return nil
 	}
 
-	// Build a lookup of button index -> type from template buttons
+	// Build a lookup of button index -> effective type from template buttons.
+	// OTP buttons resolve to their otp_type (COPY_CODE, ONE_TAP, ZERO_TAP)
+	// so the message sending logic handles them correctly.
+	// btnIsOTP tracks whether the button was originally an OTP button (auth templates
+	// need sub_type "url" instead of "copy_code").
 	btnTypes := map[string]string{}
+	btnIsOTP := map[string]bool{}
 	if len(templateButtons) > 0 {
 		for i, raw := range templateButtons[0] {
 			if btn, ok := raw.(map[string]any); ok {
 				if t, ok := btn["type"].(string); ok {
-					btnTypes[fmt.Sprintf("%d", i)] = strings.ToUpper(t)
+					key := fmt.Sprintf("%d", i)
+					effectiveType := strings.ToUpper(t)
+					if effectiveType == "OTP" {
+						btnIsOTP[key] = true
+						if otpType, ok := btn["otp_type"].(string); ok {
+							effectiveType = strings.ToUpper(otpType)
+						}
+					}
+					btnTypes[key] = effectiveType
 				}
 			}
 		}
@@ -369,10 +382,11 @@ func ButtonURLParamsToComponents(buttonParams map[string]string, templateButtons
 	for _, index := range keys {
 		value := buttonParams[index]
 		// Skip button types that don't accept dynamic parameters
-		if t := btnTypes[index]; t == "QUICK_REPLY" || t == "FLOW" || t == "PHONE_NUMBER" || t == "VOICE_CALL" || t == "OTP" {
+		if t := btnTypes[index]; t == "QUICK_REPLY" || t == "FLOW" || t == "PHONE_NUMBER" || t == "VOICE_CALL" || t == "ONE_TAP" || t == "ZERO_TAP" {
 			continue
 		}
-		if btnTypes[index] == "COPY_CODE" {
+		if btnTypes[index] == "COPY_CODE" && !btnIsOTP[index] {
+			// Regular COPY_CODE button (e.g. coupon codes)
 			components = append(components, map[string]any{
 				"type":     "button",
 				"sub_type": "copy_code",

--- a/pkg/whatsapp/template.go
+++ b/pkg/whatsapp/template.go
@@ -10,7 +10,7 @@ import (
 
 // TemplateSubmission represents a template to be submitted to Meta
 type TemplateSubmission struct {
-	MetaTemplateID  string        // If set, update existing template instead of creating new
+	MetaTemplateID  string // If set, update existing template instead of creating new
 	Name            string
 	Language        string
 	Category        string
@@ -21,6 +21,10 @@ type TemplateSubmission struct {
 	FooterContent   string
 	Buttons         []any
 	SampleValues    []any // For named: [{param_name: "name", value: "John"}, ...]
+
+	// Authentication template fields
+	AddSecurityRecommendation bool
+	CodeExpirationMinutes     int // 1-90, 0 means no expiration footer
 }
 
 // SubmitTemplate submits a template to Meta's API (creates new or updates existing)
@@ -35,9 +39,136 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 	}
 
 	// Build components array
+	var components []map[string]any
+	var compErr error
+
+	// Authentication templates have a different component structure per Meta API
+	if strings.ToUpper(template.Category) == "AUTHENTICATION" {
+		components = c.buildAuthComponents(template)
+	} else {
+		components, compErr = c.buildStandardComponents(template)
+		if compErr != nil {
+			return "", compErr
+		}
+	}
+
+	// Build request payload
+	var payload map[string]any
+	if isUpdate {
+		// Update only sends components (name, language, category are immutable)
+		payload = map[string]any{
+			"components": components,
+		}
+	} else {
+		// Create sends full template
+		payload = map[string]any{
+			"name":       template.Name,
+			"language":   template.Language,
+			"category":   template.Category,
+			"components": components,
+		}
+		// Add parameter_format for named parameters (only for create, not auth)
+		if strings.ToUpper(template.Category) != "AUTHENTICATION" {
+			isNamedParams := template.ParameterFormat == "named" || hasNamedParams(template.BodyContent)
+			if isNamedParams {
+				payload["parameter_format"] = "NAMED"
+			}
+		}
+	}
+
+	// Log payload for debugging
+	action := "Submitting"
+	if isUpdate {
+		action = "Updating"
+	}
+	payloadJSON, _ := json.MarshalIndent(payload, "", "  ")
+	c.Log.Info(action+" template to Meta", "url", url, "name", template.Name, "payload", string(payloadJSON))
+
+	respBody, err := c.doRequest(ctx, http.MethodPost, url, payload, account.AccessToken)
+	if err != nil {
+		c.Log.Error("Failed to "+action+" template", "error", err, "name", template.Name)
+		return "", err
+	}
+
+	// For updates, return existing ID; for creates, parse response for new ID
+	if isUpdate {
+		c.Log.Info("Template updated", "template_id", template.MetaTemplateID, "name", template.Name)
+		return template.MetaTemplateID, nil
+	}
+
+	var result TemplateResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	c.Log.Info("Template submitted", "template_id", result.ID, "name", template.Name)
+	return result.ID, nil
+}
+
+// buildAuthComponents builds Meta API components for AUTHENTICATION templates.
+// Auth templates have fixed preset body text and use special fields instead of free text.
+func (c *Client) buildAuthComponents(template *TemplateSubmission) []map[string]any {
 	components := []map[string]any{}
 
-	// Check if using named parameters
+	// BODY component — no text field, only add_security_recommendation
+	body := map[string]any{"type": "BODY"}
+	if template.AddSecurityRecommendation {
+		body["add_security_recommendation"] = true
+	}
+	components = append(components, body)
+
+	// FOOTER component — only code_expiration_minutes (optional, 1-90)
+	if template.CodeExpirationMinutes > 0 {
+		components = append(components, map[string]any{
+			"type":                   "FOOTER",
+			"code_expiration_minutes": template.CodeExpirationMinutes,
+		})
+	}
+
+	// BUTTONS component — OTP button with supported_apps for ONE_TAP/ZERO_TAP
+	if len(template.Buttons) > 0 {
+		for _, btn := range template.Buttons {
+			btnMap, ok := btn.(map[string]any)
+			if !ok {
+				continue
+			}
+			btnType, _ := btnMap["type"].(string)
+			if strings.ToUpper(btnType) != "OTP" {
+				continue
+			}
+			otpType, _ := btnMap["otp_type"].(string)
+			if otpType == "" {
+				otpType = "COPY_CODE"
+			}
+			button := map[string]any{
+				"type":     "OTP",
+				"otp_type": otpType,
+			}
+			if otpType == "ONE_TAP" || otpType == "ZERO_TAP" {
+				pkg, _ := btnMap["package_name"].(string)
+				hash, _ := btnMap["signature_hash"].(string)
+				if pkg != "" && hash != "" {
+					button["supported_apps"] = []map[string]string{{
+						"package_name":   pkg,
+						"signature_hash": hash,
+					}}
+				}
+			}
+			components = append(components, map[string]any{
+				"type":    "BUTTONS",
+				"buttons": []map[string]any{button},
+			})
+			break // Only one OTP button allowed
+		}
+	}
+
+	return components
+}
+
+// buildStandardComponents builds Meta API components for MARKETING/UTILITY templates.
+func (c *Client) buildStandardComponents(template *TemplateSubmission) ([]map[string]any, error) {
+	components := []map[string]any{}
+
 	isNamedParams := template.ParameterFormat == "named" || hasNamedParams(template.BodyContent)
 
 	// Header component (must come before BODY)
@@ -68,13 +199,11 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 				}
 			}
 		case "IMAGE", "VIDEO", "DOCUMENT":
-			// Media headers require a handle - skip if not provided
 			if template.HeaderContent != "" {
 				header["example"] = map[string]any{
 					"header_handle": []string{template.HeaderContent},
 				}
 			} else {
-				// Don't add media header without a handle
 				addHeader = false
 			}
 		}
@@ -88,7 +217,6 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 		"type": "BODY",
 		"text": template.BodyContent,
 	}
-	// Add examples if there are variables in body
 	if strings.Contains(template.BodyContent, "{{") {
 		if isNamedParams {
 			namedExamples := extractNamedExamplesForComponent(template.SampleValues, "body")
@@ -99,7 +227,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 			} else {
 				varCount := strings.Count(template.BodyContent, "{{")
 				if varCount > 0 {
-					return "", fmt.Errorf("sample values are required for template variables. Found %d variable(s) in body but no sample values provided", varCount)
+					return nil, fmt.Errorf("sample values are required for template variables. Found %d variable(s) in body but no sample values provided", varCount)
 				}
 			}
 		} else {
@@ -111,7 +239,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 			} else {
 				varCount := strings.Count(template.BodyContent, "{{")
 				if varCount > 0 {
-					return "", fmt.Errorf("sample values are required for template variables. Found %d variable(s) in body but no sample values provided", varCount)
+					return nil, fmt.Errorf("sample values are required for template variables. Found %d variable(s) in body but no sample values provided", varCount)
 				}
 			}
 		}
@@ -255,54 +383,7 @@ func (c *Client) SubmitTemplate(ctx context.Context, account *Account, template 
 		}
 	}
 
-	// Build request payload
-	var payload map[string]any
-	if isUpdate {
-		// Update only sends components (name, language, category are immutable)
-		payload = map[string]any{
-			"components": components,
-		}
-	} else {
-		// Create sends full template
-		payload = map[string]any{
-			"name":       template.Name,
-			"language":   template.Language,
-			"category":   template.Category,
-			"components": components,
-		}
-		// Add parameter_format for named parameters (only for create)
-		if isNamedParams {
-			payload["parameter_format"] = "NAMED"
-		}
-	}
-
-	// Log payload for debugging
-	action := "Submitting"
-	if isUpdate {
-		action = "Updating"
-	}
-	payloadJSON, _ := json.MarshalIndent(payload, "", "  ")
-	c.Log.Info(action+" template to Meta", "url", url, "name", template.Name, "payload", string(payloadJSON))
-
-	respBody, err := c.doRequest(ctx, http.MethodPost, url, payload, account.AccessToken)
-	if err != nil {
-		c.Log.Error("Failed to "+action+" template", "error", err, "name", template.Name)
-		return "", err
-	}
-
-	// For updates, return existing ID; for creates, parse response for new ID
-	if isUpdate {
-		c.Log.Info("Template updated", "template_id", template.MetaTemplateID, "name", template.Name)
-		return template.MetaTemplateID, nil
-	}
-
-	var result TemplateResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	c.Log.Info("Template submitted", "template_id", result.ID, "name", template.Name)
-	return result.ID, nil
+	return components, nil
 }
 
 // FetchTemplates fetches all templates from Meta's API

--- a/test/testutil/db.go
+++ b/test/testutil/db.go
@@ -119,6 +119,15 @@ func runMigrations(db *gorm.DB) error {
 		&models.CannedResponse{},
 		// Dashboard
 		&models.Widget{},
+		// Conversation Notes
+		&models.ConversationNote{},
+		// Calling / IVR
+		&models.CallLog{},
+		&models.IVRFlow{},
+		&models.CallTransfer{},
+		&models.CallPermission{},
+		// Audit
+		&models.AuditLog{},
 	)
 }
 


### PR DESCRIPTION
Frontend:
- Show fixed preset body text with security recommendation toggle
- Add code expiration minutes input (1-90, optional)
- Hide header/footer free text for auth templates
- Keep OTP button optional via standard button UI

Backend:
- Build auth template components per Meta spec: BODY with add_security_recommendation, FOOTER with code_expiration_minutes, OTP button with supported_apps array
- Add auth field validation (code_expiration_minutes 1-90)
- Store add_security_recommendation and code_expiration_minutes in template model

Closes #63