### PR TITLE
feat(canned-responses): support interactive buttons

### DIFF
--- a/frontend/src/components/shared/MessageButtonsEditor.vue
+++ b/frontend/src/components/shared/MessageButtonsEditor.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Reply, ExternalLink, Phone, Trash2 } from 'lucide-vue-next'
+import type { ButtonConfig } from '@/types/flow-preview'
+
+type ButtonType = 'reply' | 'url' | 'phone'
+
+const props = withDefaults(
+  defineProps<{
+    buttons: ButtonConfig[]
+    allowedTypes?: ButtonType[]
+    /** Cap when no CTA buttons are present. WhatsApp allows up to 10 reply buttons. */
+    maxButtons?: number
+    disabled?: boolean
+    showIdField?: boolean
+  }>(),
+  {
+    allowedTypes: () => ['reply', 'url', 'phone'],
+    maxButtons: 10,
+    disabled: false,
+    showIdField: false,
+  },
+)
+
+const emit = defineEmits<{
+  'update:buttons': [buttons: ButtonConfig[]]
+  /** Per-button title edit — host views (e.g. chatbot select input) listen to keep state in sync. */
+  'change': [buttons: ButtonConfig[]]
+}>()
+
+const { t } = useI18n()
+
+// WhatsApp rules: reply buttons (1-3) and CTA buttons (url/phone, max 2) can't mix.
+const hasReplyButtons = computed(() =>
+  props.buttons.some((b) => !b.type || b.type === 'reply'),
+)
+const ctaCount = computed(() =>
+  props.buttons.filter((b) => b.type === 'url' || b.type === 'phone').length,
+)
+const hasCtaButtons = computed(() => ctaCount.value > 0)
+const ctaLimitReached = computed(() => ctaCount.value >= 2)
+
+const effectiveMax = computed(() => (hasCtaButtons.value ? 2 : props.maxButtons))
+
+function emitButtons(next: ButtonConfig[]) {
+  emit('update:buttons', next)
+  emit('change', next)
+}
+
+function addButton(type: ButtonType) {
+  if (props.buttons.length >= effectiveMax.value) return
+  const newButton: ButtonConfig = {
+    id: `btn_${props.buttons.length + 1}`,
+    title: '',
+    type,
+  }
+  if (type === 'url') newButton.url = ''
+  else if (type === 'phone') newButton.phone_number = ''
+  emitButtons([...props.buttons, newButton])
+}
+
+function removeButton(index: number) {
+  const next = [...props.buttons]
+  next.splice(index, 1)
+  emitButtons(next)
+}
+
+function updateButton(index: number, patch: Partial<ButtonConfig>) {
+  const next = props.buttons.map((b, i) => (i === index ? { ...b, ...patch } : b))
+  emitButtons(next)
+}
+
+function canAdd(type: ButtonType): boolean {
+  if (props.disabled) return false
+  if (props.buttons.length >= effectiveMax.value) return false
+  if (type === 'reply') return !hasCtaButtons.value
+  // url / phone
+  return !hasReplyButtons.value && !ctaLimitReached.value
+}
+
+function typeLabel(type?: string): string {
+  if (type === 'url') return 'URL'
+  if (type === 'phone') return t('flowBuilder.phoneButton', 'Phone')
+  return t('flowBuilder.replyButton', 'Reply')
+}
+
+function typeIcon(type?: string) {
+  if (type === 'url') return ExternalLink
+  if (type === 'phone') return Phone
+  return Reply
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div class="flex items-center justify-between flex-wrap gap-2">
+      <Label class="text-xs">
+        {{ $t('flowBuilder.buttonOptions', 'Buttons') }} ({{ buttons.length }}/{{ effectiveMax }})
+      </Label>
+      <div class="flex gap-1">
+        <Button
+          v-if="allowedTypes.includes('reply')"
+          variant="outline"
+          size="sm"
+          class="h-6 text-xs"
+          :disabled="!canAdd('reply')"
+          @click="addButton('reply')"
+        >
+          <Reply class="h-3 w-3 mr-1" />
+          {{ $t('flowBuilder.replyButton', 'Reply') }}
+        </Button>
+        <Button
+          v-if="allowedTypes.includes('url')"
+          variant="outline"
+          size="sm"
+          class="h-6 text-xs"
+          :disabled="!canAdd('url')"
+          @click="addButton('url')"
+        >
+          <ExternalLink class="h-3 w-3 mr-1" />
+          {{ $t('flowBuilder.urlButton', 'URL') }}
+        </Button>
+        <Button
+          v-if="allowedTypes.includes('phone')"
+          variant="outline"
+          size="sm"
+          class="h-6 text-xs"
+          :disabled="!canAdd('phone')"
+          @click="addButton('phone')"
+        >
+          <Phone class="h-3 w-3 mr-1" />
+          {{ $t('flowBuilder.phoneButton', 'Phone') }}
+        </Button>
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <div
+        v-for="(btn, idx) in buttons"
+        :key="idx"
+        class="p-2 border rounded-md bg-muted/30 space-y-2"
+      >
+        <div class="flex items-center gap-2">
+          <Badge variant="outline" class="text-[10px] px-1.5">
+            <component :is="typeIcon(btn.type)" class="h-2.5 w-2.5 mr-1" />
+            {{ typeLabel(btn.type) }}
+          </Badge>
+          <Input
+            :model-value="btn.title"
+            :placeholder="$t('flowBuilder.buttonTitle', 'Button title')"
+            class="h-7 flex-1 text-xs"
+            :disabled="disabled"
+            @update:model-value="updateButton(idx, { title: String($event) })"
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            class="h-7 w-7"
+            :disabled="disabled"
+            @click="removeButton(idx)"
+          >
+            <Trash2 class="h-3 w-3 text-destructive" />
+          </Button>
+        </div>
+
+        <div v-if="btn.type === 'url'">
+          <Input
+            :model-value="btn.url"
+            :placeholder="$t('flowBuilder.exampleUrlPlaceholder', 'https://example.com')"
+            class="h-7 text-xs"
+            :disabled="disabled"
+            @update:model-value="updateButton(idx, { url: String($event) })"
+          />
+        </div>
+        <div v-else-if="btn.type === 'phone'">
+          <Input
+            :model-value="btn.phone_number"
+            :placeholder="$t('flowBuilder.phoneNumberPlaceholder', '+1234567890')"
+            class="h-7 text-xs"
+            :disabled="disabled"
+            @update:model-value="updateButton(idx, { phone_number: String($event) })"
+          />
+        </div>
+        <div v-else-if="showIdField">
+          <Input
+            :model-value="btn.id"
+            :placeholder="$t('flowBuilder.buttonIdPlaceholder', 'button-id')"
+            class="h-7 text-xs"
+            :disabled="disabled"
+            @update:model-value="updateButton(idx, { id: String($event) })"
+          />
+        </div>
+
+        <!-- Per-button extras (e.g. chatbot conditional-routing select) -->
+        <slot name="button-extra" :button="btn" :index="idx" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -243,8 +243,23 @@ export const dataService = {
 export const messagesService = {
   list: (contactId: string, params?: { page?: number; limit?: number; before_id?: string; account?: string }) =>
     api.get(`/contacts/${contactId}/messages`, { params }),
-  send: (contactId: string, data: { type: string; content: any; reply_to_message_id?: string; whatsapp_account?: string }) =>
-    api.post(`/contacts/${contactId}/messages`, data),
+  send: (
+    contactId: string,
+    data: {
+      type: string
+      content: any
+      reply_to_message_id?: string
+      whatsapp_account?: string
+      // Interactive button / cta_url payload. Mirrors backend InteractiveContent.
+      interactive?: {
+        type: 'button' | 'cta_url' | 'list'
+        body: string
+        buttons?: Array<{ id: string; title: string }>
+        button_text?: string
+        url?: string
+      }
+    },
+  ) => api.post(`/contacts/${contactId}/messages`, data),
   sendTemplate: (contactId: string, data: { template_name: string; template_params?: Record<string, string>; button_params?: Record<string, string>; account_name?: string }, headerFile?: File) => {
     if (headerFile) {
       const formData = new FormData()
@@ -376,6 +391,14 @@ export const chatbotService = {
     api.put(`/chatbot/transfers/${id}/assign`, { agent_id: agentId, team_id: teamId })
 }
 
+export interface CannedResponseButton {
+  id: string
+  title: string
+  type?: 'reply' | 'url' | 'phone'
+  url?: string
+  phone_number?: string
+}
+
 export interface CannedResponse {
   id: string
   name: string
@@ -384,17 +407,27 @@ export interface CannedResponse {
   category: string
   is_active: boolean
   usage_count: number
+  buttons?: CannedResponseButton[]
   created_at: string
   updated_at: string
+}
+
+interface CannedResponseUpsertPayload {
+  name?: string
+  shortcut?: string
+  content?: string
+  category?: string
+  is_active?: boolean
+  buttons?: CannedResponseButton[]
 }
 
 export const cannedResponsesService = {
   list: (params?: { category?: string; search?: string; active_only?: string; page?: number; limit?: number }) =>
     api.get<{ canned_responses: CannedResponse[]; total?: number }>('/canned-responses', { params }),
   get: (id: string) => api.get<CannedResponse>(`/canned-responses/${id}`),
-  create: (data: { name: string; shortcut?: string; content: string; category?: string }) =>
+  create: (data: CannedResponseUpsertPayload & { name: string; content: string }) =>
     api.post('/canned-responses', data),
-  update: (id: string, data: { name?: string; shortcut?: string; content?: string; category?: string; is_active?: boolean }) =>
+  update: (id: string, data: CannedResponseUpsertPayload) =>
     api.put(`/canned-responses/${id}`, data),
   delete: (id: string) => api.delete(`/canned-responses/${id}`),
   use: (id: string) => api.post(`/canned-responses/${id}/use`)

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -221,9 +221,22 @@ export const useContactsStore = defineStore('contacts', () => {
     }
   }
 
-  async function sendMessage(contactId: string, type: string, content: any, replyToMessageId?: string, whatsappAccount?: string) {
+  async function sendMessage(
+    contactId: string,
+    type: string,
+    content: any,
+    replyToMessageId?: string,
+    whatsappAccount?: string,
+    extra?: { interactive?: Parameters<typeof messagesService.send>[1]['interactive'] },
+  ) {
     try {
-      const response = await messagesService.send(contactId, { type, content, reply_to_message_id: replyToMessageId, whatsapp_account: whatsappAccount })
+      const response = await messagesService.send(contactId, {
+        type,
+        content,
+        reply_to_message_id: replyToMessageId,
+        whatsapp_account: whatsappAccount,
+        ...(extra?.interactive ? { interactive: extra.interactive } : {}),
+      })
       // API returns { status: "success", data: { ... } }
       const newMessage = response.data.data || response.data
       // Use addMessage which has duplicate checking (WebSocket may also broadcast this)

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -848,15 +848,48 @@ async function sendCannedResponse() {
 
   const body = cannedPreview.value
   const responseId = selectedCannedResponse.value.id
+  const buttons = selectedCannedResponse.value.buttons || []
+  const replyButtons = buttons.filter(b => !b.type || b.type === 'reply')
+  const urlButtons = buttons.filter(b => b.type === 'url')
+
+  // WhatsApp Cloud API supports interactive button (≤3 reply) or single
+  // cta_url. Phone buttons and multi-URL combos aren't representable, so we
+  // fall back to plain text in those cases — same body, just no inline buttons.
+  let sendType: 'text' | 'interactive' = 'text'
+  let interactive: {
+    type: 'button' | 'cta_url'
+    body: string
+    buttons?: Array<{ id: string; title: string }>
+    button_text?: string
+    url?: string
+  } | undefined
+
+  if (buttons.length > 0 && replyButtons.length === buttons.length && replyButtons.length <= 3) {
+    sendType = 'interactive'
+    interactive = {
+      type: 'button',
+      body,
+      buttons: replyButtons.map(b => ({ id: b.id, title: b.title })),
+    }
+  } else if (buttons.length === 1 && urlButtons.length === 1) {
+    sendType = 'interactive'
+    interactive = {
+      type: 'cta_url',
+      body,
+      button_text: urlButtons[0].title,
+      url: urlButtons[0].url || '',
+    }
+  }
 
   isSendingCanned.value = true
   try {
     await contactsStore.sendMessage(
       contactsStore.currentContact.id,
-      'text',
-      { body },
+      sendType,
+      sendType === 'interactive' ? { body } : { body },
       contactsStore.replyingTo?.id,
-      selectedAccount.value || undefined
+      selectedAccount.value || undefined,
+      interactive ? { interactive } : undefined,
     )
     cannedResponsesService.use(responseId).catch(() => {})
     contactsStore.clearReplyingTo()

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -801,30 +801,45 @@ function extractCannedTokens(content: string): string[] {
   return Array.from(seen)
 }
 
-const cannedPreview = computed(() => {
-  if (!selectedCannedResponse.value) return ''
+// Collect tokens from the message body AND every button field, so the param
+// dialog prompts for custom tokens used anywhere on the response.
+function extractCannedTokensFromResponse(r: CannedResponse): string[] {
+  const seen = new Set<string>(extractCannedTokens(r.content))
+  for (const btn of r.buttons || []) {
+    for (const t of extractCannedTokens(btn.title || '')) seen.add(t)
+    for (const t of extractCannedTokens(btn.url || '')) seen.add(t)
+    for (const t of extractCannedTokens(btn.phone_number || '')) seen.add(t)
+  }
+  return Array.from(seen)
+}
+
+// Shared {{...}} resolver used by the body preview and the button fields, so
+// `{{phone_number}}` works inside a button URL the same way it does in content.
+function resolveCannedTokens(text: string): string {
+  if (!text) return text
   const contact = contactsStore.currentContact
-  return selectedCannedResponse.value.content.replace(
-    /\{\{\s*([\w.-]+)\s*\}\}/g,
-    (_match, key: string) => {
-      if (key === 'contact_name') {
-        return contact?.profile_name || contact?.name || 'there'
-      }
-      if (key === 'phone_number') {
-        return contact?.phone_number || ''
-      }
-      if (key === 'user_name' || key === 'agent_name') {
-        return authStore.user?.full_name || ''
-      }
-      const value = cannedParamValues.value[key]
-      return value ? value : `{{${key}}}`
+  return text.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_match, key: string) => {
+    if (key === 'contact_name') {
+      return contact?.profile_name || contact?.name || 'there'
     }
-  )
-})
+    if (key === 'phone_number') {
+      return contact?.phone_number || ''
+    }
+    if (key === 'user_name' || key === 'agent_name') {
+      return authStore.user?.full_name || ''
+    }
+    const value = cannedParamValues.value[key]
+    return value ? value : `{{${key}}}`
+  })
+}
+
+const cannedPreview = computed(() =>
+  selectedCannedResponse.value ? resolveCannedTokens(selectedCannedResponse.value.content) : '',
+)
 
 function handleCannedSelect(response: CannedResponse) {
   selectedCannedResponse.value = response
-  const tokens = extractCannedTokens(response.content).filter(
+  const tokens = extractCannedTokensFromResponse(response).filter(
     t => !AUTO_RESOLVED_CANNED_TOKENS.has(t)
   )
   cannedParamNames.value = tokens
@@ -848,7 +863,14 @@ async function sendCannedResponse() {
 
   const body = cannedPreview.value
   const responseId = selectedCannedResponse.value.id
-  const buttons = selectedCannedResponse.value.buttons || []
+  // Substitute {{...}} tokens in every button field — same rules as the body —
+  // so URLs like https://x.com/u/{{phone_number}} resolve at send time.
+  const buttons = (selectedCannedResponse.value.buttons || []).map(b => ({
+    ...b,
+    title: resolveCannedTokens(b.title),
+    ...(b.url !== undefined ? { url: resolveCannedTokens(b.url) } : {}),
+    ...(b.phone_number !== undefined ? { phone_number: resolveCannedTokens(b.phone_number) } : {}),
+  }))
   const replyButtons = buttons.filter(b => !b.type || b.type === 'reply')
   const urlButtons = buttons.filter(b => b.type === 'url')
 

--- a/frontend/src/views/chatbot/ChatbotFlowBuilderView.vue
+++ b/frontend/src/views/chatbot/ChatbotFlowBuilderView.vue
@@ -50,9 +50,6 @@ import {
   ChevronRight,
   Save,
   Settings,
-  ExternalLink,
-  Reply,
-  Phone,
 } from 'lucide-vue-next'
 import draggable from 'vuedraggable'
 import FlowChart from '@/components/chatbot/flow-builder/FlowChart.vue'
@@ -60,6 +57,7 @@ import FlowPreviewPanel from '@/components/chatbot/flow-preview/FlowPreviewPanel
 import UnsavedChangesDialog from '@/components/shared/UnsavedChangesDialog.vue'
 import AuditLogPanel from '@/components/shared/AuditLogPanel.vue'
 import MetadataPanel from '@/components/shared/MetadataPanel.vue'
+import MessageButtonsEditor from '@/components/shared/MessageButtonsEditor.vue'
 
 interface ApiConfig {
   url: string
@@ -687,51 +685,8 @@ function setInputType(type: string | number | bigint | Record<string, any> | nul
   }
 }
 
-// Button helpers
-function addButton(type: 'reply' | 'url' | 'phone' = 'reply') {
-  if (!selectedStep.value) return
-  if (selectedStep.value.buttons.length >= 10) {
-    toast.error(t('flowBuilder.maxOptionsError'))
-    return
-  }
-  const newButton: ButtonConfig = {
-    id: `btn_${selectedStep.value.buttons.length + 1}`,
-    title: '',
-    type
-  }
-  if (type === 'url') {
-    newButton.url = ''
-  } else if (type === 'phone') {
-    newButton.phone_number = ''
-  }
-  selectedStep.value.buttons.push(newButton)
-}
-
-// WhatsApp doesn't allow mixing reply buttons with CTA (URL/phone) buttons.
-// CTA buttons are limited to max 2 per message (can mix URL + phone).
-const hasReplyButtons = computed(() =>
-  selectedStep.value?.buttons.some((b: ButtonConfig) => !b.type || b.type === 'reply') ?? false
-)
-const ctaButtonCount = computed(() =>
-  selectedStep.value?.buttons.filter((b: ButtonConfig) => b.type === 'url' || b.type === 'phone').length ?? 0
-)
-const hasCtaButtons = computed(() => ctaButtonCount.value > 0)
-const ctaLimitReached = computed(() => ctaButtonCount.value >= 2)
-
-function removeButton(index: number) {
-  if (!selectedStep.value) return
-  selectedStep.value.buttons.splice(index, 1)
-  // Sync options if input type is select
-  syncButtonTitlesToOptions()
-}
-
-function updateButtonTitle(index: number, title: string) {
-  if (!selectedStep.value) return
-  selectedStep.value.buttons[index].title = title
-  // Sync options if input type is select
-  syncButtonTitlesToOptions()
-}
-
+// Keep the `select` input type's options in sync with reply-button titles.
+// Wired via the MessageButtonsEditor @change event.
 function syncButtonTitlesToOptions() {
   if (!selectedStep.value) return
   if (selectedStep.value.input_type !== 'select') return
@@ -1528,72 +1483,39 @@ function confirmCancel() {
 
                 <!-- Buttons Configuration -->
                 <template v-if="selectedStep.message_type === 'buttons'">
-                  <div class="space-y-3">
-                    <div class="flex items-center justify-between">
-                      <Label class="text-xs">{{ $t('flowBuilder.buttonOptions') }} ({{ selectedStep.buttons.length }}/{{ hasCtaButtons ? 2 : 10 }})</Label>
-                      <div class="flex gap-1">
-                        <Button variant="outline" size="sm" class="h-6 text-xs" @click="addButton('reply')" :disabled="selectedStep.buttons.length >= 10 || hasCtaButtons">
-                          <Reply class="h-3 w-3 mr-1" />
-                          {{ $t('flowBuilder.replyButton') }}
-                        </Button>
-                        <Button variant="outline" size="sm" class="h-6 text-xs" @click="addButton('url')" :disabled="ctaLimitReached || hasReplyButtons">
-                          <ExternalLink class="h-3 w-3 mr-1" />
-                          {{ $t('flowBuilder.urlButton') }}
-                        </Button>
-                        <Button variant="outline" size="sm" class="h-6 text-xs" @click="addButton('phone')" :disabled="ctaLimitReached || hasReplyButtons">
-                          <Phone class="h-3 w-3 mr-1" />
-                          {{ $t('flowBuilder.phoneButton') }}
-                        </Button>
-                      </div>
-                    </div>
-                    <div class="space-y-2">
-                      <div v-for="(btn, idx) in selectedStep.buttons" :key="idx" class="p-2 border rounded-md bg-muted/30 space-y-2">
-                        <div class="flex items-center gap-2">
-                          <Badge variant="outline" class="text-[10px] px-1.5">
-                            <component :is="btn.type === 'url' ? ExternalLink : btn.type === 'phone' ? Phone : Reply" class="h-2.5 w-2.5 mr-1" />
-                            {{ btn.type === 'url' ? 'URL' : btn.type === 'phone' ? $t('flowBuilder.phoneButton') : $t('flowBuilder.replyButton') }}
-                          </Badge>
-                          <Input :model-value="btn.title" @update:model-value="updateButtonTitle(idx, $event)" :placeholder="$t('flowBuilder.buttonTitle')" class="h-7 flex-1 text-xs" />
-                          <Button variant="ghost" size="icon" class="h-7 w-7" @click="removeButton(idx)">
-                            <Trash2 class="h-3 w-3 text-destructive" />
-                          </Button>
-                        </div>
-                        <div v-if="btn.type === 'url'" class="flex gap-2">
-                          <Input v-model="btn.url" :placeholder="$t('flowBuilder.exampleUrlPlaceholder')" class="h-7 text-xs flex-1" />
-                        </div>
-                        <div v-else-if="btn.type === 'phone'" class="flex gap-2">
-                          <Input v-model="btn.phone_number" :placeholder="$t('flowBuilder.phoneNumberPlaceholder')" class="h-7 text-xs flex-1" />
-                        </div>
-                        <div v-else class="space-y-2">
-                          <Input v-model="btn.id" :placeholder="$t('flowBuilder.buttonIdPlaceholder')" class="h-7 text-xs" />
-                          <div class="flex items-center gap-2">
-                            <Label class="text-xs text-muted-foreground whitespace-nowrap">{{ $t('flowBuilder.goTo') }}:</Label>
-                            <Select
-                              :model-value="getButtonNextStep(getButtonId(btn, idx))"
-                              @update:model-value="setButtonNextStep(getButtonId(btn, idx), $event)"
+                  <MessageButtonsEditor
+                    :buttons="selectedStep.buttons"
+                    show-id-field
+                    @update:buttons="selectedStep.buttons = $event"
+                    @change="syncButtonTitlesToOptions"
+                  >
+                    <template #button-extra="{ button, index }">
+                      <div v-if="!button.type || button.type === 'reply'" class="flex items-center gap-2">
+                        <Label class="text-xs text-muted-foreground whitespace-nowrap">{{ $t('flowBuilder.goTo') }}:</Label>
+                        <Select
+                          :model-value="getButtonNextStep(getButtonId(button, index))"
+                          @update:model-value="setButtonNextStep(getButtonId(button, index), $event)"
+                        >
+                          <SelectTrigger class="h-7 text-xs flex-1">
+                            <SelectValue :placeholder="$t('flowBuilder.nextStepSequential')" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="__default__">{{ $t('flowBuilder.nextStepSequential') }}</SelectItem>
+                            <SelectItem
+                              v-for="step in stepsWithNames"
+                              :key="`goto-${step.step_name}`"
+                              :value="step.step_name"
                             >
-                              <SelectTrigger class="h-7 text-xs flex-1">
-                                <SelectValue :placeholder="$t('flowBuilder.nextStepSequential')" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="__default__">{{ $t('flowBuilder.nextStepSequential') }}</SelectItem>
-                                <SelectItem
-                                  v-for="step in stepsWithNames"
-                                  :key="`goto-${step.step_name}`"
-                                  :value="step.step_name"
-                                >
-                                  {{ step.step_name }}
-                                </SelectItem>
-                              </SelectContent>
-                            </Select>
-                          </div>
-                        </div>
+                              {{ step.step_name }}
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
                       </div>
-                    </div>
-                    <p class="text-[10px] text-muted-foreground">
-                      {{ $t('flowBuilder.buttonsHint') }}
-                    </p>
-                  </div>
+                    </template>
+                  </MessageButtonsEditor>
+                  <p class="text-[10px] text-muted-foreground">
+                    {{ $t('flowBuilder.buttonsHint') }}
+                  </p>
                 </template>
 
                 <!-- API Fetch Configuration -->

--- a/frontend/src/views/settings/CannedResponseDetailView.vue
+++ b/frontend/src/views/settings/CannedResponseDetailView.vue
@@ -11,6 +11,9 @@ import DetailPageLayout from '@/components/shared/DetailPageLayout.vue'
 import MetadataPanel from '@/components/shared/MetadataPanel.vue'
 import AuditLogPanel from '@/components/shared/AuditLogPanel.vue'
 import UnsavedChangesDialog from '@/components/shared/UnsavedChangesDialog.vue'
+import MessageButtonsEditor from '@/components/shared/MessageButtonsEditor.vue'
+import PreviewButtonGroup from '@/components/chatbot/flow-preview/PreviewButtonGroup.vue'
+import type { ButtonConfig } from '@/types/flow-preview'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -63,6 +66,7 @@ const form = ref({
   content: '',
   category: '',
   is_active: true,
+  buttons: [] as ButtonConfig[],
 })
 
 const breadcrumbs = computed(() => [
@@ -104,6 +108,7 @@ function syncForm() {
     content: response.value.content,
     category: response.value.category || '',
     is_active: response.value.is_active,
+    buttons: (response.value.buttons || []).map(b => ({ ...b })),
   }
 }
 
@@ -124,6 +129,7 @@ async function save() {
         shortcut: form.value.shortcut || undefined,
         content: form.value.content,
         category: form.value.category || undefined,
+        buttons: form.value.buttons,
       })
       toast.success(t('common.createdSuccess', { resource: t('resources.CannedResponse') }))
       const created = (res.data as any).data || res.data
@@ -141,6 +147,7 @@ async function save() {
         content: form.value.content,
         category: form.value.category,
         is_active: form.value.is_active,
+        buttons: form.value.buttons,
       })
       toast.success(t('common.updatedSuccess', { resource: t('resources.CannedResponse') }))
       await loadResponse()
@@ -258,6 +265,29 @@ onMounted(() => { loadResponse() })
               @update:checked="form.is_active = $event"
               :disabled="!canWrite"
             />
+          </div>
+        </CardContent>
+      </Card>
+
+      <!-- Buttons -->
+      <Card>
+        <CardHeader class="pb-3">
+          <CardTitle class="text-sm font-medium">{{ $t('cannedResponses.buttons', 'Buttons') }}</CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <MessageButtonsEditor
+            :buttons="form.buttons"
+            :disabled="!canWrite"
+            @update:buttons="form.buttons = $event"
+          />
+
+          <!-- WhatsApp-style preview -->
+          <div v-if="form.buttons.length > 0" class="border-t pt-3">
+            <p class="text-[11px] text-muted-foreground mb-2">{{ $t('common.preview', 'Preview') }}</p>
+            <div class="max-w-sm bg-[#0a141a] dark:bg-[#0a141a] rounded-lg p-3 space-y-1">
+              <p v-if="form.content" class="text-sm text-white whitespace-pre-wrap">{{ form.content }}</p>
+              <PreviewButtonGroup :buttons="form.buttons" disabled />
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/internal/handlers/canned_responses.go
+++ b/internal/handlers/canned_responses.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"encoding/json"
+
 	"github.com/google/uuid"
 	"github.com/shridarpatil/whatomate/internal/audit"
 	"github.com/shridarpatil/whatomate/internal/models"
@@ -9,26 +11,38 @@ import (
 	"gorm.io/gorm"
 )
 
+// CannedResponseButton mirrors the chatbot flow ButtonConfig shape.
+// type is one of "reply", "url", "phone".
+type CannedResponseButton struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Type        string `json:"type,omitempty"`
+	URL         string `json:"url,omitempty"`
+	PhoneNumber string `json:"phone_number,omitempty"`
+}
+
 // CannedResponseRequest represents the request body for creating/updating a canned response
 type CannedResponseRequest struct {
-	Name     string `json:"name"`
-	Shortcut string `json:"shortcut"`
-	Content  string `json:"content"`
-	Category string `json:"category"`
-	IsActive bool   `json:"is_active"`
+	Name     string                 `json:"name"`
+	Shortcut string                 `json:"shortcut"`
+	Content  string                 `json:"content"`
+	Category string                 `json:"category"`
+	IsActive bool                   `json:"is_active"`
+	Buttons  []CannedResponseButton `json:"buttons"`
 }
 
 // CannedResponseResponse represents the API response for a canned response
 type CannedResponseResponse struct {
-	ID         uuid.UUID `json:"id"`
-	Name       string    `json:"name"`
-	Shortcut   string    `json:"shortcut"`
-	Content    string    `json:"content"`
-	Category   string    `json:"category"`
-	IsActive   bool      `json:"is_active"`
-	UsageCount int       `json:"usage_count"`
-	CreatedAt  string    `json:"created_at"`
-	UpdatedAt  string    `json:"updated_at"`
+	ID         uuid.UUID              `json:"id"`
+	Name       string                 `json:"name"`
+	Shortcut   string                 `json:"shortcut"`
+	Content    string                 `json:"content"`
+	Category   string                 `json:"category"`
+	IsActive   bool                   `json:"is_active"`
+	UsageCount int                    `json:"usage_count"`
+	Buttons    []CannedResponseButton `json:"buttons"`
+	CreatedAt  string                 `json:"created_at"`
+	UpdatedAt  string                 `json:"updated_at"`
 }
 
 // ListCannedResponses returns all canned responses for the organization
@@ -117,6 +131,7 @@ func (a *App) CreateCannedResponse(r *fastglue.Request) error {
 		Content:        req.Content,
 		Category:       req.Category,
 		IsActive:       true,
+		Buttons:        buttonsToJSONBArray(req.Buttons),
 		CreatedByID:    userID,
 	}
 
@@ -190,6 +205,7 @@ func (a *App) UpdateCannedResponse(r *fastglue.Request) error {
 	}
 	cannedResponse.Category = req.Category
 	cannedResponse.IsActive = req.IsActive
+	cannedResponse.Buttons = buttonsToJSONBArray(req.Buttons)
 
 	if err := a.DB.Save(&cannedResponse).Error; err != nil {
 		a.Log.Error("Failed to update canned response", "error", err)
@@ -260,16 +276,22 @@ func (a *App) IncrementCannedResponseUsage(r *fastglue.Request) error {
 // cannedResponseAuditSnapshot returns a diff-friendly representation of a
 // canned response for audit logging. Noisy fields (usage_count, timestamps) are
 // intentionally excluded so the activity log reflects user edits only.
+//
+// Note: the buttons array is serialised under "button_config" because the
+// shared audit "buttons" field is on the global skipFields list (chatbot flow
+// step buttons are noisy on every edit). Stringifying gives a readable
+// before/after in the activity log.
 func cannedResponseAuditSnapshot(cr *models.CannedResponse) map[string]any {
 	if cr == nil {
 		return nil
 	}
 	return map[string]any{
-		"name":      cr.Name,
-		"shortcut":  cr.Shortcut,
-		"content":   cr.Content,
-		"category":  cr.Category,
-		"is_active": cr.IsActive,
+		"name":          cr.Name,
+		"shortcut":      cr.Shortcut,
+		"content":       cr.Content,
+		"category":      cr.Category,
+		"is_active":     cr.IsActive,
+		"button_config": buttonsToAuditString(cr.Buttons),
 	}
 }
 
@@ -282,7 +304,83 @@ func cannedResponseToResponse(cr models.CannedResponse) CannedResponseResponse {
 		Category:   cr.Category,
 		IsActive:   cr.IsActive,
 		UsageCount: cr.UsageCount,
+		Buttons:    jsonbArrayToButtons(cr.Buttons),
 		CreatedAt:  cr.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:  cr.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}
+}
+
+// buttonsToJSONBArray converts the typed request shape into the JSONBArray
+// column. We round-trip through JSON so the stored shape matches what the
+// chatbot flow steps use (and what the frontend / whatsapp client expect).
+func buttonsToJSONBArray(buttons []CannedResponseButton) models.JSONBArray {
+	if len(buttons) == 0 {
+		return models.JSONBArray{}
+	}
+	arr := make(models.JSONBArray, 0, len(buttons))
+	for _, b := range buttons {
+		raw, err := json.Marshal(b)
+		if err != nil {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			continue
+		}
+		arr = append(arr, m)
+	}
+	return arr
+}
+
+func jsonbArrayToButtons(arr models.JSONBArray) []CannedResponseButton {
+	out := make([]CannedResponseButton, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		raw, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		var b CannedResponseButton
+		if err := json.Unmarshal(raw, &b); err != nil {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// buttonsToAuditString renders the buttons array as a compact comparable
+// string (e.g. "Yes [reply], Open (https://x.com) [url]") so the audit diff
+// records a single readable change rather than a deep JSON blob.
+func buttonsToAuditString(arr models.JSONBArray) string {
+	buttons := jsonbArrayToButtons(arr)
+	if len(buttons) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(buttons))
+	for _, b := range buttons {
+		t := b.Type
+		if t == "" {
+			t = "reply"
+		}
+		switch t {
+		case "url":
+			parts = append(parts, b.Title+" ("+b.URL+") [url]")
+		case "phone":
+			parts = append(parts, b.Title+" ("+b.PhoneNumber+") [phone]")
+		default:
+			parts = append(parts, b.Title+" [reply]")
+		}
+	}
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
 }

--- a/internal/models/canned_responses.go
+++ b/internal/models/canned_responses.go
@@ -7,14 +7,17 @@ import (
 // CannedResponse represents a pre-defined response text for quick insertion in chat
 type CannedResponse struct {
 	BaseModel
-	OrganizationID uuid.UUID `gorm:"type:uuid;index;not null" json:"organization_id"`
-	Name           string    `gorm:"size:100;not null" json:"name"`
-	Shortcut       string    `gorm:"size:50;index" json:"shortcut"`
-	Content        string    `gorm:"type:text;not null" json:"content"`
-	Category       string    `gorm:"size:50" json:"category"`
-	IsActive       bool      `gorm:"default:true" json:"is_active"`
-	UsageCount     int       `gorm:"default:0" json:"usage_count"`
-	CreatedByID    uuid.UUID `gorm:"type:uuid" json:"created_by_id"`
+	OrganizationID uuid.UUID  `gorm:"type:uuid;index;not null" json:"organization_id"`
+	Name           string     `gorm:"size:100;not null" json:"name"`
+	Shortcut       string     `gorm:"size:50;index" json:"shortcut"`
+	Content        string     `gorm:"type:text;not null" json:"content"`
+	Category       string     `gorm:"size:50" json:"category"`
+	IsActive       bool       `gorm:"default:true" json:"is_active"`
+	UsageCount     int        `gorm:"default:0" json:"usage_count"`
+	// Buttons stored in the same shape as chatbot flow steps:
+	// [{id, title, type:'reply'|'url'|'phone', url?, phone_number?}]
+	Buttons     JSONBArray `gorm:"type:jsonb;default:'[]'" json:"buttons"`
+	CreatedByID uuid.UUID  `gorm:"type:uuid" json:"created_by_id"`
 
 	// Relations
 	Organization *Organization `gorm:"foreignKey:OrganizationID" json:"organization,omitempty"`


### PR DESCRIPTION
Add reply / URL / phone buttons to canned responses, reusing the chatbot flow's editor via a new shared MessageButtonsEditor (chatbot view now consumes the same component). When an agent picks a canned response with buttons, the chat send path uses interactive.button (reply, ≤3) or interactive.cta_url (single URL); phone / mixed combos fall back to plain text since the WhatsApp Cloud API can't carry them.