### PR TITLE
fix: handle GetOrCreateContact error to prevent nil pointer panic

### DIFF
--- a/internal/handlers/chatbot_processor.go
+++ b/internal/handlers/chatbot_processor.go
@@ -128,7 +128,11 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 	}
 
 	// Get or create contact (always do this for all incoming messages)
-	contact, isNewContact, _ := contactutil.GetOrCreateContact(a.DB, account.OrganizationID, msg.From, profileName)
+	contact, isNewContact, err := contactutil.GetOrCreateContact(a.DB, account.OrganizationID, msg.From, profileName)
+	if err != nil {
+		a.Log.Error("Failed to get or create contact", "from", msg.From, "error", err)
+		return
+	}
 
 	// Store BSUID if provided and not already set
 	if msg.FromUserID != "" && contact.BSUID != msg.FromUserID {


### PR DESCRIPTION
The error from GetOrCreateContact was silently discarded, causing a nil pointer dereference panic when the DB call failed. Log the error and return early instead.

Closes #325