### PR TITLE
fix(canned-responses): show buttons in the chat send preview

### DIFF
--- a/frontend/src/components/chatbot/flow-preview/PreviewButtonGroup.vue
+++ b/frontend/src/components/chatbot/flow-preview/PreviewButtonGroup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ButtonConfig } from '@/types/flow-preview'
-import { ExternalLink } from 'lucide-vue-next'
+import { ExternalLink, Phone } from 'lucide-vue-next'
 
 defineProps<{
   buttons: ButtonConfig[]
@@ -12,12 +12,7 @@ const emit = defineEmits<{
 }>()
 
 function handleClick(button: ButtonConfig) {
-  if (button.type === 'url' && button.url) {
-    // For URL buttons, just acknowledge in preview
-    emit('select', button)
-  } else {
-    emit('select', button)
-  }
+  emit('select', button)
 }
 </script>
 
@@ -35,6 +30,7 @@ function handleClick(button: ButtonConfig) {
       @click="handleClick(btn)"
     >
       <ExternalLink v-if="btn.type === 'url'" class="h-4 w-4" />
+      <Phone v-else-if="btn.type === 'phone'" class="h-4 w-4" />
       {{ btn.title || 'Option' }}
     </button>
   </div>

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -90,6 +90,7 @@ import { getInitials, getAvatarGradient } from '@/lib/utils'
 import { useColorMode } from '@/composables/useColorMode'
 import { useInfiniteScroll } from '@/composables/useInfiniteScroll'
 import CannedResponsePicker from '@/components/chat/CannedResponsePicker.vue'
+import PreviewButtonGroup from '@/components/chatbot/flow-preview/PreviewButtonGroup.vue'
 import TemplatePicker from '@/components/chat/TemplatePicker.vue'
 import ContactInfoPanel from '@/components/chat/ContactInfoPanel.vue'
 import ConversationNotes from '@/components/chat/ConversationNotes.vue'
@@ -836,6 +837,18 @@ function resolveCannedTokens(text: string): string {
 const cannedPreview = computed(() =>
   selectedCannedResponse.value ? resolveCannedTokens(selectedCannedResponse.value.content) : '',
 )
+
+// Resolved buttons (with {{...}} substitution applied) for the dialog preview.
+// Empty array when no response is selected or it has no buttons.
+const cannedPreviewButtons = computed(() => {
+  const raw = selectedCannedResponse.value?.buttons || []
+  return raw.map(b => ({
+    ...b,
+    title: resolveCannedTokens(b.title),
+    ...(b.url !== undefined ? { url: resolveCannedTokens(b.url) } : {}),
+    ...(b.phone_number !== undefined ? { phone_number: resolveCannedTokens(b.phone_number) } : {}),
+  }))
+})
 
 function handleCannedSelect(response: CannedResponse) {
   selectedCannedResponse.value = response
@@ -2442,10 +2455,15 @@ async function sendMediaMessage() {
               class="h-9 canned-response-param"
             />
           </div>
-          <div v-if="cannedPreview" class="space-y-1">
+          <div v-if="cannedPreview || cannedPreviewButtons.length" class="space-y-1">
             <label class="text-xs font-medium text-muted-foreground">{{ $t('chat.preview') }}</label>
             <div id="canned-response-preview" class="chat-bubble chat-bubble-outgoing ml-auto" style="max-width: 100%;">
-              <span class="whitespace-pre-wrap break-words text-sm">{{ cannedPreview }}</span>
+              <span v-if="cannedPreview" class="whitespace-pre-wrap break-words text-sm">{{ cannedPreview }}</span>
+              <PreviewButtonGroup
+                v-if="cannedPreviewButtons.length"
+                :buttons="cannedPreviewButtons"
+                disabled
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
The canned-response confirm dialog only previewed the resolved body — buttons configured on the response were invisible until the message landed. Render them via the shared PreviewButtonGroup with tokens already resolved, and add a Phone icon to the preview component so phone CTAs are visually distinct from reply buttons (URL already had its ExternalLink icon).