### PR TITLE
fix(chat): clear unread badge when message arrives in open chat (#280)

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -637,6 +637,7 @@ func setupRoutes(g *fastglue.Fastglue, app *handlers.App, lo logf.Logger, basePa
 	// Messages
 	g.GET("/api/contacts/{id}/messages", app.GetMessages)
 	g.POST("/api/contacts/{id}/messages", app.SendMessage)
+	g.POST("/api/contacts/{id}/mark-read", app.MarkContactRead)
 	g.POST("/api/contacts/{id}/messages/{message_id}/reaction", app.SendReaction)
 	g.POST("/api/messages", app.SendMessage) // Legacy route
 	g.POST("/api/messages/template", app.SendTemplateMessage)

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -319,6 +319,7 @@
     "cancelReply": "Cancel reply",
     "selectConversation": "Select a conversation",
     "chooseContact": "Choose a contact to start chatting",
+    "unreadMessage": "unread message",
     "unreadMessages": "unread messages",
     "today": "Today",
     "yesterday": "Yesterday",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -178,7 +178,7 @@ export const contactsService = {
   updateTags: (id: string, tags: string[]) =>
     api.put(`/contacts/${id}/tags`, { tags }),
   getSessionData: (id: string) => api.get(`/contacts/${id}/session-data`),
-  markRead: (id: string) => api.post(`/contacts/${id}/mark-read`)
+  markRead: (id: string) => api.post(`/contacts/${encodeURIComponent(id)}/mark-read`)
 }
 
 // Generic Import/Export Service

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -177,7 +177,8 @@ export const contactsService = {
     api.put(`/contacts/${id}/assign`, { user_id: userId }),
   updateTags: (id: string, tags: string[]) =>
     api.put(`/contacts/${id}/tags`, { tags }),
-  getSessionData: (id: string) => api.get(`/contacts/${id}/session-data`)
+  getSessionData: (id: string) => api.get(`/contacts/${id}/session-data`),
+  markRead: (id: string) => api.post(`/contacts/${id}/mark-read`)
 }
 
 // Generic Import/Export Service

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -312,8 +312,11 @@ class WebSocketService {
     // the server before refetching so the unread badge stays at zero
     // (otherwise the new message comes back as unread and the sidebar flashes
     // a count for a chat that's already open). See issue #280.
-    if (isViewingThisContact && payload.direction === 'incoming') {
-      contactsService.markRead(payload.contact_id)
+    // Use currentContact.id (already validated, from our /contacts response)
+    // rather than the WS payload value to avoid pushing untrusted data into
+    // a request URL.
+    if (isViewingThisContact && currentContact && payload.direction === 'incoming') {
+      contactsService.markRead(currentContact.id)
         .catch(() => { /* non-critical, will resync on next chat-open */ })
         .finally(() => store.fetchContacts())
     } else {

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -3,6 +3,7 @@ import { useTransfersStore } from '@/stores/transfers'
 import { useCallingStore } from '@/stores/calling'
 import { useAuthStore } from '@/stores/auth'
 import { useNotesStore } from '@/stores/notes'
+import { contactsService } from '@/services/api'
 import { toast } from 'vue-sonner'
 import router from '@/router'
 
@@ -307,8 +308,17 @@ class WebSocketService {
       }
     }
 
-    // Update contacts list (for unread count, last message preview)
-    store.fetchContacts()
+    // If the user is actively viewing this contact, mark messages read on
+    // the server before refetching so the unread badge stays at zero
+    // (otherwise the new message comes back as unread and the sidebar flashes
+    // a count for a chat that's already open). See issue #280.
+    if (isViewingThisContact && payload.direction === 'incoming') {
+      contactsService.markRead(payload.contact_id)
+        .catch(() => { /* non-critical, will resync on next chat-open */ })
+        .finally(() => store.fetchContacts())
+    } else {
+      store.fetchContacts()
+    }
   }
 
   private handleStatusUpdate(store: ReturnType<typeof useContactsStore>, payload: any) {

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -120,11 +120,12 @@ const isSending = ref(false)
 const isAssignDialogOpen = ref(false)
 const isTransferring = ref(false)
 const isResuming = ref(false)
-// Tracks new incoming messages that arrived while the user is scrolled up.
+// Tracks incoming messages that arrived while the chat is open.
 // Surfaced as a "N unread messages" pill at the top of the chat panel
-// (WhatsApp-style); cleared when the user scrolls to the bottom or clicks
-// the pill. See issue #280.
+// (WhatsApp-style). Click the pill to jump up to the first message of
+// the unread batch; cleared on click or contact switch. See issue #280.
 const newMessagesCount = ref(0)
+const firstUnreadId = ref<string | null>(null)
 const isAtBottom = ref(true)
 const SCROLL_BOTTOM_THRESHOLD = 80
 const isInfoPanelOpen = ref(false)
@@ -506,6 +507,7 @@ async function selectContact(id: string) {
   if (contact) {
     // Reset unread pill — fetchMessages will mark everything read on the server
     newMessagesCount.value = 0
+    firstUnreadId.value = null
     isAtBottom.value = true
 
     // Remove old scroll listener before switching contacts
@@ -585,16 +587,21 @@ async function selectContact(id: string) {
   }
 }
 
-// Watch for new messages. Outgoing (own sends) scroll to bottom as before.
-// Incoming messages bump the unread pill instead of auto-scrolling — the
-// pill is the user's signal, click it to jump to the latest (issue #280).
+// Watch for new messages. Auto-scroll if the user is already at the
+// bottom (or sent the message themselves). Every incoming message also
+// increments the unread pill; the pill click jumps up to the first
+// message of the batch so the user can read forward (issue #280).
 watch(() => contactsStore.messages.length, (newLen, oldLen) => {
   if (newLen <= oldLen) return
   const latest = contactsStore.messages[newLen - 1]
   const isIncoming = latest?.direction === 'incoming'
   if (isIncoming) {
+    if (newMessagesCount.value === 0) {
+      firstUnreadId.value = latest.id
+    }
     newMessagesCount.value += 1
-  } else {
+  }
+  if (isAtBottom.value || !isIncoming) {
     scrollToBottom()
   }
 })
@@ -981,10 +988,15 @@ function scrollToBottom(instant = false) {
   })
 }
 
-function jumpToLatest() {
+function jumpToFirstUnread() {
+  if (firstUnreadId.value) {
+    const el = document.getElementById(`message-${firstUnreadId.value}`)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
   newMessagesCount.value = 0
-  isAtBottom.value = true
-  scrollToBottom()
+  firstUnreadId.value = null
 }
 
 function getMessageStatusIcon(status: string) {
@@ -1683,7 +1695,7 @@ async function sendMediaMessage() {
               v-if="newMessagesCount > 0"
               type="button"
               class="absolute top-2 left-1/2 -translate-x-1/2 z-20 px-3 py-1 bg-white/[0.08] light:bg-gray-200 backdrop-blur-sm rounded-full text-[11px] text-white/70 light:text-gray-700 font-medium shadow-sm hover:bg-white/[0.12] light:hover:bg-gray-300 transition-colors"
-              @click="jumpToLatest"
+              @click="jumpToFirstUnread"
             >
               {{ newMessagesCount }} {{ newMessagesCount === 1 ? $t('chat.unreadMessage', 'unread message') : $t('chat.unreadMessages', 'unread messages') }}
             </button>
@@ -2038,7 +2050,7 @@ async function sendMediaMessage() {
               </div>
             </div>
             </template>
-            <div ref="messagesEndRef" style="overflow-anchor: none" />
+            <div ref="messagesEndRef" />
           </div>
         </ScrollArea>
         </div>

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -585,19 +585,16 @@ async function selectContact(id: string) {
   }
 }
 
-// Watch for new messages. Auto-scroll only when the user is already at
-// the bottom (or sent the message themselves) — otherwise we'd yank them
-// out of older history they're reading. Every new incoming message bumps
-// the unread pill regardless; the pill clears only on click or contact
-// switch (issue #280).
+// Watch for new messages. Outgoing (own sends) scroll to bottom as before.
+// Incoming messages bump the unread pill instead of auto-scrolling — the
+// pill is the user's signal, click it to jump to the latest (issue #280).
 watch(() => contactsStore.messages.length, (newLen, oldLen) => {
   if (newLen <= oldLen) return
   const latest = contactsStore.messages[newLen - 1]
   const isIncoming = latest?.direction === 'incoming'
   if (isIncoming) {
     newMessagesCount.value += 1
-  }
-  if (isAtBottom.value || !isIncoming) {
+  } else {
     scrollToBottom()
   }
 })

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -2038,7 +2038,7 @@ async function sendMediaMessage() {
               </div>
             </div>
             </template>
-            <div ref="messagesEndRef" />
+            <div ref="messagesEndRef" style="overflow-anchor: none" />
           </div>
         </ScrollArea>
         </div>

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -120,6 +120,13 @@ const isSending = ref(false)
 const isAssignDialogOpen = ref(false)
 const isTransferring = ref(false)
 const isResuming = ref(false)
+// Tracks new incoming messages that arrived while the user is scrolled up.
+// Surfaced as a "N unread messages" pill at the top of the chat panel
+// (WhatsApp-style); cleared when the user scrolls to the bottom or clicks
+// the pill. See issue #280.
+const newMessagesCount = ref(0)
+const isAtBottom = ref(true)
+const SCROLL_BOTTOM_THRESHOLD = 80
 const isInfoPanelOpen = ref(false)
 const isNotesPanelOpen = ref(false)
 const contactSessionData = ref<any>(null)
@@ -229,8 +236,17 @@ const messagesScroll = useInfiniteScroll({
   },
   hasMore: computed(() => contactsStore.hasMoreMessages),
   isLoading: computed(() => contactsStore.isLoadingOlderMessages),
-  onScroll: (event) => updateStickyDate(event.target as HTMLElement)
+  onScroll: (event) => {
+    const el = event.target as HTMLElement
+    updateStickyDate(el)
+    updateAtBottom(el)
+  }
 })
+
+function updateAtBottom(el: HTMLElement) {
+  const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop
+  isAtBottom.value = distanceFromBottom < SCROLL_BOTTOM_THRESHOLD
+}
 
 const contactId = computed(() => route.params.contactId as string | undefined)
 
@@ -488,6 +504,10 @@ watch(contactId, async (newId) => {
 async function selectContact(id: string) {
   const contact = contactsStore.contacts.find(c => c.id === id)
   if (contact) {
+    // Reset unread pill — fetchMessages will mark everything read on the server
+    newMessagesCount.value = 0
+    isAtBottom.value = true
+
     // Remove old scroll listener before switching contacts
     messagesScroll.cleanup()
 
@@ -565,12 +585,20 @@ async function selectContact(id: string) {
   }
 }
 
-// Watch for new messages to auto-scroll and load media
-watch(() => contactsStore.messages.length, () => {
-  scrollToBottom()
-  try {
-  } catch (e) {
-    console.error('Error loading media:', e)
+// Watch for new messages. Auto-scroll only when the user is already at
+// the bottom (or sent the message themselves) — otherwise we'd yank them
+// out of older history they're reading. Every new incoming message bumps
+// the unread pill regardless; the pill clears only on click or contact
+// switch (issue #280).
+watch(() => contactsStore.messages.length, (newLen, oldLen) => {
+  if (newLen <= oldLen) return
+  const latest = contactsStore.messages[newLen - 1]
+  const isIncoming = latest?.direction === 'incoming'
+  if (isIncoming) {
+    newMessagesCount.value += 1
+  }
+  if (isAtBottom.value || !isIncoming) {
+    scrollToBottom()
   }
 })
 
@@ -954,6 +982,12 @@ function scrollToBottom(instant = false) {
       })
     }
   })
+}
+
+function jumpToLatest() {
+  newMessagesCount.value = 0
+  isAtBottom.value = true
+  scrollToBottom()
 }
 
 function getMessageStatusIcon(status: string) {
@@ -1644,6 +1678,18 @@ async function sendMediaMessage() {
             >
               {{ stickyDate }}
             </div>
+          </Transition>
+
+          <!-- Unread-messages pill (WhatsApp-style; click to jump to bottom) -->
+          <Transition name="sticky-date">
+            <button
+              v-if="newMessagesCount > 0"
+              type="button"
+              class="absolute top-2 left-1/2 -translate-x-1/2 z-20 px-3 py-1 bg-white/[0.08] light:bg-gray-200 backdrop-blur-sm rounded-full text-[11px] text-white/70 light:text-gray-700 font-medium shadow-sm hover:bg-white/[0.12] light:hover:bg-gray-300 transition-colors"
+              @click="jumpToLatest"
+            >
+              {{ newMessagesCount }} {{ newMessagesCount === 1 ? $t('chat.unreadMessage', 'unread message') : $t('chat.unreadMessages', 'unread messages') }}
+            </button>
           </Transition>
 
           <ScrollArea :ref="(el: any) => messagesScroll.scrollAreaRef.value = el" class="h-full p-3 chat-background">

--- a/internal/handlers/contacts.go
+++ b/internal/handlers/contacts.go
@@ -479,6 +479,34 @@ func (a *App) buildMessagesResponse(messages []models.Message) []MessageResponse
 	return response
 }
 
+// MarkContactRead marks all incoming messages from a contact as read.
+// Called from the frontend when a new message arrives for the chat the
+// user is currently viewing, so the sidebar unread badge stays at zero.
+func (a *App) MarkContactRead(r *fastglue.Request) error {
+	orgID, userID, err := a.getOrgAndUserID(r)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
+	}
+	contactID, err := parsePathUUID(r, "id", "contact")
+	if err != nil {
+		return nil
+	}
+
+	hasContactsReadPermission := a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID)
+
+	var contact models.Contact
+	query := a.DB.Where("id = ? AND organization_id = ?", contactID, orgID)
+	if !hasContactsReadPermission {
+		query = query.Where("assigned_user_id = ?", userID)
+	}
+	if err := query.First(&contact).Error; err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
+	}
+
+	a.markMessagesAsRead(orgID, contactID, &contact)
+	return r.SendEnvelope(map[string]any{"status": "ok"})
+}
+
 // markMessagesAsRead marks messages as read and sends read receipts
 func (a *App) markMessagesAsRead(orgID uuid.UUID, contactID uuid.UUID, contact *models.Contact) {
 	var unreadMessages []models.Message


### PR DESCRIPTION
Add POST /api/contacts/:id/mark-read and call it from the WS handler when an incoming message is for the currently-viewed contact. Without this, fetchContacts() refreshed the badge to N+1, and only chat-reopen cleared it.

Fixes: https://github.com/shridarpatil/whatomate/issues/280