### PR TITLE
fix(chat): mark customer message read at save time when bot will handle

### DIFF
--- a/internal/handlers/agent_transfers.go
+++ b/internal/handlers/agent_transfers.go
@@ -1039,6 +1039,22 @@ func (a *App) hasActiveAgentTransfer(orgID, contactID uuid.UUID) bool {
 	return count > 0
 }
 
+// willChatbotHandle returns true when an incoming message is expected to be
+// handled by the chatbot — i.e. chatbot is enabled for the account and the
+// contact has no active agent transfer. Used to pre-mark messages as read
+// so the agent's contact-list unread count doesn't flash for bot-handled
+// conversations.
+func (a *App) willChatbotHandle(account *models.WhatsAppAccount, contact *models.Contact) bool {
+	if a.hasActiveAgentTransfer(account.OrganizationID, contact.ID) {
+		return false
+	}
+	settings, err := a.getChatbotSettingsCached(account.OrganizationID, account.Name)
+	if err != nil || !settings.IsEnabled {
+		return false
+	}
+	return true
+}
+
 // WebSocket broadcast helpers
 
 func (a *App) broadcastTransferCreated(transfer *models.AgentTransfer, contact *models.Contact) {

--- a/internal/handlers/chatbot_processor.go
+++ b/internal/handlers/chatbot_processor.go
@@ -2317,6 +2317,16 @@ func (a *App) saveIncomingMessage(account *models.WhatsAppAccount, contact *mode
 		return
 	}
 
+	// If the chatbot will handle this conversation (enabled + no active
+	// agent transfer), pre-mark the message as read so the contact-list
+	// unread badge doesn't briefly flash before the bot's reply arrives.
+	// See issue #280.
+	if a.willChatbotHandle(account, contact) {
+		a.DB.Model(&models.Message{}).Where("id = ?", message.ID).
+			Update("status", models.MessageStatusRead)
+		message.Status = models.MessageStatusRead
+	}
+
 	// Update contact's last message info
 	preview := content
 	if len(preview) > 100 {

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -85,6 +85,11 @@ type MessageSendOptions struct {
 	// Async if true, sends in background goroutine and returns immediately
 	// Message is persisted before send, status updated after
 	Async bool
+
+	// MarkIncomingRead marks the contact's incoming messages as read after a
+	// successful send. Used for chatbot replies so a bot-handled exchange
+	// doesn't leave an "unread" badge in the agent's contact list.
+	MarkIncomingRead bool
 }
 
 // DefaultSendOptions returns options suitable for agent UI sends
@@ -104,6 +109,7 @@ func ChatbotSendOptions() MessageSendOptions {
 		DispatchWebhook:    false,
 		TrackSLA:           true,
 		Async:              false,
+		MarkIncomingRead:   true,
 	}
 }
 
@@ -432,6 +438,13 @@ func (a *App) finalizeMessageSend(msg *models.Message, req OutgoingMessageReques
 				"wamid":      wamid,
 			},
 		})
+	}
+
+	// Mark the contact's incoming messages as read once a chatbot reply has
+	// gone out. Keeps the agent's contact-list unread count clean for
+	// conversations the bot is auto-handling. See issue #280.
+	if opts.MarkIncomingRead {
+		a.markMessagesAsRead(req.Account.OrganizationID, req.Contact.ID, req.Contact)
 	}
 }
 


### PR DESCRIPTION
Pre-mark the incoming message as read in saveIncomingMessage if the chatbot is going to process it (enabled + no active transfer). Avoids the brief unread-badge flash before the bot's reply arrives. Also adds MarkIncomingRead to ChatbotSendOptions as a backstop for bot replies that follow.