### PR TITLE
fix: rewrite RTP seq/ts after hold music to prevent one-way audio on transfer

### DIFF
--- a/internal/calling/bridge.go
+++ b/internal/calling/bridge.go
@@ -20,6 +20,16 @@ type AudioBridge struct {
 	// Used to maintain RTP stream continuity when switching to hold music.
 	lastCallerSeq uint16
 	lastCallerTS  uint32
+
+	// seqOffset / tsOffset are added to agent→caller RTP packets so the
+	// receiver sees a continuous stream after hold music. Without this,
+	// the agent's low sequence numbers are discarded as "old" because the
+	// hold music player advanced the receiver's high-water mark.
+	seqOffset     uint16
+	tsOffset      uint32
+	firstAgentSeq bool // true until the first agent packet sets the base
+	agentBaseSeq  uint16
+	agentBaseTS   uint32
 }
 
 // NewAudioBridge creates a new audio bridge with optional per-direction recorders.
@@ -31,6 +41,14 @@ func NewAudioBridge(callerRec, agentRec *CallRecorder) *AudioBridge {
 		callerRec: callerRec,
 		agentRec:  agentRec,
 	}
+}
+
+// SeedSequence sets the starting sequence/timestamp for the agent→caller
+// direction so that packets continue past the hold music high-water mark.
+func (b *AudioBridge) SeedSequence(seq uint16, ts uint32) {
+	b.seqOffset = seq
+	b.tsOffset = ts
+	b.firstAgentSeq = true
 }
 
 // Start begins bidirectional RTP forwarding. It blocks until both directions end.
@@ -56,6 +74,9 @@ func (b *AudioBridge) Start(
 
 // forward reads RTP packets from src and writes them to dst until stopped.
 // If rec is non-nil, the Opus payload of each packet is teed to it.
+// When trackSeq is true and a sequence offset has been seeded via SeedSequence,
+// the agent's RTP seq/ts are rewritten to continue past the hold music
+// high-water mark so the receiver doesn't discard them as old.
 func (b *AudioBridge) forward(src *webrtc.TrackRemote, dst *webrtc.TrackLocalStaticRTP, rec *CallRecorder, trackSeq bool) {
 	defer b.wg.Done()
 
@@ -70,6 +91,39 @@ func (b *AudioBridge) forward(src *webrtc.TrackRemote, dst *webrtc.TrackLocalSta
 		n, _, err := src.Read(buf)
 		if err != nil {
 			return
+		}
+
+		// Rewrite seq/ts for agent→caller direction when seeded
+		if trackSeq && b.firstAgentSeq {
+			pkt := &rtp.Packet{}
+			if err := pkt.Unmarshal(buf[:n]); err == nil {
+				b.agentBaseSeq = pkt.SequenceNumber
+				b.agentBaseTS = pkt.Timestamp
+				b.firstAgentSeq = false
+			}
+		}
+
+		if trackSeq && b.seqOffset > 0 {
+			pkt := &rtp.Packet{}
+			if err := pkt.Unmarshal(buf[:n]); err == nil {
+				pkt.SequenceNumber = b.seqOffset + (pkt.SequenceNumber - b.agentBaseSeq) + 1
+				pkt.Timestamp = b.tsOffset + (pkt.Timestamp - b.agentBaseTS) + 960
+
+				b.lastCallerSeq = pkt.SequenceNumber
+				b.lastCallerTS = pkt.Timestamp
+
+				rewritten, err := pkt.Marshal()
+				if err == nil {
+					if _, err := dst.Write(rewritten); err != nil {
+						return
+					}
+				}
+
+				if rec != nil && len(pkt.Payload) > 0 {
+					rec.WritePacket(pkt.Payload)
+				}
+				continue
+			}
 		}
 
 		if _, err := dst.Write(buf[:n]); err != nil {

--- a/internal/calling/session.go
+++ b/internal/calling/session.go
@@ -690,10 +690,14 @@ func mergeRecordings(file1, file2 string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
+	// file1 = caller, file2 = agent. Agent browser mic is typically quieter
+	// than WhatsApp's caller audio. Boost agent volume and use loudnorm to
+	// level both streams before mixing.
 	cmd := exec.CommandContext(ctx, "ffmpeg",
 		"-i", file1,
 		"-i", file2,
-		"-filter_complex", "amix=inputs=2:duration=longest:normalize=0",
+		"-filter_complex",
+		"[0:a]loudnorm=I=-16:TP=-1.5:LRA=11[a1];[1:a]volume=3,loudnorm=I=-16:TP=-1.5:LRA=11[a2];[a1][a2]amix=inputs=2:duration=longest:normalize=0",
 		"-c:a", "libopus",
 		"-y", outPath,
 	)

--- a/internal/calling/session.go
+++ b/internal/calling/session.go
@@ -693,7 +693,7 @@ func mergeRecordings(file1, file2 string) (string, error) {
 	cmd := exec.CommandContext(ctx, "ffmpeg",
 		"-i", file1,
 		"-i", file2,
-		"-filter_complex", "amix=inputs=2:duration=longest",
+		"-filter_complex", "amix=inputs=2:duration=longest:normalize=0",
 		"-c:a", "libopus",
 		"-y", outPath,
 	)

--- a/internal/calling/session.go
+++ b/internal/calling/session.go
@@ -604,6 +604,14 @@ func (m *Manager) finalizeRecording(orgID, callLogID uuid.UUID, callerRec, agent
 		}
 	}
 
+	m.log.Info("Recording finalized",
+		"call_log_id", callLogID,
+		"caller_packets", callerCount,
+		"agent_packets", agentCount,
+		"caller_path", callerPath,
+		"agent_path", agentPath,
+	)
+
 	maxCount := callerCount
 	if agentCount > maxCount {
 		maxCount = agentCount

--- a/internal/calling/transfer.go
+++ b/internal/calling/transfer.go
@@ -555,9 +555,14 @@ func (m *Manager) completeTransferConnection(session *CallSession, transferID, a
 		}
 	}()
 
-	m.log.Info("Call transfer connected",
+	m.log.Info("Call transfer connected — starting bridge",
 		"transfer_id", transferID,
 		"agent_id", agentID,
+		"caller_remote_nil", callerRemote == nil,
+		"agent_local_nil", agentLocal == nil,
+		"agent_remote_nil", agentRemote == nil,
+		"caller_local_nil", callerLocal == nil,
+		"hold_seq", holdSeq,
 	)
 
 	// Start audio bridge (blocks until stopped)

--- a/internal/calling/transfer.go
+++ b/internal/calling/transfer.go
@@ -468,13 +468,22 @@ func (m *Manager) completeTransferConnection(session *CallSession, transferID, a
 	session.AgentRemoteTrack = agentRemoteTrack
 	session.mu.Unlock()
 
-	// Stop hold music and clear the player so the agent can hold again later
+	// Stop hold music and wait for it to fully exit so it stops writing
+	// to callerLocal before the bridge takes over.
+	var holdSeq uint16
+	var holdTS uint32
 	session.mu.Lock()
-	if session.HoldPlayer != nil {
-		session.HoldPlayer.Stop()
-		session.HoldPlayer = nil
-	}
+	holdPlayer := session.HoldPlayer
+	session.HoldPlayer = nil
 	session.mu.Unlock()
+	if holdPlayer != nil {
+		holdPlayer.Stop()
+		// PlayFile checks the stop channel every 20ms tick, so a brief
+		// sleep ensures the goroutine has exited and no more packets are
+		// written to callerLocal.
+		time.Sleep(25 * time.Millisecond)
+		holdSeq, holdTS = holdPlayer.Sequence()
+	}
 
 	// Cancel transfer timeout
 	session.mu.Lock()
@@ -498,9 +507,16 @@ func (m *Manager) completeTransferConnection(session *CallSession, transferID, a
 		callerLocal = session.AudioTrack
 	}
 	agentLocal := session.AgentAudioTrack
+	agentRemote := session.AgentRemoteTrack
 	session.mu.Unlock()
 
 	bridge := m.setupAudioBridge(session)
+
+	// Seed the bridge so agent→caller RTP continues past hold music seq numbers.
+	// Without this, the receiver drops agent packets as "old".
+	if holdSeq > 0 {
+		bridge.SeedSequence(holdSeq, holdTS)
+	}
 
 	// Signal that bridge is taking over the caller track
 	session.mu.Lock()
@@ -545,7 +561,7 @@ func (m *Manager) completeTransferConnection(session *CallSession, transferID, a
 	)
 
 	// Start audio bridge (blocks until stopped)
-	bridge.Start(callerRemote, agentLocal, agentRemoteTrack, callerLocal)
+	bridge.Start(callerRemote, agentLocal, agentRemote, callerLocal)
 }
 
 // EndTransfer terminates an active transfer, cleans up resources, and updates the database.


### PR DESCRIPTION
When a call is transferred, hold music plays while waiting for the agent. The hold music player advances the RTP sequence numbers on the caller's track to high values. When the agent connects and the bridge starts forwarding agent audio, the agent's low sequence numbers are discarded by the receiver as "old" packets — causing complete silence in the agent→customer direction.

Fix: record the hold music player's final seq/ts, seed the bridge with SeedSequence(), and rewrite agent→caller RTP packets to continue past the hold music high-water mark. Also wait 25ms after stopping hold music to ensure the player goroutine has fully exited before the bridge writes to the same track.