### PR TITLE
fix(templates): pass filename in DOCUMENT header so customer sees real name

### DIFF
--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -52,10 +52,11 @@ type OutgoingMessageRequest struct {
 	URL             string            // For CTA URL button
 
 	// Template messages
-	Template        *models.Template
-	BodyParams      map[string]string // Parameter name -> value (supports both named and positional)
-	HeaderMediaID   string            // WhatsApp media ID for template header (IMAGE/VIDEO/DOCUMENT)
-	ButtonURLParams map[string]string // Button index (as string) -> dynamic URL param value
+	Template            *models.Template
+	BodyParams          map[string]string // Parameter name -> value (supports both named and positional)
+	HeaderMediaID       string            // WhatsApp media ID for template header (IMAGE/VIDEO/DOCUMENT)
+	HeaderMediaFilename string            // Filename — required by Meta for DOCUMENT headers
+	ButtonURLParams     map[string]string // Button index (as string) -> dynamic URL param value
 
 	// WhatsApp Flow messages
 	FlowID          string // Meta Flow ID
@@ -194,7 +195,7 @@ func (a *App) SendOutgoingMessage(ctx context.Context, req OutgoingMessageReques
 			if req.Template == nil {
 				return "", fmt.Errorf("template is required for template messages")
 			}
-			components := whatsapp.BuildTemplateComponents(req.BodyParams, req.Template.HeaderType, req.HeaderMediaID)
+			components := whatsapp.BuildTemplateComponents(req.BodyParams, req.Template.HeaderType, req.HeaderMediaID, req.HeaderMediaFilename)
 			// Add auto-generated button components (Flow needs flow_token)
 			flowComponents := whatsapp.AutoButtonComponents(req.Template.Buttons)
 			components = append(components, flowComponents...)
@@ -607,8 +608,9 @@ type SendTemplateMessageRequest struct {
 	//   1. header_media_id  — pre-uploaded WhatsApp media ID (skip upload)
 	//   2. header_media_url — URL to fetch the media from (server downloads & uploads to WhatsApp)
 	//   3. multipart header_file — raw file upload via multipart/form-data
-	HeaderMediaID  string `json:"header_media_id"`  // Already-uploaded WhatsApp media ID
-	HeaderMediaURL string `json:"header_media_url"` // URL to download media from
+	HeaderMediaID       string `json:"header_media_id"`       // Already-uploaded WhatsApp media ID
+	HeaderMediaURL      string `json:"header_media_url"`      // URL to download media from
+	HeaderMediaFilename string `json:"header_media_filename"` // Filename — required by Meta for DOCUMENT headers (#351)
 }
 
 // SendTemplateMessage sends a template message to a contact or phone number.
@@ -622,6 +624,7 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 	var req SendTemplateMessageRequest
 	var headerFileData []byte
 	var headerFileMimeType string
+	var headerFileFilename string
 
 	contentType := string(r.RequestCtx.Request.Header.ContentType())
 	if strings.HasPrefix(contentType, "multipart/form-data") {
@@ -674,6 +677,10 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 			if headerFileMimeType == "" {
 				headerFileMimeType = "application/octet-stream"
 			}
+			headerFileFilename = fh.Filename
+		}
+		if v := form.Value["header_media_filename"]; len(v) > 0 {
+			req.HeaderMediaFilename = v[0]
 		}
 	} else {
 		if err := a.decodeRequest(r, &req); err != nil {
@@ -865,17 +872,25 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		}
 	}
 
+	// Resolve filename for DOCUMENT headers — required by Meta (#351).
+	// Caller-supplied wins, then the multipart filename.
+	headerMediaFilename := req.HeaderMediaFilename
+	if headerMediaFilename == "" {
+		headerMediaFilename = headerFileFilename
+	}
+
 	// Send using unified message sender
 	msgReq := OutgoingMessageRequest{
-		Account:         account,
-		Contact:         contact,
-		Type:            models.MessageTypeTemplate,
-		Template:        &template,
-		BodyParams:      req.TemplateParams,
-		HeaderMediaID:   headerMediaID,
-		MediaURL:        headerLocalPath,
-		MediaMimeType:   headerMimeType,
-		ButtonURLParams: buttonParams,
+		Account:             account,
+		Contact:             contact,
+		Type:                models.MessageTypeTemplate,
+		Template:            &template,
+		BodyParams:          req.TemplateParams,
+		HeaderMediaID:       headerMediaID,
+		HeaderMediaFilename: headerMediaFilename,
+		MediaURL:            headerLocalPath,
+		MediaMimeType:       headerMimeType,
+		ButtonURLParams:     buttonParams,
 	}
 
 	opts := DefaultSendOptions()

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -115,7 +115,7 @@ func (w *Worker) HandleRecipientJob(ctx context.Context, job *queue.RecipientJob
 	}
 
 	// Send template message
-	waMessageID, err := w.sendTemplateMessage(ctx, &account, campaign.Template, recipient, campaign.HeaderMediaID)
+	waMessageID, err := w.sendTemplateMessage(ctx, &account, campaign.Template, recipient, campaign.HeaderMediaID, campaign.HeaderMediaFilename)
 
 	// Create Message record
 	message := models.Message{
@@ -251,7 +251,7 @@ func (w *Worker) checkCampaignCompletion(ctx context.Context, campaignID, organi
 }
 
 // sendTemplateMessage sends a template message via WhatsApp Cloud API
-func (w *Worker) sendTemplateMessage(ctx context.Context, account *models.WhatsAppAccount, template *models.Template, recipient *models.BulkMessageRecipient, campaignHeaderMediaID string) (string, error) {
+func (w *Worker) sendTemplateMessage(ctx context.Context, account *models.WhatsAppAccount, template *models.Template, recipient *models.BulkMessageRecipient, campaignHeaderMediaID, campaignHeaderMediaFilename string) (string, error) {
 	waAccount := account.ToWAAccount()
 
 	// Resolve body parameters into a map for BuildTemplateComponents
@@ -267,7 +267,7 @@ func (w *Worker) sendTemplateMessage(ctx context.Context, account *models.WhatsA
 	}
 
 	// Use the shared component builder (same as chat template sending)
-	components := whatsapp.BuildTemplateComponents(bodyParams, template.HeaderType, campaignHeaderMediaID)
+	components := whatsapp.BuildTemplateComponents(bodyParams, template.HeaderType, campaignHeaderMediaID, campaignHeaderMediaFilename)
 	// Add auto-generated button components (Flow needs flow_token)
 	flowComponents := whatsapp.AutoButtonComponents(template.Buttons)
 	components = append(components, flowComponents...)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -491,7 +491,7 @@ func TestWorker_sendTemplateMessage_BuildsComponents(t *testing.T) {
 		},
 	}
 
-	msgID, err := w.sendTemplateMessage(context.Background(), account, template, recipient, "")
+	msgID, err := w.sendTemplateMessage(context.Background(), account, template, recipient, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "wamid.test123", msgID)
 
@@ -547,7 +547,7 @@ func TestWorker_sendTemplateMessage_NoParams(t *testing.T) {
 		TemplateParams: nil, // No params
 	}
 
-	msgID, err := w.sendTemplateMessage(context.Background(), account, template, recipient, "")
+	msgID, err := w.sendTemplateMessage(context.Background(), account, template, recipient, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "wamid.test456", msgID)
 

--- a/pkg/whatsapp/message.go
+++ b/pkg/whatsapp/message.go
@@ -301,17 +301,23 @@ func BodyParamsToComponents(bodyParams map[string]string) []map[string]any {
 
 // BuildTemplateComponents builds the full WhatsApp template components array,
 // including an optional header component (for IMAGE/VIDEO/DOCUMENT) and body parameters.
-func BuildTemplateComponents(bodyParams map[string]string, headerType string, headerMediaID string) []map[string]any {
+//
+// headerMediaFilename is required by Meta for DOCUMENT headers — without it, the
+// API returns error 132012 "Header Format Mismatch (Expected DOCUMENT, received
+// UNKNOWN)". It is ignored for IMAGE/VIDEO.
+func BuildTemplateComponents(bodyParams map[string]string, headerType, headerMediaID, headerMediaFilename string) []map[string]any {
 	var components []map[string]any
 
 	// Add header component if media is provided
 	if headerMediaID != "" {
 		mediaType := strings.ToLower(headerType) // "image", "video", "document"
+		mediaObj := map[string]any{"id": headerMediaID}
+		if mediaType == "document" && headerMediaFilename != "" {
+			mediaObj["filename"] = headerMediaFilename
+		}
 		headerParam := map[string]any{
-			"type": mediaType,
-			mediaType: map[string]any{
-				"id": headerMediaID,
-			},
+			"type":    mediaType,
+			mediaType: mediaObj,
 		}
 		components = append(components, map[string]any{
 			"type":       "header",

--- a/pkg/whatsapp/message_test.go
+++ b/pkg/whatsapp/message_test.go
@@ -603,3 +603,41 @@ func TestBodyParamsToComponents_NamedParamsRetainLexicalOrder(t *testing.T) {
 	assert.Equal(t, "order_id", params[1]["parameter_name"])
 	assert.Equal(t, "o1", params[1]["text"])
 }
+
+// Document headers must include filename — Meta returns 132012 "Header
+// Format Mismatch" without it. Issue #351.
+func TestBuildTemplateComponents_DocumentHeaderIncludesFilename(t *testing.T) {
+	components := whatsapp.BuildTemplateComponents(nil, "DOCUMENT", "media-id-123", "invoice.pdf")
+	require.Len(t, components, 1)
+	assert.Equal(t, "header", components[0]["type"])
+
+	params := components[0]["parameters"].([]map[string]any)
+	require.Len(t, params, 1)
+	assert.Equal(t, "document", params[0]["type"])
+
+	doc := params[0]["document"].(map[string]any)
+	assert.Equal(t, "media-id-123", doc["id"])
+	assert.Equal(t, "invoice.pdf", doc["filename"])
+}
+
+func TestBuildTemplateComponents_ImageHeaderOmitsFilename(t *testing.T) {
+	components := whatsapp.BuildTemplateComponents(nil, "IMAGE", "media-id-456", "photo.jpg")
+	require.Len(t, components, 1)
+	params := components[0]["parameters"].([]map[string]any)
+	img := params[0]["image"].(map[string]any)
+	assert.Equal(t, "media-id-456", img["id"])
+	_, hasFilename := img["filename"]
+	assert.False(t, hasFilename, "image headers must not include filename")
+}
+
+func TestBuildTemplateComponents_DocumentHeaderEmptyFilename(t *testing.T) {
+	// If no filename was supplied, don't include the key — better than sending
+	// an empty string Meta might reject.
+	components := whatsapp.BuildTemplateComponents(nil, "DOCUMENT", "media-id-789", "")
+	require.Len(t, components, 1)
+	params := components[0]["parameters"].([]map[string]any)
+	doc := params[0]["document"].(map[string]any)
+	assert.Equal(t, "media-id-789", doc["id"])
+	_, hasFilename := doc["filename"]
+	assert.False(t, hasFilename, "empty filename should not be set")
+}


### PR DESCRIPTION
Without filename in the document parameter, WhatsApp shows the file as 'untitled' on the recipient's side. Thread the original filename through campaign worker (campaign.HeaderMediaFilename) and chat-side template send (multipart fh.Filename or explicit header_media_filename field).
