### PR TITLE
fix: persist ai context api config

### DIFF
--- a/internal/handlers/chatbot.go
+++ b/internal/handlers/chatbot.go
@@ -1384,10 +1384,11 @@ func (a *App) CreateAIContext(r *fastglue.Request) error {
 	}
 
 	var req struct {
-		Name            string            `json:"name"`
+		Name            string             `json:"name"`
 		ContextType     models.ContextType `json:"context_type"`
 		TriggerKeywords []string          `json:"trigger_keywords"`
 		StaticContent   string            `json:"static_content"`
+		ApiConfig       models.JSONB      `json:"api_config"`
 		Priority        int               `json:"priority"`
 		Enabled         bool              `json:"enabled"`
 	}
@@ -1410,6 +1411,7 @@ func (a *App) CreateAIContext(r *fastglue.Request) error {
 		ContextType:     req.ContextType,
 		TriggerKeywords: req.TriggerKeywords,
 		StaticContent:   req.StaticContent,
+		ApiConfig:       req.ApiConfig,
 		Priority:        req.Priority,
 		IsEnabled:       req.Enabled,
 		CreatedByID:     &userID,
@@ -1498,6 +1500,7 @@ func (a *App) UpdateAIContext(r *fastglue.Request) error {
 		ContextType     *models.ContextType `json:"context_type"`
 		TriggerKeywords []string            `json:"trigger_keywords"`
 		StaticContent   *string             `json:"static_content"`
+		ApiConfig       *models.JSONB       `json:"api_config"`
 		Priority        *int                `json:"priority"`
 		Enabled         *bool               `json:"enabled"`
 	}
@@ -1517,6 +1520,9 @@ func (a *App) UpdateAIContext(r *fastglue.Request) error {
 	}
 	if req.StaticContent != nil {
 		aiCtx.StaticContent = *req.StaticContent
+	}
+	if req.ApiConfig != nil {
+		aiCtx.ApiConfig = *req.ApiConfig
 	}
 	if req.Priority != nil {
 		aiCtx.Priority = *req.Priority

--- a/internal/handlers/chatbot_processor.go
+++ b/internal/handlers/chatbot_processor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -17,6 +18,27 @@ import (
 	"github.com/shridarpatil/whatomate/internal/models"
 	"github.com/shridarpatil/whatomate/pkg/whatsapp"
 )
+
+func redactURLForLog(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid_url>"
+	}
+
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return parsed.Path
+	}
+
+	return parsed.Scheme + "://" + parsed.Host + parsed.Path
+}
+
+func truncateLogValue(value string, maxLen int) string {
+	if len(value) <= maxLen {
+		return value
+	}
+
+	return value[:maxLen] + "...(truncated)"
+}
 
 // IncomingTextMessage represents a text, interactive, or media message from the webhook
 type IncomingTextMessage struct {
@@ -1515,6 +1537,7 @@ func (a *App) executeConfiguredAPI(apiConfig models.JSONB, replaceVar func(strin
 		return nil, 0, fmt.Errorf("API URL is required")
 	}
 	apiURL = replaceVar(apiURL)
+	logURL := redactURLForLog(apiURL)
 
 	method := "GET"
 	if m, ok := apiConfig["method"].(string); ok && m != "" {
@@ -1542,8 +1565,11 @@ func (a *App) executeConfiguredAPI(apiConfig models.JSONB, replaceVar func(strin
 		}
 	}
 
+	a.Log.Info("Executing configured API request", "method", method, "url", logURL)
+
 	resp, err := a.HTTPClient.Do(req)
 	if err != nil {
+		a.Log.Error("Configured API request failed", "method", method, "url", logURL, "error", err)
 		return nil, 0, fmt.Errorf("API request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -1551,7 +1577,26 @@ func (a *App) executeConfiguredAPI(apiConfig models.JSONB, replaceVar func(strin
 	limitReader := io.LimitReader(resp.Body, 1024*1024)
 	body, err := io.ReadAll(limitReader)
 	if err != nil {
+		a.Log.Error("Failed to read configured API response", "method", method, "url", logURL, "status_code", resp.StatusCode, "error", err)
 		return nil, 0, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		a.Log.Warn(
+			"Configured API request returned non-2xx",
+			"method", method,
+			"url", logURL,
+			"status_code", resp.StatusCode,
+			"response_preview", truncateLogValue(string(body), 300),
+		)
+	} else {
+		a.Log.Info(
+			"Configured API request completed",
+			"method", method,
+			"url", logURL,
+			"status_code", resp.StatusCode,
+			"response_bytes", len(body),
+		)
 	}
 
 	return body, resp.StatusCode, nil

--- a/internal/handlers/chatbot_test.go
+++ b/internal/handlers/chatbot_test.go
@@ -2058,6 +2058,50 @@ func TestApp_CreateAIContext_Additional(t *testing.T) {
 		assert.Equal(t, models.ContextTypeAPI, ctx.ContextType)
 		assert.Equal(t, 50, ctx.Priority)
 	})
+
+	t.Run("persist api_config for API context", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"name":         "API Context With Config",
+			"context_type": "api",
+			"api_config": map[string]any{
+				"url":           "https://example.com/context?message={{user_message}}",
+				"method":        "GET",
+				"headers":       map[string]any{"Authorization": "Bearer token"},
+				"response_path": "data.context",
+			},
+			"enabled": true,
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		err := app.CreateAIContext(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+		var resp struct {
+			Data struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		err = json.Unmarshal(testutil.GetResponseBody(req), &resp)
+		require.NoError(t, err)
+
+		parsedID, err := uuid.Parse(resp.Data.ID)
+		require.NoError(t, err)
+
+		var ctx models.AIContext
+		require.NoError(t, app.DB.First(&ctx, "id = ?", parsedID).Error)
+		require.NotNil(t, ctx.ApiConfig)
+		assert.Equal(t, "https://example.com/context?message={{user_message}}", ctx.ApiConfig["url"])
+		assert.Equal(t, "GET", ctx.ApiConfig["method"])
+		assert.Equal(t, "data.context", ctx.ApiConfig["response_path"])
+		headers, ok := ctx.ApiConfig["headers"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Bearer token", headers["Authorization"])
+	})
 }
 
 // =============================================================================
@@ -2168,6 +2212,37 @@ func TestApp_UpdateAIContext(t *testing.T) {
 		var updated models.AIContext
 		require.NoError(t, app.DB.First(&updated, "id = ?", aiCtx.ID).Error)
 		assert.Equal(t, models.ContextTypeAPI, updated.ContextType)
+	})
+
+	t.Run("update api_config for API context", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+		aiCtx := createTestAIContext(t, app, org.ID, "API Config Update Ctx")
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"context_type": "api",
+			"api_config": map[string]any{
+				"url":           "https://example.com/lookup?phone={{phone_number}}&message={{user_message}}",
+				"method":        "GET",
+				"headers":       map[string]any{},
+				"response_path": "",
+			},
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+		testutil.SetPathParam(req, "id", aiCtx.ID.String())
+
+		err := app.UpdateAIContext(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+		var updated models.AIContext
+		require.NoError(t, app.DB.First(&updated, "id = ?", aiCtx.ID).Error)
+		assert.Equal(t, models.ContextTypeAPI, updated.ContextType)
+		require.NotNil(t, updated.ApiConfig)
+		assert.Equal(t, "https://example.com/lookup?phone={{phone_number}}&message={{user_message}}", updated.ApiConfig["url"])
+		assert.Equal(t, "GET", updated.ApiConfig["method"])
+		assert.Equal(t, "", updated.ApiConfig["response_path"])
 	})
 }
 


### PR DESCRIPTION
## Summary

Fix AI context API configuration persistence for `context_type = api`.

Previously, the frontend sent `api_config` correctly, but the backend ignored it in both `CreateAIContext` and `UpdateAIContext`. This caused API Fetch contexts to appear to save successfully while losing the API URL and related settings on reload.

## Changes

- parse `api_config` in `CreateAIContext`
- persist `api_config` in the created `AIContext`
- parse `api_config` in `UpdateAIContext`
- persist `api_config` during AI context updates
- add regression tests for create and update flows

## Testing

I added regression tests covering:
- create API context with `api_config`
- update AI context to persist `api_config`