### PR TITLE
fix(chat): show loader and clear stale messages on contact switch

### DIFF
--- a/frontend/src/components/ui/spinner/Spinner.vue
+++ b/frontend/src/components/ui/spinner/Spinner.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue"
+import { computed } from "vue"
+import { Loader2 } from "lucide-vue-next"
+import { cn } from "@/lib/utils"
+
+interface SpinnerProps {
+  size?: "sm" | "md" | "lg"
+  // When true, the spinner fills its nearest positioned ancestor and centers itself.
+  overlay?: boolean
+  class?: HTMLAttributes["class"]
+}
+
+const props = withDefaults(defineProps<SpinnerProps>(), {
+  size: "md",
+  overlay: false,
+})
+
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case "sm":
+      return "h-4 w-4"
+    case "lg":
+      return "h-8 w-8"
+    default:
+      return "h-6 w-6"
+  }
+})
+</script>
+
+<template>
+  <div
+    v-if="overlay"
+    class="absolute inset-0 z-20 flex items-center justify-center"
+  >
+    <Loader2 :class="cn('animate-spin text-white/40 light:text-gray-400', sizeClass, props.class)" />
+  </div>
+  <Loader2
+    v-else
+    :class="cn('animate-spin', sizeClass, props.class)"
+  />
+</template>

--- a/frontend/src/components/ui/spinner/index.ts
+++ b/frontend/src/components/ui/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from "./Spinner.vue"

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -183,6 +183,9 @@ export const useContactsStore = defineStore('contacts', () => {
 
   async function fetchMessages(contactId: string, params?: { page?: number; limit?: number; account?: string }) {
     isLoadingMessages.value = true
+    // Drop the previous contact's messages immediately so the list doesn't show
+    // stale content under the new contact's header while the fetch is in flight.
+    messages.value = []
     try {
       const response = await messagesService.list(contactId, params)
       // API returns { status: "success", data: { messages: [...], has_more: boolean } }

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -18,6 +18,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Spinner } from '@/components/ui/spinner'
 import { Separator } from '@/components/ui/separator'
 import {
   Tooltip,
@@ -1918,6 +1919,9 @@ async function sendMediaMessage() {
 
         <!-- Messages -->
         <div class="relative flex-1 min-h-0 overflow-hidden">
+          <!-- Loading overlay while switching contacts / loading the first page -->
+          <Spinner v-if="contactsStore.isLoadingMessages" overlay />
+
           <!-- Sticky date header -->
           <Transition name="sticky-date">
             <div


### PR DESCRIPTION
Switching contacts updated the header immediately but left the previous contact's messages rendered until the fetch resolved. Clear messages at the start of fetchMessages and show a centered Spinner overlay while the first page loads. Adds a reusable Spinner UI component.