### PR TITLE
fix(rbac): use permission instead of role name for transfer/analytics views

### DIFF
--- a/frontend/e2e/tests/settings/transfers-permissions.spec.ts
+++ b/frontend/e2e/tests/settings/transfers-permissions.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, Page } from '@playwright/test'
+import { ApiHelper, generateUniqueName, generateUniqueEmail } from '../../helpers'
+
+/**
+ * Regression: a user on a CUSTOM role (not literally named admin/manager)
+ * with transfers:read + transfers:write should see all three tabs on the
+ * Transfers page. Before the role-name-to-permission fix, the tabs were
+ * gated on `userRole === 'admin' || userRole === 'manager'`, so custom
+ * roles silently saw the agent-only view.
+ */
+
+async function loginWithCredentials(page: Page, email: string, password: string) {
+  await page.goto('/login')
+  await page.locator('input[name="email"], input[type="email"]').fill(email)
+  await page.locator('input[name="password"], input[type="password"]').fill(password)
+  await page.locator('button[type="submit"]').click()
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 10000 })
+}
+
+test.describe('Transfers tabs respect transfers:write permission', () => {
+  const customRoleName = generateUniqueName('E2E Transfer Manager')
+  const fullAccessEmail = generateUniqueEmail('e2e-transfers-write')
+  const readOnlyEmail = generateUniqueEmail('e2e-transfers-read')
+  const password = 'Password123!'
+
+  let api: ApiHelper
+  let fullAccessRoleId: string
+  let readOnlyRoleId: string
+  let fullAccessUserId: string
+  let readOnlyUserId: string
+
+  test.beforeAll(async ({ request }) => {
+    api = new ApiHelper(request)
+    await api.login('admin@admin.com', 'admin')
+
+    // Custom role with full transfers access — name deliberately not "admin"/"manager"
+    const fullPerms = await api.findPermissionKeys([
+      { resource: 'chat', action: 'read' },
+      { resource: 'transfers', action: 'read' },
+      { resource: 'transfers', action: 'write' },
+      { resource: 'transfers', action: 'pickup' },
+    ])
+    const fullRole = await api.createRole({
+      name: customRoleName,
+      description: 'Custom role with full transfer permissions for e2e',
+      permissions: fullPerms,
+    })
+    fullAccessRoleId = fullRole.id
+
+    const fullUser = await api.createUser({
+      email: fullAccessEmail,
+      password,
+      full_name: 'E2E Full Transfer Access',
+      role_id: fullAccessRoleId,
+    })
+    fullAccessUserId = fullUser.id
+
+    // Custom role with only read+pickup — should see agent-only view
+    const readPerms = await api.findPermissionKeys([
+      { resource: 'chat', action: 'read' },
+      { resource: 'transfers', action: 'read' },
+      { resource: 'transfers', action: 'pickup' },
+    ])
+    const readRole = await api.createRole({
+      name: generateUniqueName('E2E Transfer Agent'),
+      description: 'Custom role with read-only transfers for e2e',
+      permissions: readPerms,
+    })
+    readOnlyRoleId = readRole.id
+
+    const readUser = await api.createUser({
+      email: readOnlyEmail,
+      password,
+      full_name: 'E2E Read-Only Transfer',
+      role_id: readOnlyRoleId,
+    })
+    readOnlyUserId = readUser.id
+  })
+
+  test.afterAll(async () => {
+    if (fullAccessUserId) await api.deleteUser(fullAccessUserId).catch(() => {})
+    if (readOnlyUserId) await api.deleteUser(readOnlyUserId).catch(() => {})
+    if (fullAccessRoleId) await api.deleteRole(fullAccessRoleId).catch(() => {})
+    if (readOnlyRoleId) await api.deleteRole(readOnlyRoleId).catch(() => {})
+  })
+
+  test('custom role with transfers:write sees all three tabs', async ({ page }) => {
+    await loginWithCredentials(page, fullAccessEmail, password)
+    await page.goto('/chatbot/transfers')
+    await page.waitForLoadState('networkidle')
+
+    // Tabs only render in the admin/manager view; with the role-name-based
+    // check they would have been hidden for this custom role.
+    const tablist = page.locator('[role="tablist"]')
+    await expect(tablist).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('tab', { name: /My Transfers/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: /Queue/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: /History/i })).toBeVisible()
+  })
+
+  test('custom role without transfers:write sees agent-only view (no tabs)', async ({ page }) => {
+    await loginWithCredentials(page, readOnlyEmail, password)
+    await page.goto('/chatbot/transfers')
+    await page.waitForLoadState('networkidle')
+
+    // Agent view has no tabs — they go straight to their own transfers list.
+    await expect(page.locator('[role="tablist"]')).toHaveCount(0)
+  })
+})

--- a/frontend/e2e/tests/settings/transfers-permissions.spec.ts
+++ b/frontend/e2e/tests/settings/transfers-permissions.spec.ts
@@ -18,7 +18,10 @@ async function loginWithCredentials(page: Page, email: string, password: string)
 }
 
 test.describe('Transfers tabs respect transfers:write permission', () => {
-  const customRoleName = generateUniqueName('E2E Transfer Manager')
+  // Role names deliberately avoid the words "Agent" / "Manager" so they
+  // don't collide with users.spec.ts's hasText('Agent') filter on the role
+  // dropdown — leftover soft-deleted rows would otherwise break that test.
+  const customRoleName = generateUniqueName('E2E Tx Full')
   const fullAccessEmail = generateUniqueEmail('e2e-transfers-write')
   const readOnlyEmail = generateUniqueEmail('e2e-transfers-read')
   const password = 'Password123!'
@@ -62,7 +65,7 @@ test.describe('Transfers tabs respect transfers:write permission', () => {
       { resource: 'transfers', action: 'pickup' },
     ])
     const readRole = await api.createRole({
-      name: generateUniqueName('E2E Transfer Agent'),
+      name: generateUniqueName('E2E Tx Read'),
       description: 'Custom role with read-only transfers for e2e',
       permissions: readPerms,
     })

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -373,12 +373,13 @@ class WebSocketService {
     // Refresh to get complete data including SLA fields
     transfersStore.fetchTransfers({ status: 'active' })
 
-    // Show toast notification for admin/manager or assigned agent
-    const userRole = authStore.user?.role?.name
+    // Toast only the assigned agent — managers/admins get notification noise
+    // for every transfer in the org otherwise. They can keep the Transfers
+    // page open if they want live updates.
     const currentUserId = authStore.user?.id
     const isAssignedToMe = payload.agent_id === currentUserId
 
-    if (userRole === 'admin' || userRole === 'manager' || isAssignedToMe) {
+    if (isAssignedToMe) {
       const contactName = payload.contact_name || payload.phone_number
       toast.info('New Transfer', {
         description: `${contactName} has been transferred to ${isAssignedToMe ? 'you' : 'agent queue'}`,
@@ -441,11 +442,10 @@ class WebSocketService {
     const notifyIds: string[] = payload.escalation_notify_ids || []
     const shouldNotify = notifyIds.includes(currentUserId || '')
 
-    // Also notify admins/managers
-    const userRole = authStore.user?.role?.name
-    const isAdminOrManager = userRole === 'admin' || userRole === 'manager'
-
-    if (shouldNotify || isAdminOrManager) {
+    // Trust the backend's escalation_notify_ids list — it already includes
+    // the right people per the escalation rules. Don't broadcast to every
+    // manager too; that's just noise and risks burying real alerts.
+    if (shouldNotify) {
       const levelName = payload.level_name === 'critical' ? 'Critical' : 'Warning'
       const contactName = payload.contact_name || payload.phone_number
 

--- a/frontend/src/views/analytics/AgentAnalyticsView.vue
+++ b/frontend/src/views/analytics/AgentAnalyticsView.vue
@@ -73,7 +73,9 @@ interface AgentAnalyticsResponse {
 const { t } = useI18n()
 const authStore = useAuthStore()
 const usersStore = useUsersStore()
-const isAdminOrManager = computed(() => ['admin', 'manager'].includes(authStore.user?.role?.name || ''))
+// Permission-driven (analytics.agents:read), not role-name based — custom
+// roles with the right permission should get the same view.
+const isAdminOrManager = computed(() => authStore.hasPermission('analytics.agents', 'read'))
 
 const analytics = ref<AgentAnalyticsResponse | null>(null)
 const isLoading = ref(true)

--- a/frontend/src/views/chatbot/AgentTransfersView.vue
+++ b/frontend/src/views/chatbot/AgentTransfersView.vue
@@ -46,8 +46,10 @@ const agents = ref<{ id: string; full_name: string }[]>([])
 const teams = ref<Team[]>([])
 const selectedTeamFilter = ref<string>('all')
 
-const userRole = computed(() => authStore.user?.role?.name)
-const isAdminOrManager = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
+// Backend grants full transfer visibility on transfers:write (agent_transfers.go:110).
+// Honor the same permission here instead of hardcoding role names — otherwise
+// custom roles with the right permissions still see the agent-only view.
+const isAdminOrManager = computed(() => authStore.hasPermission('transfers', 'write'))
 const currentUserId = computed(() => authStore.user?.id)
 
 const myTransfers = computed(() =>


### PR DESCRIPTION
Two views gated their admin/manager UI on role name being literally 'admin' or 'manager'. Custom roles with the right permissions saw the agent-only view. Switch to authStore.hasPermission so the permission system is the source of truth.