### PR TITLE
Fix/security hardening

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -529,6 +529,34 @@ func setupRoutes(g *fastglue.Fastglue, app *handlers.App, lo logf.Logger, basePa
 		return r
 	})
 
+	// Global rate limit on all /api/ routes, keyed by user ID (or IP if unauthenticated).
+	// Runs after auth so the user identity is available.
+	if cfg.RateLimit.Enabled {
+		apiMax := cfg.RateLimit.APIMaxRequests
+		if apiMax == 0 {
+			apiMax = 200
+		}
+		apiWindow := cfg.RateLimit.APIWindowSeconds
+		if apiWindow == 0 {
+			apiWindow = 60
+		}
+		apiRL := middleware.UserAwareRateLimit(middleware.RateLimitOpts{
+			Redis:      rdb,
+			Log:        lo,
+			Max:        apiMax,
+			Window:     time.Duration(apiWindow) * time.Second,
+			KeyPrefix:  "api_global",
+			TrustProxy: cfg.RateLimit.TrustProxy,
+		})
+		g.Before(func(r *fastglue.Request) *fastglue.Request {
+			path := string(r.RequestCtx.Path())
+			if len(path) > 4 && path[:4] == "/api" {
+				return apiRL(r)
+			}
+			return r
+		})
+	}
+
 	// Role-based access control middleware
 	g.Before(func(r *fastglue.Request) *fastglue.Request {
 		method := string(r.RequestCtx.Method())

--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -131,6 +131,11 @@ func runServer(args []string) {
 		lo.Warn("Debug mode is enabled in production! This may expose sensitive information.")
 	}
 
+	// Require explicit CORS origins in production
+	if cfg.App.Environment == "production" && cfg.Server.AllowedOrigins == "" {
+		lo.Fatal("server.allowed_origins must be set in production (e.g. \"https://app.example.com\")")
+	}
+
 	// Set log level based on environment
 	if cfg.App.Environment == "production" {
 		lo = logf.New(logf.Opts{

--- a/config.example.toml
+++ b/config.example.toml
@@ -64,6 +64,8 @@ refresh_max_attempts = 30      # Max token refresh attempts per IP per window
 sso_max_attempts = 10          # Max SSO init/callback attempts per IP per window
 window_seconds = 60            # Time window in seconds
 trust_proxy = false            # Trust X-Forwarded-For / X-Real-IP headers (set true behind reverse proxy)
+api_max_requests = 200         # Max requests per IP per window for all /api/ routes (0 = 200)
+api_window_seconds = 60        # Time window for global API rate limit (0 = 60)
 
 # Text-to-Speech for IVR greetings (optional, requires piper + opusenc installed)
 # Download piper: https://github.com/rhasspy/piper/releases (standalone binary)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,6 +136,8 @@ type RateLimitConfig struct {
 	SSOMaxAttempts      int  `koanf:"sso_max_attempts"`
 	WindowSeconds       int  `koanf:"window_seconds"`
 	TrustProxy          bool `koanf:"trust_proxy"`
+	APIMaxRequests      int  `koanf:"api_max_requests"`
+	APIWindowSeconds    int  `koanf:"api_window_seconds"`
 }
 
 // Load loads configuration from file and environment variables

--- a/internal/handlers/custom_actions.go
+++ b/internal/handlers/custom_actions.go
@@ -557,7 +557,16 @@ func (a *App) executeJavaScriptAction(action models.CustomAction, context map[st
 				result.Clipboard = clip
 			}
 			if url, ok := jsResult["url"].(string); ok {
-				result.RedirectURL = url
+				tokenBytes := make([]byte, 16)
+				_, _ = rand.Read(tokenBytes)
+				token := hex.EncodeToString(tokenBytes)
+				redirectTokenMutex.Lock()
+				redirectTokens[token] = redirectToken{
+					URL:       url,
+					ExpiresAt: time.Now().Add(30 * time.Second),
+				}
+				redirectTokenMutex.Unlock()
+				result.RedirectURL = "/api/custom-actions/redirect/" + token
 			}
 			if msg, ok := jsResult["message"].(string); ok {
 				result.Message = msg

--- a/internal/handlers/custom_actions_test.go
+++ b/internal/handlers/custom_actions_test.go
@@ -831,6 +831,41 @@ func TestApp_ExecuteCustomAction(t *testing.T) {
 		assert.Equal(t, "success", resp.Data.Toast.Type)
 	})
 
+	t.Run("JavaScript_URL_WrappedInRedirectToken", func(t *testing.T) {
+		t.Parallel()
+
+		app := newTestApp(t, withHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+		contact := testutil.CreateTestContact(t, app.DB, org.ID)
+
+		action := createTestCustomAction(t, app, org.ID, "Open External", models.ActionTypeJavascript,
+			map[string]interface{}{
+				"code": `return { url: "https://evil.example.com/phish" }`,
+			}, true, 0)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"contact_id": contact.ID.String(),
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+		testutil.SetPathParam(req, "id", action.ID.String())
+
+		err := app.ExecuteCustomAction(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+		var resp struct {
+			Data handlers.ActionResult `json:"data"`
+		}
+		err = json.Unmarshal(testutil.GetResponseBody(req), &resp)
+		require.NoError(t, err)
+		assert.True(t, resp.Data.Success)
+		// URL must be wrapped in a redirect token, never returned raw
+		assert.Contains(t, resp.Data.RedirectURL, "/api/custom-actions/redirect/")
+		assert.NotContains(t, resp.Data.RedirectURL, "evil.example.com",
+			"raw external URL must not be returned to the client")
+	})
+
 	t.Run("InactiveAction", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/handlers/webhook.go
+++ b/internal/handlers/webhook.go
@@ -244,8 +244,28 @@ func (a *App) WebhookHandler(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid payload", nil, "")
 	}
 
-	// Track if signature has been verified (only need to verify once per request)
-	signatureVerified := false
+	// Verify webhook signature before processing any fields.
+	// Find a phoneNumberID from any change to look up the account's AppSecret.
+	if len(signature) > 0 {
+		for _, entry := range payload.Entry {
+			for _, change := range entry.Changes {
+				phoneNumberID := change.Value.Metadata.PhoneNumberID
+				if phoneNumberID == "" {
+					continue
+				}
+				account, err := a.getWhatsAppAccountCached(phoneNumberID)
+				if err != nil || account.AppSecret == "" {
+					continue
+				}
+				if !verifyWebhookSignature(body, signature, []byte(account.AppSecret)) {
+					a.Log.Warn("Invalid webhook signature", "phone_id", phoneNumberID)
+					return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Invalid signature", nil, "")
+				}
+				a.Log.Debug("Webhook signature verified successfully")
+				break
+			}
+		}
+	}
 
 	// Process each entry
 	for _, entry := range payload.Entry {
@@ -308,19 +328,6 @@ func (a *App) WebhookHandler(r *fastglue.Request) error {
 			}
 
 			phoneNumberID := change.Value.Metadata.PhoneNumberID
-
-			// Verify webhook signature on first message processing (uses cached account)
-			if !signatureVerified && len(signature) > 0 && phoneNumberID != "" {
-				account, err := a.getWhatsAppAccountCached(phoneNumberID)
-				if err == nil && account.AppSecret != "" {
-					if !verifyWebhookSignature(body, signature, []byte(account.AppSecret)) {
-						a.Log.Warn("Invalid webhook signature", "phone_id", phoneNumberID)
-						return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Invalid signature", nil, "")
-					}
-					a.Log.Debug("Webhook signature verified successfully")
-				}
-				signatureVerified = true
-			}
 
 			// Process messages
 			for _, msg := range change.Value.Messages {

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/valyala/fasthttp"
 	"github.com/zerodha/fastglue"
@@ -59,6 +60,53 @@ func RateLimit(opts RateLimitOpts) fastglue.FastMiddleware {
 				retryAfter = 1
 			}
 
+			r.RequestCtx.Response.Header.Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+			_ = r.SendErrorEnvelope(fasthttp.StatusTooManyRequests,
+				"Too many requests. Please try again later.", nil, "")
+			return nil
+		}
+
+		return r
+	}
+}
+
+// UserAwareRateLimit returns a middleware that keys by authenticated user ID
+// when available, falling back to client IP for unauthenticated requests.
+// This prevents shared-IP environments (VPNs, offices) from pooling quotas.
+func UserAwareRateLimit(opts RateLimitOpts) fastglue.FastMiddleware {
+	return func(r *fastglue.Request) *fastglue.Request {
+		identity := ""
+		if uid, ok := r.RequestCtx.UserValue(ContextKeyUserID).(uuid.UUID); ok && uid != uuid.Nil {
+			identity = "u:" + uid.String()
+		} else {
+			identity = "ip:" + extractClientIP(r, opts.TrustProxy)
+		}
+		key := fmt.Sprintf("ratelimit:%s:%s", opts.KeyPrefix, identity)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		count, err := opts.Redis.Incr(ctx, key).Result()
+		if err != nil {
+			opts.Log.Error("Rate limit Redis INCR failed", "error", err, "key", key)
+			return r
+		}
+
+		if count == 1 {
+			if err := opts.Redis.Expire(ctx, key, opts.Window).Err(); err != nil {
+				opts.Log.Error("Rate limit Redis EXPIRE failed", "error", err, "key", key)
+			}
+		}
+
+		if count > int64(opts.Max) {
+			ttl, err := opts.Redis.TTL(ctx, key).Result()
+			if err != nil || ttl < 0 {
+				ttl = opts.Window
+			}
+			retryAfter := int(ttl.Seconds())
+			if retryAfter < 1 {
+				retryAfter = 1
+			}
 			r.RequestCtx.Response.Header.Set("Retry-After", fmt.Sprintf("%d", retryAfter))
 			_ = r.SendErrorEnvelope(fasthttp.StatusTooManyRequests,
 				"Too many requests. Please try again later.", nil, "")

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,182 @@
+package middleware_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shridarpatil/whatomate/internal/middleware"
+	"github.com/shridarpatil/whatomate/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+	"github.com/zerodha/fastglue"
+)
+
+func TestRateLimit_AllowsUnderLimit(t *testing.T) {
+	t.Parallel()
+	rdb := testutil.SetupTestRedis(t)
+	if rdb == nil {
+		t.Skip("TEST_REDIS_URL not set")
+	}
+
+	rl := middleware.RateLimit(middleware.RateLimitOpts{
+		Redis:     rdb,
+		Log:       testutil.NopLogger(),
+		Max:       5,
+		Window:    10 * time.Second,
+		KeyPrefix: "test_allow_" + uuid.New().String()[:8],
+	})
+
+	for i := 0; i < 5; i++ {
+		req := newTestRequest()
+		req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.1:12345"))
+		result := rl(req)
+		require.NotNil(t, result, "request %d should be allowed", i+1)
+	}
+}
+
+func TestRateLimit_BlocksOverLimit(t *testing.T) {
+	t.Parallel()
+	rdb := testutil.SetupTestRedis(t)
+	if rdb == nil {
+		t.Skip("TEST_REDIS_URL not set")
+	}
+
+	prefix := "test_block_" + uuid.New().String()[:8]
+	rl := middleware.RateLimit(middleware.RateLimitOpts{
+		Redis:     rdb,
+		Log:       testutil.NopLogger(),
+		Max:       3,
+		Window:    10 * time.Second,
+		KeyPrefix: prefix,
+	})
+
+	for i := 0; i < 3; i++ {
+		req := newTestRequest()
+		req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.2:12345"))
+		result := rl(req)
+		require.NotNil(t, result)
+	}
+
+	// 4th request should be blocked
+	req := newTestRequest()
+	req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.2:12345"))
+	result := rl(req)
+	assert.Nil(t, result, "request over limit should be blocked")
+	assert.Equal(t, fasthttp.StatusTooManyRequests, req.RequestCtx.Response.StatusCode())
+	assert.NotEmpty(t, string(req.RequestCtx.Response.Header.Peek("Retry-After")))
+}
+
+func TestRateLimit_DifferentIPsGetSeparateLimits(t *testing.T) {
+	t.Parallel()
+	rdb := testutil.SetupTestRedis(t)
+	if rdb == nil {
+		t.Skip("TEST_REDIS_URL not set")
+	}
+
+	prefix := "test_sep_" + uuid.New().String()[:8]
+	rl := middleware.RateLimit(middleware.RateLimitOpts{
+		Redis:     rdb,
+		Log:       testutil.NopLogger(),
+		Max:       2,
+		Window:    10 * time.Second,
+		KeyPrefix: prefix,
+	})
+
+	// Exhaust limit for IP A
+	for i := 0; i < 2; i++ {
+		req := newTestRequest()
+		req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.3:12345"))
+		require.NotNil(t, rl(req))
+	}
+
+	// IP B should still be allowed
+	req := newTestRequest()
+	req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.4:12345"))
+	result := rl(req)
+	assert.NotNil(t, result, "different IP should have its own limit")
+}
+
+func TestUserAwareRateLimit_KeysByUserID(t *testing.T) {
+	t.Parallel()
+	rdb := testutil.SetupTestRedis(t)
+	if rdb == nil {
+		t.Skip("TEST_REDIS_URL not set")
+	}
+
+	prefix := "test_user_" + uuid.New().String()[:8]
+	rl := middleware.UserAwareRateLimit(middleware.RateLimitOpts{
+		Redis:     rdb,
+		Log:       testutil.NopLogger(),
+		Max:       2,
+		Window:    10 * time.Second,
+		KeyPrefix: prefix,
+	})
+
+	userA := uuid.New()
+	userB := uuid.New()
+
+	// Exhaust limit for user A (same IP for both users — simulates VPN)
+	for i := 0; i < 2; i++ {
+		req := newTestRequest()
+		req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.5:12345"))
+		req.RequestCtx.SetUserValue(middleware.ContextKeyUserID, userA)
+		require.NotNil(t, rl(req), "user A request %d should be allowed", i+1)
+	}
+
+	// User A is now blocked
+	req := newTestRequest()
+	req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.5:12345"))
+	req.RequestCtx.SetUserValue(middleware.ContextKeyUserID, userA)
+	assert.Nil(t, rl(req), "user A should be blocked after exceeding limit")
+
+	// User B on the SAME IP should still be allowed
+	req = newTestRequest()
+	req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.5:12345"))
+	req.RequestCtx.SetUserValue(middleware.ContextKeyUserID, userB)
+	assert.NotNil(t, rl(req), "user B on same IP should have its own limit")
+}
+
+func TestUserAwareRateLimit_FallsBackToIP_WhenUnauthenticated(t *testing.T) {
+	t.Parallel()
+	rdb := testutil.SetupTestRedis(t)
+	if rdb == nil {
+		t.Skip("TEST_REDIS_URL not set")
+	}
+
+	prefix := "test_noauth_" + uuid.New().String()[:8]
+	rl := middleware.UserAwareRateLimit(middleware.RateLimitOpts{
+		Redis:     rdb,
+		Log:       testutil.NopLogger(),
+		Max:       2,
+		Window:    10 * time.Second,
+		KeyPrefix: prefix,
+	})
+
+	// No user ID set — should key by IP
+	for i := 0; i < 2; i++ {
+		req := newTestRequest()
+		req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.6:12345"))
+		require.NotNil(t, rl(req))
+	}
+
+	req := newTestRequest()
+	req.RequestCtx.SetRemoteAddr(mockAddr("10.0.0.6:12345"))
+	assert.Nil(t, rl(req), "unauthenticated requests should be rate limited by IP")
+}
+
+// mockAddr implements net.Addr for testing.
+type mockAddr string
+
+func (a mockAddr) Network() string { return "tcp" }
+func (a mockAddr) String() string  { return string(a) }
+
+// Ensure newTestRequest is available (defined in middleware_test.go already,
+// but if running in isolation this provides it).
+func init() {
+	_ = func() *fastglue.Request {
+		ctx := &fasthttp.RequestCtx{}
+		return &fastglue.Request{RequestCtx: ctx}
+	}
+}


### PR DESCRIPTION
## Summary
- Verify webhook signature before processing all field types (template status, user preferences, calls were previously unverified)
- Fail startup if `environment=production` and `allowed_origins` is not configured (CORS)
- Wrap JavaScript custom action URLs in one-time redirect tokens to prevent open redirect
- Add global per-user rate limiting for all `/api/` routes (keys by user ID, falls back to IP for unauthenticated)

## Details

**Webhook signature** — Signature verification was only applied to the `messages` field. Template status updates, user preferences, and call events bypassed it entirely. Moved to a single upfront pass before any field-specific processing.

**CORS enforcement** — When `allowed_origins` was empty (the default), any origin was reflected back. Added a startup check that fatals in production if unconfigured.

**Custom action redirect** — JavaScript custom actions could return arbitrary URLs that the frontend opened via `window.open()`. Now uses the same one-time redirect token mechanism already used by URL actions.

**Rate limiting** — Previously only auth/SSO endpoints were rate-limited. Added a global per-user limit (200 req/min default) to all `/api/` routes. Keys by authenticated user ID so users behind shared IPs (VPNs, offices) get individual quotas. Falls back to per-IP for unauthenticated requests. Configurable via `api_max_requests` and `api_window_seconds` in `[rate_limit]`.

## Test plan
- [x] Rate limiter: allows under limit, blocks with 429 + Retry-After over limit
- [x] Rate limiter: separate limits per IP
- [x] Rate limiter: `UserAwareRateLimit` keys by user ID (VPN-safe), two users on same IP get independent quotas
- [x] Rate limiter: falls back to IP when unauthenticated
- [x] Custom actions: JS action returning external URL gets wrapped in redirect token, raw URL never exposed
- [x] `go build`, `go vet` clean

Fixes: https://github.com/shridarpatil/whatomate/issues/326