### PR TITLE
fix(whatsapp): sort positional template params numerically (#354)

### DIFF
--- a/pkg/whatsapp/message.go
+++ b/pkg/whatsapp/message.go
@@ -227,6 +227,35 @@ type TemplateParam struct {
 }
 
 // SendTemplateMessage sends a template message
+// sortParamKeys returns the keys of paramMap in the order they should be sent
+// to Meta. Named templates (forceLexical=true, or any non-numeric key) sort
+// lexicographically. Otherwise keys are treated as positional indices and
+// sorted numerically — required so that "1","2",..,"10","11" stay in order
+// instead of becoming "1","10","11",..,"2","9".
+func sortParamKeys(paramMap map[string]string, forceLexical bool) []string {
+	keys := make([]string, 0, len(paramMap))
+	for k := range paramMap {
+		keys = append(keys, k)
+	}
+	if forceLexical {
+		sort.Strings(keys)
+		return keys
+	}
+	for _, k := range keys {
+		if _, err := strconv.Atoi(k); err != nil {
+			// Mixed/named keys — fall back to lexical to keep behaviour stable.
+			sort.Strings(keys)
+			return keys
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		ni, _ := strconv.Atoi(keys[i])
+		nj, _ := strconv.Atoi(keys[j])
+		return ni < nj
+	})
+	return keys
+}
+
 // BodyParamsToComponents converts a bodyParams map into WhatsApp template components.
 // Supports both positional (numeric keys) and named parameters.
 func BodyParamsToComponents(bodyParams map[string]string) []map[string]any {
@@ -243,12 +272,12 @@ func BodyParamsToComponents(bodyParams map[string]string) []map[string]any {
 		}
 	}
 
-	// Get sorted keys for deterministic ordering
-	keys := make([]string, 0, len(bodyParams))
-	for k := range bodyParams {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	// Get sorted keys for deterministic ordering. For positional templates the
+	// keys are numeric strings ("1".."14") and MUST be ordered numerically —
+	// sort.Strings would yield "1","10","11",..,"2",..,"9" and ship parameters
+	// to Meta in the wrong slot, so {{2}}..{{9}} render as the values that
+	// belonged in {{10}}+ on the recipient's device (issue #354).
+	keys := sortParamKeys(bodyParams, isNamedParams)
 
 	params := make([]map[string]any, 0, len(bodyParams))
 	for _, key := range keys {
@@ -372,11 +401,9 @@ func ButtonURLParamsToComponents(buttonParams map[string]string, templateButtons
 		}
 	}
 
-	keys := make([]string, 0, len(buttonParams))
-	for k := range buttonParams {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	// Button indices are always numeric strings ("0", "1", ...) so sort
+	// numerically — same lexical-sort hazard as positional body params.
+	keys := sortParamKeys(buttonParams, false)
 
 	components := make([]map[string]any, 0, len(buttonParams))
 	for _, index := range keys {

--- a/pkg/whatsapp/message_test.go
+++ b/pkg/whatsapp/message_test.go
@@ -558,3 +558,49 @@ func TestButtonURLParamsToComponents(t *testing.T) {
 	})
 }
 
+// Regression for issue #354. Lexical sort would order positional keys as
+// "1","10","11",..,"2",..,"9", which silently shipped recipients the value
+// from {{10}}+ in the {{2}}..{{9}} slots.
+func TestBodyParamsToComponents_PositionalNumericOrder(t *testing.T) {
+	bodyParams := map[string]string{
+		"1":  "v1",
+		"2":  "v2",
+		"3":  "v3",
+		"9":  "v9",
+		"10": "v10",
+		"11": "v11",
+		"14": "v14",
+	}
+
+	components := whatsapp.BodyParamsToComponents(bodyParams)
+	require.Len(t, components, 1)
+
+	params := components[0]["parameters"].([]map[string]any)
+	got := make([]string, len(params))
+	for i, p := range params {
+		got[i] = p["text"].(string)
+		// Positional templates must NOT carry parameter_name (Meta rejects it).
+		_, hasName := p["parameter_name"]
+		assert.False(t, hasName, "positional params must not include parameter_name")
+	}
+	assert.Equal(t, []string{"v1", "v2", "v3", "v9", "v10", "v11", "v14"}, got)
+}
+
+func TestBodyParamsToComponents_NamedParamsRetainLexicalOrder(t *testing.T) {
+	bodyParams := map[string]string{
+		"order_id": "o1",
+		"name":     "alice",
+	}
+
+	components := whatsapp.BodyParamsToComponents(bodyParams)
+	require.Len(t, components, 1)
+	params := components[0]["parameters"].([]map[string]any)
+
+	// Named templates must include parameter_name and stay lexically sorted.
+	require.Len(t, params, 2)
+	assert.Equal(t, "name", params[0]["parameter_name"])
+	assert.Equal(t, "alice", params[0]["text"])
+	assert.Equal(t, "order_id", params[1]["parameter_name"])
+	assert.Equal(t, "o1", params[1]["text"])
+}
+


### PR DESCRIPTION
## Summary
- Positional template parameters were sorted lexically in `BodyParamsToComponents` and `ButtonURLParamsToComponents`, so keys ordered "1","10","11",..,"2",..,"9" instead of "1","2",..,"9","10",..,"14". Meta then sent recipients the wrong values for {{2}}..{{9}} (they got values intended for {{10}}+).
- Extract `sortParamKeys`: numeric sort for positional, lexical for named.
- Add regression tests pinning both orders.

Closes #354

## Test plan
- [x] `go test ./pkg/whatsapp/` passes
- [x] New `TestBodyParamsToComponents_PositionalNumericOrder` enforces 1,2,3,9,10,11,14 ordering
- [x] New `TestBodyParamsToComponents_NamedParamsRetainLexicalOrder` confirms named templates still sort lexically and carry `parameter_name`
- [ ] Manual: send a 10+ positional template via campaign and confirm recipient sees correct values