### PR TITLE
docs(chatbot): document v2 graph-based flow model

### DIFF
--- a/docs/src/content/docs/api-reference/chatbot.mdx
+++ b/docs/src/content/docs/api-reference/chatbot.mdx
@@ -251,6 +251,11 @@ POST /api/chatbot/flows
 
 ### Request Body
 
+Flows are stored as a graph: `nodes` (each with an `id`, `type`, and
+type-specific `config`) connected by `edges` labelled with the
+outcome they handle. Execution starts at `entry_node` and walks edges
+until a node yields (waiting on user input) or terminates.
+
 ```json
 {
   "name": "Feedback Collection",
@@ -258,78 +263,93 @@ POST /api/chatbot/flows
   "initial_message": "Hi! I'd like to collect your feedback.",
   "completion_message": "Thank you for your feedback!",
   "enabled": true,
-  "panel_config": {
-    "sections": [
+  "graph": {
+    "version": 2,
+    "entry_node": "rating",
+    "nodes": [
       {
-        "id": "customer",
-        "label": "Customer Info",
-        "columns": 1,
-        "collapsible": true,
-        "default_collapsed": false,
-        "order": 1,
-        "fields": [
-          {"key": "rating", "label": "Rating", "order": 1},
-          {"key": "comment", "label": "Comment", "order": 2}
-        ]
+        "id": "rating",
+        "type": "buttons",
+        "label": "Ask for rating",
+        "position": {"x": 0, "y": 0},
+        "config": {
+          "body": "How would you rate your experience?",
+          "buttons": [
+            {"id": "excellent", "title": "Excellent"},
+            {"id": "good", "title": "Good"},
+            {"id": "poor", "title": "Poor"}
+          ]
+        }
+      },
+      {
+        "id": "comment",
+        "type": "prompt",
+        "label": "Collect comment",
+        "position": {"x": 250, "y": 0},
+        "config": {
+          "body": "Any additional comments?",
+          "store_as": "comment"
+        }
+      },
+      {
+        "id": "handoff",
+        "type": "transfer",
+        "label": "Transfer to team",
+        "position": {"x": 500, "y": 0},
+        "config": {
+          "body": "Connecting you with our team…",
+          "team_id": "<uuid>",
+          "notes": "Rating: {{rating}}"
+        }
       }
+    ],
+    "edges": [
+      {"from": "rating", "to": "comment", "condition": "button:excellent"},
+      {"from": "rating", "to": "comment", "condition": "button:good"},
+      {"from": "rating", "to": "handoff", "condition": "button:poor"},
+      {"from": "comment", "to": "handoff", "condition": "default"}
     ]
-  },
-  "steps": [
-    {
-      "step_name": "rating",
-      "step_order": 1,
-      "message": "How would you rate your experience?",
-      "message_type": "buttons",
-      "input_type": "select",
-      "buttons": [
-        {"id": "excellent", "title": "Excellent"},
-        {"id": "good", "title": "Good"},
-        {"id": "poor", "title": "Poor"}
-      ],
-      "store_as": "rating"
-    },
-    {
-      "step_name": "comment",
-      "step_order": 2,
-      "message": "Any additional comments?",
-      "message_type": "text",
-      "input_type": "text",
-      "store_as": "comment"
-    },
-    {
-      "step_name": "transfer",
-      "step_order": 3,
-      "message": "Connecting you with our team...",
-      "message_type": "transfer",
-      "transfer_config": {
-        "team_id": "uuid",
-        "notes": "Rating: {{rating}}"
-      }
-    }
-  ]
+  }
 }
 ```
 
-### Step Message Types
+### Node Types
 
-| Type | Description |
-|------|-------------|
-| `text` | Send a static text message |
-| `buttons` | Send message with interactive buttons |
-| `api_fetch` | Fetch message content from external API |
-| `whatsapp_flow` | Trigger a native WhatsApp Flow |
-| `transfer` | Transfer conversation to agent/team and end flow |
+Every node has the shape `{ "id", "type", "label", "position", "config" }`.
+The `config` schema depends on `type`.
 
-### Transfer Step Configuration
+| Type | Purpose | Key config fields | Outgoing edge conditions |
+|------|---------|-------------------|--------------------------|
+| `message` | Send a templated text message. | `message` | `default` |
+| `prompt` | Send a question; wait for and validate a reply. | `body`, `store_as`, `validation_regex`, `validation_error`, `max_retries` | `default`, `max_retries` |
+| `buttons` | Interactive reply buttons. | `body`, `buttons: [{id,title}]` | `button:<id>` per button |
+| `api_call` | HTTP request with response capture + optional templated reply. | `url`, `method`, `headers`, `body`, `response_mapping`, `message_template` | `http:2xx`, `http:non2xx` |
+| `condition` | Boolean expression branch ([expr-lang](https://expr-lang.org/) syntax) over session data. | `expression` | `true`, `false` |
+| `timing` | Business-hours routing. | `schedule: [{day,enabled,start_time,end_time}]` | `in_hours`, `out_of_hours` |
+| `whatsapp_flow` | Send a native WhatsApp Flow form. | `flow_id`, `header`, `body`, `cta` | `default` |
+| `transfer` | Hand off to a team / queue and end the session. | `body`, `team_id`, `notes` | (terminal) |
+| `goto_flow` | Jump to another flow in the same org/account. | `flow_id` | (handled internally) |
+| `webhook` | Fire-and-forget HTTP call; result ignored. | `url`, `method`, `headers`, `body` | `default` |
+| `end` | Optionally send a final message and terminate. | `message` | (terminal) |
 
-The `transfer` message type ends the flow and creates an agent transfer:
+### Edge resolution
+
+For a node `N` that produces outcome `O`, the runtime picks the first
+edge in `edges` where `from == N.id && condition == O`. If no exact
+match exists it falls back to a `condition: "default"` edge. With no
+match at all the session terminates as completed.
+
+### Transfer Node Configuration
+
+A `transfer` node ends the flow and creates an agent transfer:
 
 ```json
 {
-  "message_type": "transfer",
-  "message": "Connecting you with our support team...",
-  "transfer_config": {
-    "team_id": "uuid",
+  "id": "handoff",
+  "type": "transfer",
+  "config": {
+    "body": "Connecting you with our support team…",
+    "team_id": "<uuid>",
     "notes": "From flow: {{variable_name}}"
   }
 }
@@ -337,8 +357,9 @@ The `transfer` message type ends the flow and creates an agent transfer:
 
 | Field | Description |
 |-------|-------------|
-| `team_id` | Target team UUID (omit for general queue) |
-| `notes` | Internal notes for agents (supports `{{variable}}` placeholders) |
+| `body` | Optional message sent to the user before handoff (templated). |
+| `team_id` | Target team UUID. Omit or set to `"_general"` for the shared queue. |
+| `notes` | Internal notes for agents (supports `{{variable}}` placeholders). |
 
 ### Panel Configuration
 

--- a/docs/src/content/docs/features/chatbot.mdx
+++ b/docs/src/content/docs/features/chatbot.mdx
@@ -183,26 +183,59 @@ Design multi-step conversation flows with branching logic to guide customers thr
 <img src="/whatomate/images/conversation-flow-light.png" alt="Conversation Flow Builder" class="light-only" />
 <img src="/whatomate/images/conversation-flow-dark.png" alt="Conversation Flow Builder" class="dark-only" />
 
-The visual flow builder allows you to:
-- Create multiple conversation steps
-- Define user input types (text, buttons, lists)
-- Store responses in variables
-- Add conditional branching
-- Configure completion actions
+The visual flow builder is a node-and-edge graph editor. Drop nodes
+onto the canvas, wire them together, and the runtime walks the graph
+edge-by-edge for each inbound message. Each node has a `type` (what
+it does), a `config` blob (its parameters), and outgoing edges
+labelled with the outcome they handle (`default`, `button:<id>`,
+`true`/`false`, `in_hours`/`out_of_hours`, ...).
+
+### Node Types
+
+| Type | Purpose | Outgoing edges |
+|------|---------|----------------|
+| `message` | Send a templated text message and move on. | `default` |
+| `prompt` | Send a question, wait for the user's reply, optionally validate against a regex, and store the response. | `default`, `max_retries` |
+| `buttons` | Send interactive reply buttons and branch on which one the user taps. | `button:<id>` per button |
+| `api_call` | Fire an HTTP request, capture mapped fields into session data, optionally send a templated message. | `http:2xx`, `http:non2xx` |
+| `condition` | Evaluate an expression against session data and route on the result. | `true`, `false` |
+| `timing` | Route based on a per-day business-hours schedule. | `in_hours`, `out_of_hours` |
+| `whatsapp_flow` | Send a native WhatsApp Flow form and merge the submission into session data. | `default` |
+| `transfer` | Hand off to a team / queue and end the flow. | (terminal) |
+| `goto_flow` | Jump execution into another flow (variables carry over). | (handled internally) |
+| `webhook` | Fire-and-forget HTTP call; result is ignored. | `default` |
+| `end` | Optionally send a final message and terminate the session. | (terminal) |
+
+### Condition Expressions
+
+`condition` nodes use a small expression language
+([expr-lang](https://expr-lang.org/)) evaluated against session
+variables. Top-level identifiers refer to keys stored via
+`prompt.store_as`, `api_call.response_mapping`, or earlier inputs.
+
+```text
+tier == "premium" and amount > 100
+status in ["active", "trialing"]
+phone_number startsWith "+91"
+```
+
+Unknown identifiers resolve to `nil`, so missing data evaluates as
+"false" rather than throwing. Compile/runtime errors also resolve to
+the `false` edge — the webhook always succeeds, even on a typo.
 
 ### Flow Features
 
 | Feature | Description |
 |---------|-------------|
-| **Input Validation** | Validate user responses with regex patterns |
-| **Variable Storage** | Store user inputs for later use in the conversation |
-| **Conditional Logic** | Branch based on user responses |
+| **Input Validation** | Validate user responses on `prompt` nodes with regex patterns |
+| **Variable Storage** | Store user inputs and API response fields for later use |
+| **Conditional Logic** | Branch on expressions, button clicks, business hours, or HTTP status |
 | **API Integration** | Fetch data from external APIs with response mapping |
 | **Template Engine** | Format messages with variables, conditionals, and loops |
 | **Webhook Headers** | Configure custom headers for API calls and completion webhooks |
 | **Agent Transfer** | Transfer to human agent when needed |
 | **WhatsApp Flows** | Integrate native WhatsApp Flows |
-| **Drag & Drop Ordering** | Reorder steps by dragging them to new positions |
+| **Sub-flows** | `goto_flow` jumps into another flow, carrying variables forward |
 
 ### API Integration
 


### PR DESCRIPTION
Replaces the legacy step-list payload in the API reference with the graph shape (nodes + edges + entry_node) actually accepted by POST /api/chatbot/flows, and lists every node type with its key config fields and outgoing edge conditions. Feature page now describes the builder as a node-and-edge editor and introduces condition expressions.