### PR TITLE
fix(chat): only count unread when tab is hidden, show as inline divider

### DIFF
--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -315,7 +315,19 @@ class WebSocketService {
     // Use currentContact.id (already validated, from our /contacts response)
     // rather than the WS payload value to avoid pushing untrusted data into
     // a request URL.
-    if (isViewingThisContact && currentContact && payload.direction === 'incoming') {
+    // Skip the call when the message already arrived as 'read' — the backend
+    // pre-marks chatbot-handled messages at save time, and re-marking just
+    // touches DB rows that are already in the right state.
+    // Also skip when the agent isn't actually looking — that includes both
+    // tab-hidden (different browser tab) and window-unfocused (browser is
+    // visible but agent is in another OS window). Firing markRead in those
+    // cases would send a WhatsApp read receipt to the customer (blue ticks)
+    // for a message no one has read. The mark fires when the user comes
+    // back instead (handled in ChatView's focus/visibility listeners).
+    const alreadyRead = payload.status === 'read'
+    const userActive = typeof document === 'undefined'
+      || (document.visibilityState === 'visible' && document.hasFocus())
+    if (isViewingThisContact && currentContact && payload.direction === 'incoming' && !alreadyRead && userActive) {
       contactsService.markRead(currentContact.id)
         .catch(() => { /* non-critical, will resync on next chat-open */ })
         .finally(() => store.fetchContacts())

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -246,14 +246,7 @@ const messagesScroll = useInfiniteScroll({
 
 function updateAtBottom(el: HTMLElement) {
   const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop
-  const wasAtBottom = isAtBottom.value
   isAtBottom.value = distanceFromBottom < SCROLL_BOTTOM_THRESHOLD
-  // User scrolled to the bottom on their own — they've "seen" the new
-  // messages, drop the unread divider.
-  if (!wasAtBottom && isAtBottom.value) {
-    newMessagesCount.value = 0
-    firstUnreadId.value = null
-  }
 }
 
 const contactId = computed(() => route.params.contactId as string | undefined)
@@ -450,7 +443,30 @@ onMounted(async () => {
   if (contactId.value) {
     await selectContact(contactId.value)
   }
+
+  // Auto-scroll to the unread divider and mark messages read when the agent
+  // returns — covers both tab-switch (visibilitychange) and OS window focus
+  // (focus event), since "tab visible but window unfocused" is a real state
+  // and we don't want to send blue-tick receipts when no one is looking.
+  // See issue #280.
+  document.addEventListener('visibilitychange', onUserActive)
+  window.addEventListener('focus', onUserActive)
 })
+
+function onUserActive() {
+  if (document.visibilityState !== 'visible' || !document.hasFocus()) return
+  if (!firstUnreadId.value) return
+  if (contactsStore.currentContact) {
+    contactsService.markRead(contactsStore.currentContact.id)
+      .catch(() => { /* non-critical */ })
+  }
+  nextTick(() => {
+    const el = document.getElementById(`message-${firstUnreadId.value}`)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  })
+}
 
 onUnmounted(() => {
   wsService.setCurrentContact(null)
@@ -459,6 +475,8 @@ onUnmounted(() => {
   notesStore.clearNotes()
   // Clear sticky date timeout
   if (stickyDateTimeout) clearTimeout(stickyDateTimeout)
+  document.removeEventListener('visibilitychange', onUserActive)
+  window.removeEventListener('focus', onUserActive)
 })
 
 function updateStickyDate(scrollContainer: HTMLElement) {
@@ -595,19 +613,30 @@ async function selectContact(id: string) {
 }
 
 // Watch for new messages. WhatsApp Web style: while the browser tab is
-// focused on this chat the user is "watching", so just auto-scroll. When
-// they're on another tab, surface a "N unread messages" divider above
-// the first message that arrived while away (issue #280).
+// focused on this chat the user is "watching", so auto-scroll if they're
+// at the bottom. When they're on another tab, pile up unread and surface
+// a divider above the first message that arrived while away (issue #280).
+// The two branches are mutually exclusive — auto-scrolling while the tab
+// is hidden races with the divider state.
 watch(() => contactsStore.messages.length, (newLen, oldLen) => {
   if (newLen <= oldLen) return
   const latest = contactsStore.messages[newLen - 1]
   const isIncoming = latest?.direction === 'incoming'
-  const tabHidden = typeof document !== 'undefined' && document.visibilityState === 'hidden'
-  if (isIncoming && tabHidden) {
+  // "Not actively looking" covers both other-tab (hidden) and other-window
+  // (visible but unfocused). The divider should pile in either case.
+  const userAway = typeof document !== 'undefined'
+    && (document.visibilityState === 'hidden' || !document.hasFocus())
+  if (isIncoming && userAway) {
     if (newMessagesCount.value === 0) {
       firstUnreadId.value = latest.id
     }
     newMessagesCount.value += 1
+    return
+  }
+  // Outgoing (the agent replied) — they've seen the unread, drop the divider.
+  if (!isIncoming && newMessagesCount.value > 0) {
+    newMessagesCount.value = 0
+    firstUnreadId.value = null
   }
   if (isAtBottom.value || !isIncoming) {
     scrollToBottom()
@@ -1715,13 +1744,11 @@ async function sendMediaMessage() {
                      message that arrived while the tab was hidden) -->
                 <div
                   v-if="newMessagesCount > 0 && message.id === firstUnreadId"
-                  class="flex items-center justify-center my-3"
+                  class="flex items-center justify-center my-4"
                 >
-                  <div class="flex-1 h-px bg-emerald-500/30" />
-                  <div class="px-3 text-[11px] text-emerald-400 light:text-emerald-700 font-medium uppercase tracking-wide">
+                  <div class="px-3 py-1 bg-white/[0.06] light:bg-gray-200 rounded-full text-[11px] text-white/40 light:text-gray-600 font-medium">
                     {{ newMessagesCount }} {{ newMessagesCount === 1 ? $t('chat.unreadMessage', 'unread message') : $t('chat.unreadMessages', 'unread messages') }}
                   </div>
-                  <div class="flex-1 h-px bg-emerald-500/30" />
                 </div>
 
               <!-- Message bubble -->

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -246,7 +246,14 @@ const messagesScroll = useInfiniteScroll({
 
 function updateAtBottom(el: HTMLElement) {
   const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop
+  const wasAtBottom = isAtBottom.value
   isAtBottom.value = distanceFromBottom < SCROLL_BOTTOM_THRESHOLD
+  // User scrolled to the bottom on their own — they've "seen" the new
+  // messages, drop the unread divider.
+  if (!wasAtBottom && isAtBottom.value) {
+    newMessagesCount.value = 0
+    firstUnreadId.value = null
+  }
 }
 
 const contactId = computed(() => route.params.contactId as string | undefined)
@@ -587,15 +594,16 @@ async function selectContact(id: string) {
   }
 }
 
-// Watch for new messages. Auto-scroll if the user is already at the
-// bottom (or sent the message themselves). Every incoming message also
-// increments the unread pill; the pill click jumps up to the first
-// message of the batch so the user can read forward (issue #280).
+// Watch for new messages. WhatsApp Web style: while the browser tab is
+// focused on this chat the user is "watching", so just auto-scroll. When
+// they're on another tab, surface a "N unread messages" divider above
+// the first message that arrived while away (issue #280).
 watch(() => contactsStore.messages.length, (newLen, oldLen) => {
   if (newLen <= oldLen) return
   const latest = contactsStore.messages[newLen - 1]
   const isIncoming = latest?.direction === 'incoming'
-  if (isIncoming) {
+  const tabHidden = typeof document !== 'undefined' && document.visibilityState === 'hidden'
+  if (isIncoming && tabHidden) {
     if (newMessagesCount.value === 0) {
       firstUnreadId.value = latest.id
     }
@@ -988,16 +996,6 @@ function scrollToBottom(instant = false) {
   })
 }
 
-function jumpToFirstUnread() {
-  if (firstUnreadId.value) {
-    const el = document.getElementById(`message-${firstUnreadId.value}`)
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }
-  }
-  newMessagesCount.value = 0
-  firstUnreadId.value = null
-}
 
 function getMessageStatusIcon(status: string) {
   switch (status) {
@@ -1689,18 +1687,6 @@ async function sendMediaMessage() {
             </div>
           </Transition>
 
-          <!-- Unread-messages pill (WhatsApp-style; click to jump to bottom) -->
-          <Transition name="sticky-date">
-            <button
-              v-if="newMessagesCount > 0"
-              type="button"
-              class="absolute top-2 left-1/2 -translate-x-1/2 z-20 px-3 py-1 bg-white/[0.08] light:bg-gray-200 backdrop-blur-sm rounded-full text-[11px] text-white/70 light:text-gray-700 font-medium shadow-sm hover:bg-white/[0.12] light:hover:bg-gray-300 transition-colors"
-              @click="jumpToFirstUnread"
-            >
-              {{ newMessagesCount }} {{ newMessagesCount === 1 ? $t('chat.unreadMessage', 'unread message') : $t('chat.unreadMessages', 'unread messages') }}
-            </button>
-          </Transition>
-
           <ScrollArea :ref="(el: any) => messagesScroll.scrollAreaRef.value = el" class="h-full p-3 chat-background">
             <div class="space-y-2">
               <!-- Loading indicator for older messages -->
@@ -1723,6 +1709,19 @@ async function sendMediaMessage() {
                   <div class="px-3 py-1 bg-white/[0.06] light:bg-gray-200 rounded-full text-[11px] text-white/40 light:text-gray-600 font-medium">
                     {{ getDateLabel(message.created_at) }}
                   </div>
+                </div>
+
+                <!-- Unread divider (WhatsApp-style; appears above the first
+                     message that arrived while the tab was hidden) -->
+                <div
+                  v-if="newMessagesCount > 0 && message.id === firstUnreadId"
+                  class="flex items-center justify-center my-3"
+                >
+                  <div class="flex-1 h-px bg-emerald-500/30" />
+                  <div class="px-3 text-[11px] text-emerald-400 light:text-emerald-700 font-medium uppercase tracking-wide">
+                    {{ newMessagesCount }} {{ newMessagesCount === 1 ? $t('chat.unreadMessage', 'unread message') : $t('chat.unreadMessages', 'unread messages') }}
+                  </div>
+                  <div class="flex-1 h-px bg-emerald-500/30" />
                 </div>
 
               <!-- Message bubble -->


### PR DESCRIPTION
Pill replaced by an inline divider above the first message that arrived while the tab was hidden — like WhatsApp Web. Tab focused = auto-scroll, no divider. Divider clears when user scrolls back to the bottom or switches contact.