### PR TITLE
fix(templates): support named variables in publish and chat send

### DIFF
--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -159,9 +159,11 @@ const selectedCannedResponse = ref<CannedResponse | null>(null)
 const cannedParamNames = ref<string[]>([])
 const cannedParamValues = ref<Record<string, string>>({})
 const isSendingCanned = ref(false)
-// Tokens that the chat already knows how to fill from the current contact;
-// these stay out of the input list and are resolved straight into the preview.
-const AUTO_RESOLVED_CANNED_TOKENS = new Set(['contact_name', 'phone_number', 'user_name', 'agent_name'])
+// Tokens that the chat already knows how to fill from the current contact /
+// signed-in agent. Shared by canned responses (resolved client-side into the
+// outgoing message) and templates (pre-filled into the param payload so the
+// backend forwards the resolved value to Meta).
+const AUTO_RESOLVED_CONTEXT_TOKENS = new Set(['contact_name', 'phone_number', 'user_name', 'agent_name'])
 
 // Sticky date header state
 const stickyDate = ref('')
@@ -814,21 +816,25 @@ function extractCannedTokensFromResponse(r: CannedResponse): string[] {
   return Array.from(seen)
 }
 
+// Resolve a single context token (contact_name / phone_number / user_name /
+// agent_name) against the current chat. Returns null for any key that isn't
+// in AUTO_RESOLVED_CONTEXT_TOKENS so callers can fall back to their own param
+// dict.
+function resolveContextToken(key: string): string | null {
+  const contact = contactsStore.currentContact
+  if (key === 'contact_name') return contact?.profile_name || contact?.name || 'there'
+  if (key === 'phone_number') return contact?.phone_number || ''
+  if (key === 'user_name' || key === 'agent_name') return authStore.user?.full_name || ''
+  return null
+}
+
 // Shared {{...}} resolver used by the body preview and the button fields, so
 // `{{phone_number}}` works inside a button URL the same way it does in content.
 function resolveCannedTokens(text: string): string {
   if (!text) return text
-  const contact = contactsStore.currentContact
   return text.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_match, key: string) => {
-    if (key === 'contact_name') {
-      return contact?.profile_name || contact?.name || 'there'
-    }
-    if (key === 'phone_number') {
-      return contact?.phone_number || ''
-    }
-    if (key === 'user_name' || key === 'agent_name') {
-      return authStore.user?.full_name || ''
-    }
+    const ctx = resolveContextToken(key)
+    if (ctx !== null) return ctx
     const value = cannedParamValues.value[key]
     return value ? value : `{{${key}}}`
   })
@@ -853,7 +859,7 @@ const cannedPreviewButtons = computed(() => {
 function handleCannedSelect(response: CannedResponse) {
   selectedCannedResponse.value = response
   const tokens = extractCannedTokensFromResponse(response).filter(
-    t => !AUTO_RESOLVED_CANNED_TOKENS.has(t)
+    t => !AUTO_RESOLVED_CONTEXT_TOKENS.has(t)
   )
   cannedParamNames.value = tokens
   cannedParamValues.value = Object.fromEntries(tokens.map(t => [t, '']))
@@ -960,11 +966,14 @@ function getTemplateBodyContent(tpl: any): string {
 
 const templatePreview = computed(() => {
   if (!selectedTemplate.value) return ''
-  let body = getTemplateBodyContent(selectedTemplate.value)
-  for (const [key, value] of Object.entries(templateParamValues.value)) {
-    body = body.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value || `{{${key}}}`)
-  }
-  return body
+  const body = getTemplateBodyContent(selectedTemplate.value)
+  return body.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_match, key: string) => {
+    const supplied = templateParamValues.value[key]
+    if (supplied) return supplied
+    const ctx = resolveContextToken(key)
+    if (ctx !== null) return ctx
+    return `{{${key}}}`
+  })
 })
 
 function extractButtonUrlParams(buttons: any[]): { index: number; text: string; value: string; type: string }[] {
@@ -984,8 +993,17 @@ function extractButtonUrlParams(buttons: any[]): { index: number; text: string; 
 
 function handleTemplateWithParams(template: any, paramNames: string[]) {
   selectedTemplate.value = template
-  templateParamNames.value = paramNames
-  templateParamValues.value = Object.fromEntries(paramNames.map(n => [n, '']))
+  // Pre-fill context tokens from the conversation; keep them in the payload
+  // dict so the backend forwards them to Meta, but hide them from the dialog
+  // so the agent doesn't have to type values we already know — same pattern
+  // as canned responses (see handleCannedSelect).
+  const initial: Record<string, string> = {}
+  for (const name of paramNames) {
+    const resolved = resolveContextToken(name)
+    initial[name] = resolved ?? ''
+  }
+  templateParamValues.value = initial
+  templateParamNames.value = paramNames.filter(n => !AUTO_RESOLVED_CONTEXT_TOKENS.has(n))
   clearTemplateHeaderMedia()
   templateButtonUrlParams.value = extractButtonUrlParams(template.buttons)
   templateDialogOpen.value = true

--- a/pkg/whatsapp/template.go
+++ b/pkg/whatsapp/template.go
@@ -554,7 +554,7 @@ func extractNamedExamplesForComponent(sampleValues []any, componentType, content
 			continue
 		}
 		comp, _ := svMap["component"].(string)
-		if comp != componentType && !(comp == "" && componentType == "body") {
+		if comp != componentType && (comp != "" || componentType != "body") {
 			continue
 		}
 		value, _ := svMap["value"].(string)

--- a/pkg/whatsapp/template.go
+++ b/pkg/whatsapp/template.go
@@ -183,7 +183,7 @@ func (c *Client) buildStandardComponents(template *TemplateSubmission) ([]map[st
 			header["text"] = template.HeaderContent
 			if strings.Contains(template.HeaderContent, "{{") {
 				if isNamedParams {
-					namedExamples := extractNamedExamplesForComponent(template.SampleValues, "header")
+					namedExamples := extractNamedExamplesForComponent(template.SampleValues, "header", template.HeaderContent)
 					if len(namedExamples) > 0 {
 						header["example"] = map[string]any{
 							"header_text_named_params": namedExamples,
@@ -219,7 +219,7 @@ func (c *Client) buildStandardComponents(template *TemplateSubmission) ([]map[st
 	}
 	if strings.Contains(template.BodyContent, "{{") {
 		if isNamedParams {
-			namedExamples := extractNamedExamplesForComponent(template.SampleValues, "body")
+			namedExamples := extractNamedExamplesForComponent(template.SampleValues, "body", template.BodyContent)
 			if len(namedExamples) > 0 {
 				body["example"] = map[string]any{
 					"body_text_named_params": namedExamples,
@@ -506,26 +506,83 @@ func hasNamedParams(content string) bool {
 	return false
 }
 
-// extractNamedExamplesForComponent extracts named example values for Meta API format
-// Returns: [{"param_name": "name", "example": "John"}, ...]
-func extractNamedExamplesForComponent(sampleValues []any, componentType string) []map[string]string {
-	results := []map[string]string{}
-
-	for _, sv := range sampleValues {
-		if svMap, ok := sv.(map[string]any); ok {
-			comp, _ := svMap["component"].(string)
-			// Match component type or accept if not specified (for body)
-			if comp == componentType || (comp == "" && componentType == "body") {
-				paramName, _ := svMap["param_name"].(string)
-				value, _ := svMap["value"].(string)
-				if paramName != "" && value != "" {
-					results = append(results, map[string]string{
-						"param_name": paramName,
-						"example":    value,
-					})
-				}
+// extractNamedParamsInOrder returns the ordered list of named (non-numeric)
+// parameter names as they appear in the given content. Used to map a stored
+// sample value's positional `index` back to the named parameter it belongs to.
+func extractNamedParamsInOrder(content string) []string {
+	names := []string{}
+	parts := strings.Split(content, "{{")
+	for _, m := range parts[1:] {
+		end := strings.Index(m, "}}")
+		if end <= 0 {
+			continue
+		}
+		name := strings.TrimSpace(m[:end])
+		if name == "" {
+			continue
+		}
+		isNumeric := true
+		for _, c := range name {
+			if c < '0' || c > '9' {
+				isNumeric = false
+				break
 			}
 		}
+		if !isNumeric {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// extractNamedExamplesForComponent extracts named example values for Meta API format.
+// Returns: [{"param_name": "name", "example": "John"}, ...]
+//
+// `content` is the body/header text for the component; it's used to recover the
+// param name from a stored sample value that only carries a positional `index`
+// (the shape the frontend currently saves for both positional and named
+// templates).
+func extractNamedExamplesForComponent(sampleValues []any, componentType, content string) []map[string]string {
+	paramNames := extractNamedParamsInOrder(content)
+
+	results := []map[string]string{}
+	seen := map[string]bool{}
+
+	for _, sv := range sampleValues {
+		svMap, ok := sv.(map[string]any)
+		if !ok {
+			continue
+		}
+		comp, _ := svMap["component"].(string)
+		if comp != componentType && !(comp == "" && componentType == "body") {
+			continue
+		}
+		value, _ := svMap["value"].(string)
+		if value == "" {
+			continue
+		}
+
+		paramName, _ := svMap["param_name"].(string)
+		if paramName == "" {
+			idx := 0
+			switch v := svMap["index"].(type) {
+			case float64:
+				idx = int(v)
+			case int:
+				idx = v
+			}
+			if idx >= 1 && idx <= len(paramNames) {
+				paramName = paramNames[idx-1]
+			}
+		}
+		if paramName == "" || seen[paramName] {
+			continue
+		}
+		seen[paramName] = true
+		results = append(results, map[string]string{
+			"param_name": paramName,
+			"example":    value,
+		})
 	}
 
 	return results


### PR DESCRIPTION
Map stored sample values to param_name via the body's named-variable order so publish-to-Meta works with {{contact_name}}-style placeholders. Auto-fill contact/agent context tokens at send time using the shared canned-response resolver so agents don't re-type them.