### PR TITLE
feat(canned-responses): full-page detail view with audit logging

### DIFF
--- a/frontend/e2e/pages/SettingsPage.ts
+++ b/frontend/e2e/pages/SettingsPage.ts
@@ -275,7 +275,7 @@ export class CannedResponsesPage extends TableSettingsPage {
 
   constructor(page: Page) {
     super(page, { headingText: 'Canned Responses', addButtonText: 'Add Response' })
-    // Category filter is now the second combobox (after search)
+    // Category filter is the first combobox in the card header (search is an input)
     this.categoryFilter = page.locator('button[role="combobox"]').first()
   }
 
@@ -295,42 +295,79 @@ export class CannedResponsesPage extends TableSettingsPage {
     await this.page.waitForTimeout(300)
   }
 
-  async fillResponseForm(name: string, content: string, shortcut?: string, category?: string) {
-    await this.dialog.locator('input').first().fill(name)
-    if (shortcut) {
-      await this.dialog.locator('input').nth(1).fill(shortcut)
-    }
-    await this.dialog.locator('textarea').fill(content)
-    if (category) {
-      await this.dialog.locator('button[role="combobox"]').click()
-      await this.page.locator('[role="option"]').filter({ hasText: category }).click()
-    }
+  // --- Detail-page (full-page) form helpers ---
+
+  /** Click "Add Response" — navigates to /settings/canned-responses/new. */
+  async openCreate() {
+    await this.addButton.click()
+    await this.page.waitForURL(/\/settings\/canned-responses\/new$/)
+    await this.page.waitForLoadState('networkidle')
   }
 
-  // Table helpers - buttons in order: copy, edit, delete
+  /** Fill the detail-page form (works for both create and edit). */
+  async fillResponseForm(name: string, content: string, shortcut?: string, category?: string) {
+    const nameInput = this.page.locator('div.space-y-1\\.5:has(> label:has-text("Name")) input').first()
+    const shortcutInput = this.page.locator('div.space-y-1\\.5:has(> label:has-text("Shortcut")) input').first()
+    const textarea = this.page.locator('div.space-y-1\\.5:has(> label:has-text("Content")) textarea').first()
+
+    await nameInput.fill(name)
+    if (shortcut !== undefined) {
+      await shortcutInput.fill(shortcut)
+    }
+    await textarea.fill(content)
+    if (category) {
+      await this.page
+        .locator('div.space-y-1\\.5:has(> label:has-text("Category")) button[role="combobox"]')
+        .first()
+        .click()
+      await this.page.locator('[role="option"]').filter({ hasText: category }).click()
+    }
+    // Let the watcher mark the form dirty and reveal the Save button.
+    await this.page.waitForTimeout(300)
+  }
+
+  /** Click the Save button on the detail page. */
+  async saveDetail() {
+    const saveBtn = this.page.getByRole('button', { name: /^Save$/i })
+    await expect(saveBtn).toBeVisible({ timeout: 5000 })
+    await saveBtn.click()
+  }
+
+  /** Click the Delete button on the detail page and confirm in the alert. */
+  async deleteFromDetail() {
+    const deleteBtn = this.page.getByRole('button', { name: /^Delete$/i }).first()
+    await expect(deleteBtn).toBeVisible({ timeout: 5000 })
+    await deleteBtn.click()
+    await this.alertDialog.waitFor({ state: 'visible' })
+    await this.alertDialog.getByRole('button', { name: /^Delete$/i }).click()
+  }
+
+  // --- Table helpers ---
+
   getResponseRow(name: string): Locator {
     return this.page.locator('tbody tr').filter({ hasText: name })
   }
 
+  /** Action column order: copy, edit, delete. */
   async copyResponse(name: string) {
     const row = this.getResponseRow(name)
     await expect(row).toBeVisible({ timeout: 10000 })
-    // Copy is first button in actions column
     await row.locator('td:last-child button').first().click()
   }
 
+  /** Click the Edit (pencil) action → navigates to the detail page. */
   async editResponse(name: string) {
     const row = this.getResponseRow(name)
     await expect(row).toBeVisible({ timeout: 10000 })
-    // Edit is second button in actions column
     await row.locator('td:last-child button').nth(1).click()
-    await this.dialog.waitFor({ state: 'visible' })
+    await this.page.waitForURL(/\/settings\/canned-responses\/[a-f0-9-]+$/)
+    await this.page.waitForLoadState('networkidle')
   }
 
+  /** Click the row-level Delete action → opens the confirm AlertDialog. */
   async deleteResponse(name: string) {
     const row = this.getResponseRow(name)
     await expect(row).toBeVisible({ timeout: 10000 })
-    // Delete is third button in actions column
     await row.locator('td:last-child button').nth(2).click()
     await this.alertDialog.waitFor({ state: 'visible' })
   }
@@ -341,15 +378,6 @@ export class CannedResponsesPage extends TableSettingsPage {
 
   async expectResponseNotExists(name: string) {
     await expect(this.getResponseRow(name)).not.toBeVisible()
-  }
-
-  // Dialog helpers for tests
-  getDialogInput(index: number): Locator {
-    return this.dialog.locator('input').nth(index)
-  }
-
-  getDialogTextarea(): Locator {
-    return this.dialog.locator('textarea')
   }
 }
 

--- a/frontend/e2e/tests/settings/canned-responses.spec.ts
+++ b/frontend/e2e/tests/settings/canned-responses.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { loginAsAdmin } from '../../helpers'
+import { loginAsAdmin, verifyAuditLogged, ApiHelper, TEST_USERS } from '../../helpers'
 import { CannedResponsesPage } from '../../pages'
 import { createTestScope } from '../../framework'
 
@@ -8,8 +8,10 @@ const scope = createTestScope('canned-responses')
 test.describe('Canned Responses Management', () => {
   let cannedResponsesPage: CannedResponsesPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, request }) => {
     await loginAsAdmin(page)
+    // Authenticate the API request fixture so verifyAuditLogged can hit /api/audit-logs.
+    await new ApiHelper(request).login(TEST_USERS.admin.email, TEST_USERS.admin.password)
     cannedResponsesPage = new CannedResponsesPage(page)
     await cannedResponsesPage.goto()
   })
@@ -19,100 +21,135 @@ test.describe('Canned Responses Management', () => {
     await expect(cannedResponsesPage.addButton).toBeVisible()
   })
 
-  test('should open create canned response dialog', async () => {
-    await cannedResponsesPage.openCreateDialog()
-    await cannedResponsesPage.expectDialogVisible()
-    await expect(cannedResponsesPage.dialog).toContainText('Canned Response')
+  test('should navigate to create detail page', async ({ page }) => {
+    await cannedResponsesPage.openCreate()
+    expect(page.url()).toContain('/settings/canned-responses/new')
+    await expect(page.getByRole('heading', { name: 'Create Canned Response' })).toBeVisible()
   })
 
-  test('should show validation error for empty name and content', async () => {
-    await cannedResponsesPage.openCreateDialog()
-    await cannedResponsesPage.submitDialog()
+  test('should show validation error when saving empty form', async () => {
+    await cannedResponsesPage.openCreate()
+    // Type then clear to flip the dirty flag and reveal Save.
+    await cannedResponsesPage.fillResponseForm('temp', 'temp')
+    await cannedResponsesPage.fillResponseForm('', '')
+    await cannedResponsesPage.saveDetail()
     await cannedResponsesPage.expectToast('required')
   })
 
-  test('should create a new canned response', async () => {
-    const responseName = scope.name('test')
+  test('should create a new canned response and audit-log it', async ({ page, request }) => {
+    const responseName = scope.name('create')
     const responseContent = 'Hello! Thank you for contacting us.'
 
-    await cannedResponsesPage.openCreateDialog()
-    await cannedResponsesPage.fillResponseForm(responseName, responseContent, 'test', 'Greetings')
-    await cannedResponsesPage.submitDialog()
+    await cannedResponsesPage.openCreate()
+    await cannedResponsesPage.fillResponseForm(responseName, responseContent, 'create-sc', 'Greetings')
+    await cannedResponsesPage.saveDetail()
 
     await cannedResponsesPage.expectToast('created')
-    await expect(cannedResponsesPage.page.locator('body')).toContainText(responseName)
-  })
 
-  test('should edit existing canned response', async ({ page }) => {
-    // First create a response
-    const responseName = scope.name('edit')
+    // After save we should land on /settings/canned-responses/:id
+    await page.waitForURL(/\/settings\/canned-responses\/[a-f0-9-]+$/)
+    const id = page.url().split('/').pop()!
+    expect(id).toMatch(/^[a-f0-9-]+$/)
 
-    await cannedResponsesPage.openCreateDialog()
-    await cannedResponsesPage.fillResponseForm(responseName, 'Original content')
-    await cannedResponsesPage.submitDialog()
+    await verifyAuditLogged(request, 'canned_response', id, 'created', {
+      expectedFields: ['name', 'content'],
+    })
 
-    // Wait for create toast and dismiss it
-    await cannedResponsesPage.expectToast('created')
-    await cannedResponsesPage.dismissToast('created')
-
-    // Wait for response to appear in table
+    await cannedResponsesPage.goto()
     await cannedResponsesPage.expectResponseExists(responseName)
-
-    // Edit the response
-    await cannedResponsesPage.editResponse(responseName)
-    await cannedResponsesPage.getDialogTextarea().fill('Updated content')
-    await cannedResponsesPage.submitDialog('Update')
-
-    await cannedResponsesPage.expectToast('updated')
   })
 
-  test('should delete canned response', async ({ page }) => {
-    // First create a response
+  test('should edit existing canned response and audit-log diff', async ({ page, request }) => {
+    const responseName = scope.name('edit')
+    const updatedContent = 'Updated content body'
+
+    // Create
+    await cannedResponsesPage.openCreate()
+    await cannedResponsesPage.fillResponseForm(responseName, 'Original content')
+    await cannedResponsesPage.saveDetail()
+    await cannedResponsesPage.expectToast('created')
+    await page.waitForURL(/\/settings\/canned-responses\/[a-f0-9-]+$/)
+    const id = page.url().split('/').pop()!
+
+    // Update content on the same detail page
+    const textarea = page.locator('div.space-y-1\\.5:has(> label:has-text("Content")) textarea').first()
+    await textarea.fill(updatedContent)
+    await page.waitForTimeout(300)
+    await cannedResponsesPage.saveDetail()
+    await cannedResponsesPage.expectToast('updated')
+
+    await verifyAuditLogged(request, 'canned_response', id, 'updated', {
+      expectedFields: ['content'],
+    })
+  })
+
+  test('should delete canned response from detail page and audit-log it', async ({ page, request }) => {
     const responseName = scope.name('delete')
 
-    await cannedResponsesPage.openCreateDialog()
+    await cannedResponsesPage.openCreate()
     await cannedResponsesPage.fillResponseForm(responseName, 'To be deleted')
-    await cannedResponsesPage.submitDialog()
+    await cannedResponsesPage.saveDetail()
+    await cannedResponsesPage.expectToast('created')
+    await page.waitForURL(/\/settings\/canned-responses\/[a-f0-9-]+$/)
+    const id = page.url().split('/').pop()!
 
-    // Wait for create toast and dismiss it
+    // Dismiss the created toast so it doesn't intercept clicks.
+    await cannedResponsesPage.dismissToast('created')
+
+    await cannedResponsesPage.deleteFromDetail()
+    await cannedResponsesPage.expectToast('deleted')
+    await page.waitForURL(/\/settings\/canned-responses$/)
+
+    await verifyAuditLogged(request, 'canned_response', id, 'deleted', {
+      expectedFields: ['name'],
+    })
+  })
+
+  test('should delete canned response from row action', async ({ page }) => {
+    const responseName = scope.name('row-delete')
+
+    await cannedResponsesPage.openCreate()
+    await cannedResponsesPage.fillResponseForm(responseName, 'Row delete content')
+    await cannedResponsesPage.saveDetail()
     await cannedResponsesPage.expectToast('created')
     await cannedResponsesPage.dismissToast('created')
 
-    // Wait for response to appear in table
+    await cannedResponsesPage.goto()
+    await cannedResponsesPage.search(responseName)
     await cannedResponsesPage.expectResponseExists(responseName)
 
-    // Delete the response
     await cannedResponsesPage.deleteResponse(responseName)
     await cannedResponsesPage.confirmDelete()
-
     await cannedResponsesPage.expectToast('deleted')
   })
 
   test('should filter by category', async () => {
     await cannedResponsesPage.filterByCategory('Greetings')
-    // Results filtered (depends on existing data)
   })
 
   test('should search canned responses', async ({ page }) => {
-    // First create a response with unique text
-    const uniqueText = scope.name('unique')
+    const uniqueText = scope.name('search')
 
-    await cannedResponsesPage.openCreateDialog()
+    await cannedResponsesPage.openCreate()
     await cannedResponsesPage.fillResponseForm(uniqueText, 'Search test content')
-    await cannedResponsesPage.submitDialog()
-
-    // Wait for creation
+    await cannedResponsesPage.saveDetail()
     await cannedResponsesPage.expectToast('created')
 
-    // Search for the response
+    await cannedResponsesPage.goto()
     await cannedResponsesPage.search(uniqueText)
     await expect(page.locator('body')).toContainText(uniqueText)
   })
 
-  test('should cancel canned response creation', async () => {
-    await cannedResponsesPage.openCreateDialog()
-    await cannedResponsesPage.getDialogInput(0).fill('Cancelled Response')
-    await cannedResponsesPage.cancelDialog()
-    await cannedResponsesPage.expectDialogHidden()
+  test('should show audit log on the detail page', async ({ page }) => {
+    const responseName = scope.name('audit-view')
+
+    await cannedResponsesPage.openCreate()
+    await cannedResponsesPage.fillResponseForm(responseName, 'Audit view content')
+    await cannedResponsesPage.saveDetail()
+    await cannedResponsesPage.expectToast('created')
+    await page.waitForURL(/\/settings\/canned-responses\/[a-f0-9-]+$/)
+
+    // Activity Log panel is rendered for existing responses.
+    await expect(page.getByText('Activity Log')).toBeVisible({ timeout: 10000 })
   })
 })

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -189,6 +189,12 @@ const router = createRouter({
           meta: { permission: 'canned_responses' }
         },
         {
+          path: 'settings/canned-responses/:id',
+          name: 'canned-response-detail',
+          component: () => import('@/views/settings/CannedResponseDetailView.vue'),
+          meta: { permission: 'canned_responses' }
+        },
+        {
           path: 'settings/contacts',
           name: 'contacts',
           component: () => import('@/views/settings/ContactsView.vue'),

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -192,7 +192,10 @@ const router = createRouter({
           path: 'settings/canned-responses/:id',
           name: 'canned-response-detail',
           component: () => import('@/views/settings/CannedResponseDetailView.vue'),
-          meta: { permission: 'canned_responses' }
+          // stableKey reuses the component instance when :id flips from "new"
+          // to the new UUID after create, so the locally-set response (and the
+          // resulting Save-button reactivity) survives the route change.
+          meta: { permission: 'canned_responses', stableKey: true }
         },
         {
           path: 'settings/contacts',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -391,6 +391,7 @@ export interface CannedResponse {
 export const cannedResponsesService = {
   list: (params?: { category?: string; search?: string; active_only?: string; page?: number; limit?: number }) =>
     api.get<{ canned_responses: CannedResponse[]; total?: number }>('/canned-responses', { params }),
+  get: (id: string) => api.get<CannedResponse>(`/canned-responses/${id}`),
   create: (data: { name: string; shortcut?: string; content: string; category?: string }) =>
     api.post('/canned-responses', data),
   update: (id: string, data: { name?: string; shortcut?: string; content?: string; category?: string; is_active?: boolean }) =>

--- a/frontend/src/views/settings/CannedResponseDetailView.vue
+++ b/frontend/src/views/settings/CannedResponseDetailView.vue
@@ -1,0 +1,284 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch, nextTick } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '@/stores/auth'
+import { cannedResponsesService, type CannedResponse } from '@/services/api'
+import { toast } from 'vue-sonner'
+import { getErrorMessage } from '@/lib/api-utils'
+import { useUnsavedChangesGuard } from '@/composables/useUnsavedChangesGuard'
+import DetailPageLayout from '@/components/shared/DetailPageLayout.vue'
+import MetadataPanel from '@/components/shared/MetadataPanel.vue'
+import AuditLogPanel from '@/components/shared/AuditLogPanel.vue'
+import UnsavedChangesDialog from '@/components/shared/UnsavedChangesDialog.vue'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { MessageSquareText, Trash2, Save } from 'lucide-vue-next'
+import { CANNED_RESPONSE_CATEGORIES } from '@/lib/constants'
+
+const route = useRoute()
+const router = useRouter()
+const { t } = useI18n()
+const authStore = useAuthStore()
+
+const isNew = computed(() => route.params.id === 'new')
+const responseId = computed(() => route.params.id as string)
+const response = ref<CannedResponse | null>(null)
+const isLoading = ref(true)
+const isNotFound = ref(false)
+const isSaving = ref(false)
+const hasChanges = ref(false)
+const deleteDialogOpen = ref(false)
+
+const { showLeaveDialog, confirmLeave, cancelLeave } = useUnsavedChangesGuard(hasChanges)
+
+const canWrite = computed(() => authStore.hasPermission('canned_responses', 'write'))
+const canDelete = computed(() => authStore.hasPermission('canned_responses', 'delete'))
+
+const form = ref({
+  name: '',
+  shortcut: '',
+  content: '',
+  category: '',
+  is_active: true,
+})
+
+const breadcrumbs = computed(() => [
+  { label: t('nav.settings'), href: '/settings' },
+  { label: t('cannedResponses.title'), href: '/settings/canned-responses' },
+  { label: isNew.value ? t('cannedResponses.createTitle') : response.value?.name || '' },
+])
+
+const pageTitle = computed(() =>
+  isNew.value ? t('cannedResponses.createTitle') : response.value?.name || ''
+)
+
+async function loadResponse() {
+  if (isNew.value) {
+    isLoading.value = false
+    nextTick(() => { hasChanges.value = false })
+    return
+  }
+  isLoading.value = true
+  isNotFound.value = false
+  try {
+    const res = await cannedResponsesService.get(responseId.value)
+    const data = (res.data as any).data || res.data
+    response.value = data
+    syncForm()
+    nextTick(() => { hasChanges.value = false })
+  } catch {
+    isNotFound.value = true
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function syncForm() {
+  if (!response.value) return
+  form.value = {
+    name: response.value.name,
+    shortcut: response.value.shortcut || '',
+    content: response.value.content,
+    category: response.value.category || '',
+    is_active: response.value.is_active,
+  }
+}
+
+watch(form, () => {
+  hasChanges.value = true
+}, { deep: true })
+
+async function save() {
+  if (!form.value.name.trim() || !form.value.content.trim()) {
+    toast.error(t('cannedResponses.nameContentRequired'))
+    return
+  }
+  isSaving.value = true
+  try {
+    if (isNew.value) {
+      const res = await cannedResponsesService.create({
+        name: form.value.name,
+        shortcut: form.value.shortcut || undefined,
+        content: form.value.content,
+        category: form.value.category || undefined,
+      })
+      toast.success(t('common.createdSuccess', { resource: t('resources.CannedResponse') }))
+      const created = (res.data as any).data || res.data
+      hasChanges.value = false
+      router.replace(`/settings/canned-responses/${created.id}`)
+    } else if (response.value) {
+      await cannedResponsesService.update(response.value.id, {
+        name: form.value.name,
+        shortcut: form.value.shortcut,
+        content: form.value.content,
+        category: form.value.category,
+        is_active: form.value.is_active,
+      })
+      toast.success(t('common.updatedSuccess', { resource: t('resources.CannedResponse') }))
+      await loadResponse()
+    }
+  } catch (e) {
+    toast.error(getErrorMessage(e, t('common.failedSave', { resource: t('resources.cannedResponse') })))
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function deleteResponse() {
+  if (!response.value) return
+  try {
+    await cannedResponsesService.delete(response.value.id)
+    toast.success(t('common.deletedSuccess', { resource: t('resources.CannedResponse') }))
+    hasChanges.value = false
+    router.push('/settings/canned-responses')
+  } catch (e) {
+    toast.error(getErrorMessage(e, t('common.failedDelete', { resource: t('resources.cannedResponse') })))
+  }
+  deleteDialogOpen.value = false
+}
+
+onMounted(() => { loadResponse() })
+</script>
+
+<template>
+  <div class="h-full">
+    <DetailPageLayout
+      :title="pageTitle"
+      :icon="MessageSquareText"
+      icon-gradient="bg-gradient-to-br from-teal-500 to-emerald-600 shadow-teal-500/20"
+      back-link="/settings/canned-responses"
+      :breadcrumbs="breadcrumbs"
+      :is-loading="isLoading"
+      :is-not-found="isNotFound"
+      :not-found-title="$t('cannedResponses.noResponsesFound')"
+    >
+      <template #actions>
+        <div class="flex items-center gap-2">
+          <Button v-if="canWrite && (hasChanges || isNew)" size="sm" @click="save" :disabled="isSaving">
+            <Save class="h-4 w-4 mr-1" />
+            {{ isSaving ? $t('common.saving', 'Saving...') : $t('common.save') }}
+          </Button>
+          <Button
+            v-if="!isNew && canDelete"
+            variant="destructive"
+            size="sm"
+            @click="deleteDialogOpen = true"
+          >
+            <Trash2 class="h-4 w-4 mr-1" />
+            {{ $t('common.delete') }}
+          </Button>
+        </div>
+      </template>
+
+      <!-- Details Card -->
+      <Card>
+        <CardHeader class="pb-3">
+          <div class="flex items-center justify-between">
+            <CardTitle class="text-sm font-medium">{{ $t('teams.details', 'Details') }}</CardTitle>
+            <Badge v-if="!isNew" :variant="form.is_active ? 'default' : 'secondary'">
+              {{ form.is_active ? $t('common.active') : $t('common.inactive') }}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <div class="space-y-1.5">
+            <Label class="text-xs">{{ $t('cannedResponses.name') }} <span class="text-destructive">*</span></Label>
+            <Input v-model="form.name" placeholder="Welcome Message" :disabled="!canWrite" />
+          </div>
+          <div class="grid grid-cols-2 gap-4">
+            <div class="space-y-1.5">
+              <Label class="text-xs">{{ $t('cannedResponses.shortcut') }}</Label>
+              <div class="relative">
+                <span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">/</span>
+                <Input v-model="form.shortcut" placeholder="welcome" class="pl-7" :disabled="!canWrite" />
+              </div>
+              <p class="text-[11px] text-muted-foreground">{{ $t('cannedResponses.shortcutHint') }}</p>
+            </div>
+            <div class="space-y-1.5">
+              <Label class="text-xs">{{ $t('cannedResponses.category') }}</Label>
+              <Select v-model="form.category" :disabled="!canWrite">
+                <SelectTrigger>
+                  <SelectValue :placeholder="$t('cannedResponses.category')" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem v-for="cat in CANNED_RESPONSE_CATEGORIES" :key="cat.value" :value="cat.value">
+                    {{ cat.label }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div class="space-y-1.5">
+            <Label class="text-xs">{{ $t('cannedResponses.content') }} <span class="text-destructive">*</span></Label>
+            <Textarea v-model="form.content" :placeholder="$t('cannedResponses.contentPlaceholder')" :rows="6" :disabled="!canWrite" />
+            <p class="text-[11px] text-muted-foreground">{{ $t('cannedResponses.placeholderHint') }}</p>
+          </div>
+          <div v-if="!isNew" class="flex items-center justify-between border-t pt-4">
+            <Label class="text-xs font-normal cursor-pointer">{{ $t('common.active') }}</Label>
+            <Switch
+              :checked="form.is_active"
+              @update:checked="form.is_active = $event"
+              :disabled="!canWrite"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <!-- Activity Log -->
+      <AuditLogPanel
+        v-if="!isNew && response"
+        resource-type="canned_response"
+        :resource-id="response.id"
+      />
+
+      <!-- Sidebar -->
+      <template #sidebar>
+        <MetadataPanel
+          :created-at="response?.created_at"
+          :updated-at="response?.updated_at"
+        />
+      </template>
+    </DetailPageLayout>
+
+    <!-- Delete Confirmation -->
+    <AlertDialog v-model:open="deleteDialogOpen">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{{ $t('cannedResponses.deleteTitle') }}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {{ $t('teams.deleteConfirm', 'Are you sure? This action cannot be undone.') }}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{{ $t('common.cancel') }}</AlertDialogCancel>
+          <AlertDialogAction @click="deleteResponse">{{ $t('common.delete') }}</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+
+    <UnsavedChangesDialog :open="showLeaveDialog" @stay="cancelLeave" @leave="confirmLeave" />
+  </div>
+</template>

--- a/frontend/src/views/settings/CannedResponseDetailView.vue
+++ b/frontend/src/views/settings/CannedResponseDetailView.vue
@@ -127,6 +127,11 @@ async function save() {
       })
       toast.success(t('common.createdSuccess', { resource: t('resources.CannedResponse') }))
       const created = (res.data as any).data || res.data
+      // Set the response locally so the (reused) component switches to edit
+      // mode without re-fetching. responseId watcher below guards against a
+      // duplicate load when the route param flips from "new" to the new UUID.
+      response.value = created
+      await nextTick()
       hasChanges.value = false
       router.replace(`/settings/canned-responses/${created.id}`)
     } else if (response.value) {
@@ -159,6 +164,16 @@ async function deleteResponse() {
   }
   deleteDialogOpen.value = false
 }
+
+// Same component handles /new and /:id, so route-param changes don't remount.
+// Reload when the id genuinely changes — but skip when we just set the response
+// locally (e.g. immediately after create) to avoid an unnecessary fetch and the
+// race it causes with hasChanges reset.
+watch(responseId, async (newId, oldId) => {
+  if (!newId || newId === 'new' || newId === oldId) return
+  if (response.value?.id === newId) return
+  await loadResponse()
+})
 
 onMounted(() => { loadResponse() })
 </script>

--- a/frontend/src/views/settings/CannedResponsesView.vue
+++ b/frontend/src/views/settings/CannedResponsesView.vue
@@ -1,16 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { Textarea } from '@/components/ui/textarea'
-import { Switch } from '@/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { PageHeader, SearchInput, CrudFormDialog, DeleteConfirmDialog, DataTable, IconButton, ErrorState, type Column } from '@/components/shared'
+import { PageHeader, SearchInput, DeleteConfirmDialog, DataTable, IconButton, ErrorState, type Column } from '@/components/shared'
 import { cannedResponsesService, type CannedResponse } from '@/services/api'
 import { useCrudState } from '@/composables/useCrudState'
 import { toast } from 'vue-sonner'
@@ -20,25 +17,18 @@ import { CANNED_RESPONSE_CATEGORIES, getLabelFromValue } from '@/lib/constants'
 import { useSearchPagination } from '@/composables/useSearchPagination'
 
 const { t } = useI18n()
-
-interface CannedResponseFormData {
-  name: string
-  shortcut: string
-  content: string
-  category: string
-  is_active: boolean
-}
-
-const defaultFormData: CannedResponseFormData = { name: '', shortcut: '', content: '', category: '', is_active: true }
+const router = useRouter()
 
 const cannedResponses = ref<CannedResponse[]>([])
 const isLoading = ref(false)
 const error = ref<string | null>(null)
 const {
-  isSubmitting, isDialogOpen, editingItem: editingResponse, deleteDialogOpen, itemToDelete: responseToDelete,
-  formData, openCreateDialog, openEditDialog: baseOpenEditDialog, openDeleteDialog, closeDialog, closeDeleteDialog,
-} = useCrudState<CannedResponse, CannedResponseFormData>(defaultFormData)
+  deleteDialogOpen, itemToDelete: responseToDelete,
+  openDeleteDialog, closeDeleteDialog,
+} = useCrudState<CannedResponse, Record<string, never>>({})
 const selectedCategory = ref('all')
+
+const breadcrumbs = computed(() => [{ label: t('nav.settings'), href: '/settings' }, { label: t('cannedResponses.title') }])
 
 const columns = computed<Column<CannedResponse>[]>(() => [
   { key: 'name', label: t('cannedResponses.name'), sortable: true },
@@ -81,33 +71,10 @@ watch(selectedCategory, () => {
   resetAndFetch()
 })
 
-function openEditDialog(response: CannedResponse) {
-  baseOpenEditDialog(response, (r) => ({
-    name: r.name, shortcut: r.shortcut || '', content: r.content, category: r.category || '', is_active: r.is_active
-  }))
-}
+function openCreate() { router.push('/settings/canned-responses/new') }
+function openEdit(response: CannedResponse) { router.push(`/settings/canned-responses/${response.id}`) }
 
 onMounted(() => fetchItems())
-
-async function saveResponse() {
-  if (!formData.value.name.trim() || !formData.value.content.trim()) { toast.error(t('cannedResponses.nameContentRequired')); return }
-  isSubmitting.value = true
-  try {
-    if (editingResponse.value) {
-      await cannedResponsesService.update(editingResponse.value.id, formData.value)
-      toast.success(t('common.updatedSuccess', { resource: t('resources.CannedResponse') }))
-    } else {
-      await cannedResponsesService.create(formData.value)
-      toast.success(t('common.createdSuccess', { resource: t('resources.CannedResponse') }))
-    }
-    closeDialog()
-    await fetchItems()
-  } catch (error) {
-    toast.error(getErrorMessage(error, t('common.failedSave', { resource: t('resources.cannedResponse') })))
-  } finally {
-    isSubmitting.value = false
-  }
-}
 
 const isDeleting = ref(false)
 
@@ -132,23 +99,25 @@ function getCategoryLabel(category: string): string { return getLabelFromValue(C
 
 <template>
   <div class="flex flex-col h-full bg-[#0a0a0b] light:bg-gray-50">
-    <PageHeader :title="$t('cannedResponses.title')" :subtitle="$t('cannedResponses.subtitle')" :icon="MessageSquareText" icon-gradient="bg-gradient-to-br from-teal-500 to-emerald-600 shadow-teal-500/20">
+    <PageHeader :title="$t('cannedResponses.title')" :icon="MessageSquareText" icon-gradient="bg-gradient-to-br from-teal-500 to-emerald-600 shadow-teal-500/20" back-link="/settings" :breadcrumbs="breadcrumbs">
       <template #actions>
-        <Button variant="outline" size="sm" @click="openCreateDialog"><Plus class="h-4 w-4 mr-2" />{{ $t('cannedResponses.addResponse') }}</Button>
+        <Button variant="outline" size="sm" @click="openCreate"><Plus class="h-4 w-4 mr-2" />{{ $t('cannedResponses.addResponse') }}</Button>
       </template>
     </PageHeader>
 
-    <ScrollArea class="flex-1">
+    <ErrorState
+      v-if="error && !isLoading"
+      :title="$t('common.loadErrorTitle')"
+      :description="error"
+      :retry-label="$t('common.retry')"
+      class="flex-1"
+      @retry="fetchItems"
+    />
+
+    <ScrollArea v-else class="flex-1">
       <div class="p-6">
-        <div class="max-w-6xl mx-auto">
-          <ErrorState
-            v-if="error && !isLoading"
-            :title="$t('common.loadErrorTitle')"
-            :description="error"
-            :retry-label="$t('common.retry')"
-            @retry="fetchItems"
-          />
-          <Card v-else>
+        <div>
+          <Card>
             <CardHeader>
               <div class="flex items-center justify-between flex-wrap gap-4">
                 <div>
@@ -185,10 +154,12 @@ function getCategoryLabel(category: string): string { return getLabelFromValue(C
                 @page-change="handlePageChange"
               >
                 <template #cell-name="{ item: response }">
-                  <div>
-                    <span class="font-medium">{{ response.name }}</span>
-                    <p v-if="response.shortcut" class="text-xs font-mono text-muted-foreground">/{{ response.shortcut }}</p>
-                  </div>
+                  <RouterLink :to="`/settings/canned-responses/${response.id}`" class="text-inherit no-underline hover:opacity-80">
+                    <div>
+                      <span class="font-medium">{{ response.name }}</span>
+                      <p v-if="response.shortcut" class="text-xs font-mono text-muted-foreground">/{{ response.shortcut }}</p>
+                    </div>
+                  </RouterLink>
                 </template>
                 <template #cell-category="{ item: response }">
                   <Badge variant="outline" class="text-xs">{{ getCategoryLabel(response.category) }}</Badge>
@@ -215,7 +186,7 @@ function getCategoryLabel(category: string): string { return getLabelFromValue(C
                       :icon="Pencil"
                       :label="$t('cannedResponses.editResponse')"
                       class="h-8 w-8"
-                      @click="openEditDialog(response)"
+                      @click="openEdit(response)"
                     />
                     <IconButton
                       :icon="Trash2"
@@ -227,7 +198,7 @@ function getCategoryLabel(category: string): string { return getLabelFromValue(C
                   </div>
                 </template>
                 <template #empty-action>
-                  <Button variant="outline" size="sm" @click="openCreateDialog">
+                  <Button variant="outline" size="sm" @click="openCreate">
                     <Plus class="h-4 w-4 mr-2" />{{ $t('cannedResponses.addResponse') }}
                   </Button>
                 </template>
@@ -237,29 +208,6 @@ function getCategoryLabel(category: string): string { return getLabelFromValue(C
         </div>
       </div>
     </ScrollArea>
-
-    <CrudFormDialog v-model:open="isDialogOpen" :is-editing="!!editingResponse" :is-submitting="isSubmitting" :edit-title="$t('cannedResponses.editTitle')" :create-title="$t('cannedResponses.createTitle')" :edit-description="$t('cannedResponses.editDesc')" :create-description="$t('cannedResponses.createDesc')" max-width="max-w-lg" @submit="saveResponse">
-      <div class="space-y-4">
-        <div class="space-y-2"><Label>{{ $t('cannedResponses.name') }} <span class="text-destructive">*</span></Label><Input v-model="formData.name" placeholder="Welcome Message" /></div>
-        <div class="grid grid-cols-2 gap-4">
-          <div class="space-y-2">
-            <Label>{{ $t('cannedResponses.shortcut') }}</Label>
-            <div class="relative"><span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">/</span><Input v-model="formData.shortcut" placeholder="welcome" class="pl-7" /></div>
-            <p class="text-xs text-muted-foreground">{{ $t('cannedResponses.shortcutHint') }}</p>
-          </div>
-          <div class="space-y-2">
-            <Label>{{ $t('cannedResponses.category') }}</Label>
-            <Select v-model="formData.category"><SelectTrigger><SelectValue :placeholder="$t('cannedResponses.category')" /></SelectTrigger><SelectContent><SelectItem v-for="cat in CANNED_RESPONSE_CATEGORIES" :key="cat.value" :value="cat.value">{{ cat.label }}</SelectItem></SelectContent></Select>
-          </div>
-        </div>
-        <div class="space-y-2">
-          <Label>{{ $t('cannedResponses.content') }} <span class="text-destructive">*</span></Label>
-          <Textarea v-model="formData.content" :placeholder="$t('cannedResponses.contentPlaceholder')" :rows="5" />
-          <p class="text-xs text-muted-foreground">{{ $t('cannedResponses.placeholderHint') }}</p>
-        </div>
-        <div v-if="editingResponse" class="flex items-center justify-between"><Label>{{ $t('common.active') }}</Label><Switch v-model:checked="formData.is_active" /></div>
-      </div>
-    </CrudFormDialog>
 
     <DeleteConfirmDialog v-model:open="deleteDialogOpen" :title="$t('cannedResponses.deleteTitle')" :item-name="responseToDelete?.name" :is-submitting="isDeleting" @confirm="confirmDelete" />
   </div>

--- a/internal/handlers/canned_responses.go
+++ b/internal/handlers/canned_responses.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/google/uuid"
+	"github.com/shridarpatil/whatomate/internal/audit"
 	"github.com/shridarpatil/whatomate/internal/models"
 	"github.com/valyala/fasthttp"
 	"github.com/zerodha/fastglue"
@@ -125,6 +126,9 @@ func (a *App) CreateCannedResponse(r *fastglue.Request) error {
 			"Failed to create canned response", nil, "")
 	}
 
+	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
+		"canned_response", cannedResponse.ID, models.AuditActionCreated, nil, cannedResponseAuditSnapshot(&cannedResponse))
+
 	return r.SendEnvelope(cannedResponseToResponse(cannedResponse))
 }
 
@@ -152,7 +156,7 @@ func (a *App) GetCannedResponse(r *fastglue.Request) error {
 
 // UpdateCannedResponse updates an existing canned response
 func (a *App) UpdateCannedResponse(r *fastglue.Request) error {
-	orgID, err := a.getOrgID(r)
+	orgID, userID, err := a.getOrgAndUserID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -174,6 +178,8 @@ func (a *App) UpdateCannedResponse(r *fastglue.Request) error {
 		return nil
 	}
 
+	oldSnap := cannedResponseAuditSnapshot(&cannedResponse)
+
 	// Update fields
 	if req.Name != "" {
 		cannedResponse.Name = req.Name
@@ -191,12 +197,15 @@ func (a *App) UpdateCannedResponse(r *fastglue.Request) error {
 			"Failed to update canned response", nil, "")
 	}
 
+	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
+		"canned_response", cannedResponse.ID, models.AuditActionUpdated, oldSnap, cannedResponseAuditSnapshot(&cannedResponse))
+
 	return r.SendEnvelope(cannedResponseToResponse(cannedResponse))
 }
 
 // DeleteCannedResponse deletes a canned response
 func (a *App) DeleteCannedResponse(r *fastglue.Request) error {
-	orgID, err := a.getOrgID(r)
+	orgID, userID, err := a.getOrgAndUserID(r)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
 	}
@@ -218,6 +227,9 @@ func (a *App) DeleteCannedResponse(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError,
 			"Failed to delete canned response", nil, "")
 	}
+
+	audit.LogAudit(a.DB, orgID, userID, audit.GetUserName(a.DB, userID),
+		"canned_response", cannedResponse.ID, models.AuditActionDeleted, cannedResponseAuditSnapshot(&cannedResponse), nil)
 
 	return r.SendEnvelope(map[string]string{"message": "Canned response deleted"})
 }
@@ -243,6 +255,22 @@ func (a *App) IncrementCannedResponseUsage(r *fastglue.Request) error {
 	}
 
 	return r.SendEnvelope(map[string]string{"message": "Usage incremented"})
+}
+
+// cannedResponseAuditSnapshot returns a diff-friendly representation of a
+// canned response for audit logging. Noisy fields (usage_count, timestamps) are
+// intentionally excluded so the activity log reflects user edits only.
+func cannedResponseAuditSnapshot(cr *models.CannedResponse) map[string]any {
+	if cr == nil {
+		return nil
+	}
+	return map[string]any{
+		"name":      cr.Name,
+		"shortcut":  cr.Shortcut,
+		"content":   cr.Content,
+		"category":  cr.Category,
+		"is_active": cr.IsActive,
+	}
 }
 
 func cannedResponseToResponse(cr models.CannedResponse) CannedResponseResponse {


### PR DESCRIPTION
Replace the create/edit dialog with a dedicated detail page (mirroring the user settings flow) and log create/update/delete actions to the audit log. Updates e2e page object + spec to drive the new flow and assert audit-log entries.