### PR TITLE
fix: upgrade Node to 22 in docs CI for Astro compatibility

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: docs/package-lock.json
 


### PR DESCRIPTION
Astro requires Node >= 22.12.0 after the upgrade in #342.