### PR TITLE
fix(chat): collapse /chat and /chat/:contactId into one route

### DIFF
--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -291,7 +291,7 @@ const handleLogout = async () => {
     <main id="main-content" class="flex-1 overflow-hidden pt-12 md:pt-0 bg-[#0a0a0b] light:bg-gray-50" role="main">
       <RouterView v-slot="{ Component, route: viewRoute }">
         <Transition name="page" mode="out-in">
-          <component :is="Component" :key="viewRoute.path" />
+          <component :is="Component" :key="viewRoute.meta.stableKey ? String(viewRoute.name) : viewRoute.path" />
         </Transition>
       </RouterView>
       <ActiveCallPanel />

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -46,13 +46,7 @@ const router = createRouter({
           meta: { permission: 'analytics' }
         },
         {
-          path: 'chat',
-          name: 'chat',
-          component: () => import('@/views/chat/ChatView.vue'),
-          meta: { permission: 'chat' }
-        },
-        {
-          path: 'chat/:contactId',
+          path: 'chat/:contactId?',
           name: 'chat-conversation',
           component: () => import('@/views/chat/ChatView.vue'),
           props: true,

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -50,7 +50,7 @@ const router = createRouter({
           name: 'chat-conversation',
           component: () => import('@/views/chat/ChatView.vue'),
           props: true,
-          meta: { permission: 'chat' }
+          meta: { permission: 'chat', stableKey: true }
         },
         {
           path: 'profile',


### PR DESCRIPTION
Two route names mapped to the same component, so Vue Router was remounting ChatView on every contact click — re-fetching contacts and flashing the panel.

Fixes: https://github.com/shridarpatil/whatomate/issues/295