### PR TITLE
feat(templates): support TEXT header parameter end-to-end

### DIFF
--- a/docs/src/content/docs/api-reference/campaigns.mdx
+++ b/docs/src/content/docs/api-reference/campaigns.mdx
@@ -163,17 +163,24 @@ POST /api/campaigns/{id}/recipients/import
   "recipients": [
     {
       "phone_number": "+1234567890",
-      "name": "John Doe",
-      "discount_code": "SAVE20"
+      "recipient_name": "John Doe",
+      "template_params": { "customer_name": "John", "coupon": "SAVE20" },
+      "header_params": { "season": "Summer" }
     },
     {
       "phone_number": "+0987654321",
-      "name": "Jane Smith",
-      "discount_code": "SAVE15"
+      "recipient_name": "Jane Smith",
+      "template_params": { "customer_name": "Jane", "coupon": "SAVE15" },
+      "header_params": { "season": "Winter" }
     }
   ]
 }
 ```
+
+`header_params` is only needed for templates with a TEXT header variable
+(Meta allows at most one). It's kept separate from `template_params` so a
+positional header `{{1}}` doesn't collide with body `{{1}}`. Omit the field
+entirely for templates without a header variable.
 
 ### Response
 

--- a/docs/src/content/docs/api-reference/messages.mdx
+++ b/docs/src/content/docs/api-reference/messages.mdx
@@ -101,6 +101,7 @@ POST /api/messages/template
 | `template_name` | string | One of template_name or template_id | Name of the template |
 | `template_id` | string | One of template_name or template_id | UUID of the template |
 | `template_params` | object | No | Named or positional body parameters |
+| `header_params` | object | No | Value for a TEXT header with a `{{var}}` (max 1). Keyed by the variable's name for named templates, or `"1"` for positional. Falls back to `template_params` if omitted. |
 | `button_params` | object | No | Dynamic URL button parameters (button index → value) |
 | `account_name` | string | No | Specific WhatsApp account to use |
 
@@ -152,6 +153,26 @@ If your template has placeholders like `Hello {{name}}, your order {{order_id}} 
   }
 }
 ```
+
+**With a TEXT header variable:**
+
+Meta allows at most one variable in a TEXT header. If your template's header is `Our {{season}} sale is on!`, supply the value via `header_params`:
+
+```json
+{
+  "phone_number": "919876543210",
+  "template_name": "seasonal_promotion",
+  "header_params": {
+    "season": "Summer"
+  },
+  "template_params": {
+    "customer_name": "John",
+    "discount": "25%"
+  }
+}
+```
+
+For a positional header (`Our {{1}} sale is on!`), use `"1"` as the key. If you omit `header_params`, the value is looked up in `template_params` by the same name — convenient for named templates where the header variable doesn't collide with a body variable.
 
 **With URL button parameters:**
 

--- a/docs/src/content/docs/features/campaigns.mdx
+++ b/docs/src/content/docs/features/campaigns.mdx
@@ -63,6 +63,23 @@ For bulk imports, upload a CSV file with your recipient data:
    +0987654321,Jane Smith,Order #456,December 26
    ```
 
+   **TEXT header parameter:** if the template's header has a variable
+   (`{{...}}`), add a column named `header`. Meta indexes positional
+   placeholders per component, so header `{{1}}` and body `{{1}}` are two
+   distinct values — the reserved column name avoids that collision. The
+   header column always comes **before** the body parameter columns. For
+   example, a template with header `Our {{season}} sale` and body
+   `Hi {{customer_name}}, use code {{coupon}}`:
+   ```csv
+   phone,name,header,customer_name,coupon
+   +1234567890,John Doe,Summer,John,SAVE20
+   +0987654321,Jane Smith,Winter,Jane,SAVE15
+   ```
+
+   The recipient dialog also provides a **Download sample CSV** link that
+   generates a template with the correct columns for your campaign's
+   template — no manual setup required.
+
 2. **Upload and Validate**
 
    The system automatically validates your CSV against the selected template:

--- a/docs/src/content/docs/features/templates.mdx
+++ b/docs/src/content/docs/features/templates.mdx
@@ -109,6 +109,23 @@ Named parameters make templates easier to understand and less error-prone when d
   Named parameters are recommended for templates with 3 or more variables, as they make the template easier to understand and maintain.
 </Aside>
 
+### Header Variables
+
+A TEXT header can contain **at most one** variable — this is a Meta restriction
+that Whatomate enforces at template creation time. Both positional (`{{1}}`)
+and named (`{{season}}`) work; mixing positional and named within the same
+template (header + body) is still not allowed.
+
+When sending:
+- **API**: pass the value via the `header_params` field on
+  [Send Template Message](/api-reference/messages/#send-template-message). It
+  falls back to `template_params` if omitted — convenient for named templates
+  where the header variable name doesn't collide with a body variable.
+- **Campaigns**: add a `header` column (always before the body parameter
+  columns) in your CSV or manual entry. The dialog can generate a sample CSV
+  with the right columns for you. See
+  [Adding Recipients](/features/campaigns/#adding-recipients).
+
 ## Template Categories
 
 <CardGrid>

--- a/frontend/e2e/tests/campaigns/campaign-header-param.spec.ts
+++ b/frontend/e2e/tests/campaigns/campaign-header-param.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test'
+import { Client } from 'pg'
+import { loginAsAdmin, ApiHelper } from '../../helpers'
+import { createTestScope } from '../../framework'
+
+const scope = createTestScope('campaign-header-param')
+
+const DB_URL =
+  process.env.TEST_DATABASE_URL ||
+  'postgres://whatomate:whatomate@127.0.0.1:5432/whatomate'
+
+/**
+ * Campaigns with a TEXT header parameter must:
+ *   1. Show the "header" column in the manual-entry format hint and accept
+ *      a value for it without eating the recipient name slot.
+ *   2. Persist the value to BulkMessageRecipient.HeaderParams (not just
+ *      TemplateParams) so the worker can split header_params from body
+ *      params when calling Meta.
+ *   3. The "Download sample CSV" button generates the right column layout.
+ *
+ * Pattern mirrors template-sending.spec.ts — seed APPROVED templates via SQL
+ * because the API only ever creates DRAFT.
+ */
+
+async function execSQL(sql: string): Promise<string> {
+  const client = new Client({ connectionString: DB_URL })
+  await client.connect()
+  try {
+    const result = await client.query(sql)
+    return result.rows.length > 0 ? String(Object.values(result.rows[0])[0]) : ''
+  } finally {
+    await client.end()
+  }
+}
+
+test.describe('Campaign recipients — TEXT header parameter', () => {
+  test.describe.configure({ mode: 'serial' })
+  test.setTimeout(60000)
+
+  let accountName: string
+  let templateId: string
+  let templateName: string
+
+  test.beforeAll(async () => {
+    const reqContext = await playwrightRequest.newContext()
+    const api = new ApiHelper(reqContext)
+    await api.loginAsAdmin()
+
+    let accounts: any[] = []
+    try {
+      accounts = await api.getWhatsAppAccounts()
+    } catch {
+      // ignore
+    }
+    if (accounts.length === 0) {
+      const uid = Date.now().toString().slice(-8)
+      await api.createWhatsAppAccount({
+        name: `e2e-camp-hdr-${uid}`,
+        phone_id: `phone-${uid}`,
+        business_id: `biz-${uid}`,
+        access_token: `token-${uid}`,
+      })
+      accounts = await api.getWhatsAppAccounts()
+    }
+    accountName = accounts[0].name
+
+    const orgId = await execSQL(
+      `SELECT organization_id FROM users WHERE email = 'admin@test.com' LIMIT 1`,
+    )
+    // Clean up leftover state from previous runs. Order matters: recipients
+    // FK to campaigns FK to templates.
+    await execSQL(`DELETE FROM bulk_message_recipients WHERE campaign_id IN (SELECT id FROM bulk_message_campaigns WHERE template_id IN (SELECT id FROM templates WHERE name LIKE 'e2e_camp_hdr_%' AND organization_id = '${orgId}'))`)
+    await execSQL(`DELETE FROM bulk_message_campaigns WHERE template_id IN (SELECT id FROM templates WHERE name LIKE 'e2e_camp_hdr_%' AND organization_id = '${orgId}')`)
+    await execSQL(`DELETE FROM templates WHERE name LIKE 'e2e_camp_hdr_%' AND organization_id = '${orgId}'`)
+
+    const uid = Date.now().toString().slice(-6)
+    templateName = `e2e_camp_hdr_${uid}`
+    // Positional header + positional body — the case where the flat
+    // TemplateParams map would collide and that this fix actually addresses.
+    templateId = await execSQL(`INSERT INTO templates (id, organization_id, whats_app_account, name, display_name, language, category, status, header_type, header_content, body_content, created_at, updated_at)
+      VALUES (gen_random_uuid(), '${orgId}', '${accountName}', '${templateName}', 'E2E Campaign Header ${uid}', 'en', 'UTILITY', 'APPROVED', 'TEXT', 'Order {{1}} update', 'Hi {{1}}, code {{2}}', NOW(), NOW())
+      RETURNING id`)
+
+    await reqContext.dispose()
+  })
+
+  test('manual entry parses header column into header_params and body values into template_params', async ({ page, request }) => {
+    const api = new ApiHelper(request)
+    await api.login('admin@admin.com', 'admin')
+
+    // Seed a draft campaign for this template via the API.
+    const createResp = await api.post('/api/campaigns', {
+      name: scope.name('campaign'),
+      whatsapp_account: accountName,
+      template_id: templateId,
+    })
+    expect(createResp.ok(), `campaign POST failed: ${createResp.status()} ${await createResp.text()}`).toBe(true)
+    const campaign = (await createResp.json()).data
+    const campaignId = campaign.id
+
+    // Drive the recipient dialog through the UI.
+    await loginAsAdmin(page)
+    await page.goto(`/campaigns/${campaignId}`)
+    await page.waitForLoadState('networkidle')
+
+    await page.getByRole('button', { name: /Add Recipients/i }).first().click()
+    const dialog = page.locator('[role="dialog"]')
+    await expect(dialog).toBeVisible()
+
+    // Format hint shows the header column explicitly so users don't conflate
+    // it with the body params.
+    await expect(dialog.locator('code')).toContainText('header')
+
+    // Manual entry: phone, name, header, body_1, body_2 — header is the
+    // third column. The Textarea component doesn't forward an id; the
+    // dialog only has one textarea when the Manual tab is active.
+    const textarea = dialog.locator('textarea')
+    await textarea.fill('+15551230001, Alice, HEADER-VAL, BODY-1, BODY-2')
+
+    // Validation passes — no error chips listed.
+    await expect(dialog.getByText(/lines have errors/i)).toBeHidden()
+
+    const addBtn = dialog.getByRole('button', { name: /Add Recipients/i }).last()
+    await expect(addBtn).toBeEnabled()
+    // Wait for the POST to complete before querying the DB, otherwise we
+    // race the async insert.
+    const addResp = page.waitForResponse((r) =>
+      r.url().includes(`/api/campaigns/${campaignId}/recipients/import`) && r.request().method() === 'POST',
+    )
+    await addBtn.click()
+    await addResp
+    await expect(dialog).toBeHidden()
+
+    // Side-channel: load the recipient row and assert HeaderParams was
+    // persisted as its own JSONB field — separate from TemplateParams.
+    const stored = await execSQL(
+      `SELECT json_build_object('hp', header_params, 'tp', template_params)::text FROM bulk_message_recipients WHERE campaign_id = '${campaignId}' LIMIT 1`,
+    )
+    const parsed = JSON.parse(stored) as {
+      hp: Record<string, string>
+      tp: Record<string, string>
+    }
+    expect(parsed.hp).toEqual({ '1': 'HEADER-VAL' })
+    expect(parsed.tp).toEqual({ '1': 'BODY-1', '2': 'BODY-2' })
+
+    // Cleanup so re-runs stay deterministic.
+    await execSQL(`DELETE FROM bulk_message_recipients WHERE campaign_id = '${campaignId}'`)
+    await execSQL(`DELETE FROM bulk_message_campaigns WHERE id = '${campaignId}'`)
+  })
+
+  test('manual entry surfaces a column-count error when the header value is omitted', async ({ page, request }) => {
+    const api = new ApiHelper(request)
+    await api.login('admin@admin.com', 'admin')
+
+    const createResp = await api.post('/api/campaigns', {
+      name: scope.name('campaign-bad'),
+      whatsapp_account: accountName,
+      template_id: templateId,
+    })
+    expect(createResp.ok()).toBe(true)
+    const campaignId = (await createResp.json()).data.id
+
+    await loginAsAdmin(page)
+    await page.goto(`/campaigns/${campaignId}`)
+    await page.waitForLoadState('networkidle')
+
+    await page.getByRole('button', { name: /Add Recipients/i }).first().click()
+    const dialog = page.locator('[role="dialog"]')
+    await expect(dialog).toBeVisible()
+
+    // Missing the header column — only phone, name, and two body values.
+    // The tightened validator must catch the column-count mismatch instead
+    // of silently mapping "BODY-1" into the header slot.
+    const textarea = dialog.locator('textarea')
+    await textarea.fill('+15551230002, Alice, BODY-1, BODY-2')
+
+    await expect(dialog.getByText(/Need 3 parameter values/i)).toBeVisible()
+
+    const addBtn = dialog.getByRole('button', { name: /Add Recipients/i }).last()
+    await expect(addBtn).toBeDisabled()
+
+    // Cleanup.
+    await execSQL(`DELETE FROM bulk_message_campaigns WHERE id = '${campaignId}'`)
+  })
+
+  test('Download sample CSV produces a header row that includes the "header" column', async ({ page, request }) => {
+    const api = new ApiHelper(request)
+    await api.login('admin@admin.com', 'admin')
+
+    const createResp = await api.post('/api/campaigns', {
+      name: scope.name('campaign-csv'),
+      whatsapp_account: accountName,
+      template_id: templateId,
+    })
+    expect(createResp.ok()).toBe(true)
+    const campaignId = (await createResp.json()).data.id
+
+    await loginAsAdmin(page)
+    await page.goto(`/campaigns/${campaignId}`)
+    await page.waitForLoadState('networkidle')
+
+    await page.getByRole('button', { name: /Add Recipients/i }).first().click()
+    const dialog = page.locator('[role="dialog"]')
+    await expect(dialog).toBeVisible()
+
+    await dialog.getByRole('tab', { name: /CSV/i }).click()
+
+    const downloadPromise = page.waitForEvent('download')
+    await dialog.getByRole('button', { name: /Download sample CSV/i }).click()
+    const download = await downloadPromise
+
+    const path = await download.path()
+    expect(path).toBeTruthy()
+    const fs = await import('fs/promises')
+    const csv = await fs.readFile(path!, 'utf-8')
+    const headerRow = csv.split('\n')[0]
+    expect(headerRow.split(',')).toEqual(['phone_number', 'name', 'header', '1', '2'])
+
+    // Cleanup.
+    await execSQL(`DELETE FROM bulk_message_campaigns WHERE id = '${campaignId}'`)
+  })
+})

--- a/frontend/e2e/tests/chat/template-header-param.spec.ts
+++ b/frontend/e2e/tests/chat/template-header-param.spec.ts
@@ -1,0 +1,201 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test'
+import { Client } from 'pg'
+import { loginAsAdmin, ApiHelper } from '../../helpers'
+import { ChatPage } from '../../pages'
+import { createTestScope } from '../../framework'
+
+const scope = createTestScope('chat-tpl-header-param')
+
+const DB_URL =
+  process.env.TEST_DATABASE_URL ||
+  'postgres://whatomate:whatomate@127.0.0.1:5432/whatomate'
+
+/**
+ * Templates with a TEXT header containing a {{var}} need a dedicated input
+ * slot in the chat composer's Fill Parameters dialog, and the value must be
+ * sent to the backend under `header_params` (separate from `template_params`)
+ * so positional {{1}} in the header doesn't collide with positional {{1}} in
+ * the body.
+ *
+ * Pattern mirrors template-sending.spec.ts — seed APPROVED templates via SQL
+ * because the API only ever creates DRAFT.
+ */
+
+async function execSQL(sql: string): Promise<string> {
+  const client = new Client({ connectionString: DB_URL })
+  await client.connect()
+  try {
+    const result = await client.query(sql)
+    return result.rows.length > 0 ? String(Object.values(result.rows[0])[0]) : ''
+  } finally {
+    await client.end()
+  }
+}
+
+test.describe('Chat composer — TEXT header parameter', () => {
+  test.describe.configure({ mode: 'serial' })
+  test.setTimeout(60000)
+
+  let contactId: string
+  let accountName: string
+  let positionalTplName: string
+  let namedTplName: string
+
+  test.beforeAll(async () => {
+    const reqContext = await playwrightRequest.newContext()
+    const api = new ApiHelper(reqContext)
+    await api.loginAsAdmin()
+
+    const phone = scope.phone()
+    await api.createContact(phone, scope.name('contact'))
+    const contacts = await api.getContacts()
+    const contact = contacts.find((c: any) => c.phone_number === phone) || contacts[0]
+    contactId = contact.id
+
+    let accounts: any[] = []
+    try {
+      accounts = await api.getWhatsAppAccounts()
+    } catch {
+      // ignore
+    }
+    if (accounts.length === 0) {
+      const uid = Date.now().toString().slice(-8)
+      await api.createWhatsAppAccount({
+        name: `e2e-hdr-account-${uid}`,
+        phone_id: `phone-${uid}`,
+        business_id: `biz-${uid}`,
+        access_token: `token-${uid}`,
+      })
+      accounts = await api.getWhatsAppAccounts()
+    }
+    accountName = accounts[0].name
+
+    const orgId = await execSQL(
+      `SELECT organization_id FROM users WHERE email = 'admin@test.com' LIMIT 1`,
+    )
+    await execSQL(`DELETE FROM templates WHERE name LIKE 'e2e_hdr_%' AND organization_id = '${orgId}'`)
+
+    const uid = Date.now().toString().slice(-6)
+
+    // Positional template — header {{1}} AND body {{1}}, the case that was
+    // collapsing to a single input before this work.
+    positionalTplName = `e2e_hdr_pos_${uid}`
+    await execSQL(`INSERT INTO templates (id, organization_id, whats_app_account, name, display_name, language, category, status, header_type, header_content, body_content, created_at, updated_at)
+      VALUES (gen_random_uuid(), '${orgId}', '${accountName}', '${positionalTplName}', 'E2E Header Pos ${uid}', 'en', 'UTILITY', 'APPROVED', 'TEXT', 'Order {{1}} update', 'Hi {{1}}, code {{2}}', NOW(), NOW())`)
+
+    // Named template — separate var names; covers the "header_params is
+    // optional, falls back to template_params" path.
+    namedTplName = `e2e_hdr_named_${uid}`
+    await execSQL(`INSERT INTO templates (id, organization_id, whats_app_account, name, display_name, language, category, status, header_type, header_content, body_content, created_at, updated_at)
+      VALUES (gen_random_uuid(), '${orgId}', '${accountName}', '${namedTplName}', 'E2E Header Named ${uid}', 'en', 'UTILITY', 'APPROVED', 'TEXT', 'Our {{season}} sale', 'Hi {{name}}', NOW(), NOW())`)
+
+    await execSQL(`UPDATE contacts SET whats_app_account = '${accountName}' WHERE id = '${contactId}'`)
+    await reqContext.dispose()
+  })
+
+  test('positional template renders distinct header + body inputs', async ({ page }) => {
+    await loginAsAdmin(page)
+    const chatPage = new ChatPage(page)
+    await chatPage.goto(contactId)
+
+    await chatPage.openTemplatePicker()
+    await chatPage.waitForTemplatesLoaded()
+    await chatPage.searchTemplates('e2e_hdr_pos')
+    await chatPage.selectTemplate('E2E Header Pos')
+
+    await expect(chatPage.templateDialog).toBeVisible()
+
+    // Header slot is labeled with a "Header" badge — the dedicated input lives
+    // in its own .space-y-1 block.
+    const headerBadge = chatPage.templateDialog.getByText('Header', { exact: true })
+    await expect(headerBadge).toBeVisible()
+
+    // Two inputs must exist for {{1}}: one above the badge slot, one below.
+    // (Pre-fix, dedupe collapsed them to a single input.)
+    const allInputs = chatPage.templateDialog.locator('input[type="text"], input:not([type])')
+    expect(await allInputs.count()).toBeGreaterThanOrEqual(2)
+
+    await chatPage.cancelTemplateDialog()
+  })
+
+  test('sending a positional template emits header_params separately from template_params', async ({ page }) => {
+    await loginAsAdmin(page)
+    const chatPage = new ChatPage(page)
+    await chatPage.goto(contactId)
+
+    await chatPage.openTemplatePicker()
+    await chatPage.waitForTemplatesLoaded()
+    await chatPage.searchTemplates('e2e_hdr_pos')
+    await chatPage.selectTemplate('E2E Header Pos')
+
+    await expect(chatPage.templateDialog).toBeVisible()
+
+    // The header slot is the .space-y-1 block containing the "Header" badge.
+    const headerSlot = chatPage.templateDialog
+      .locator('.space-y-1')
+      .filter({ has: page.getByText('Header', { exact: true }) })
+    await headerSlot.locator('input').fill('HEADER-VAL')
+
+    // Body inputs follow templateParamNames order — "1" then "2".
+    const bodyInputs = chatPage.templateDialog
+      .locator('.space-y-1')
+      .filter({ hasNotText: 'Header' })
+      .locator('input')
+    await bodyInputs.nth(0).fill('BODY-VAL-1')
+    await bodyInputs.nth(1).fill('BODY-VAL-2')
+
+    // Capture the outgoing POST /api/messages/template payload to verify the
+    // split. The send is async on the backend so the request goes out as soon
+    // as we click Send.
+    const sendRequest = page.waitForRequest((r) =>
+      r.method() === 'POST' && r.url().includes('/api/messages/template'),
+    )
+    await chatPage.sendTemplate()
+    const req = await sendRequest
+
+    const body = req.postDataJSON() as {
+      template_params?: Record<string, string>
+      header_params?: Record<string, string>
+    }
+    expect(body.header_params).toEqual({ '1': 'HEADER-VAL' })
+    expect(body.template_params).toEqual({ '1': 'BODY-VAL-1', '2': 'BODY-VAL-2' })
+  })
+
+  test('named template forwards header value (no collision case)', async ({ page }) => {
+    await loginAsAdmin(page)
+    const chatPage = new ChatPage(page)
+    await chatPage.goto(contactId)
+
+    await chatPage.openTemplatePicker()
+    await chatPage.waitForTemplatesLoaded()
+    await chatPage.searchTemplates('e2e_hdr_named')
+    await chatPage.selectTemplate('E2E Header Named')
+
+    await expect(chatPage.templateDialog).toBeVisible()
+
+    const headerSlot = chatPage.templateDialog
+      .locator('.space-y-1')
+      .filter({ has: page.getByText('Header', { exact: true }) })
+    await headerSlot.locator('input').fill('Summer')
+
+    const nameInput = chatPage.templateDialog
+      .locator('.space-y-1')
+      .filter({ hasText: 'name' })
+      .filter({ hasNotText: 'Header' })
+      .locator('input')
+    await nameInput.fill('Alice')
+
+    const sendRequest = page.waitForRequest((r) =>
+      r.method() === 'POST' && r.url().includes('/api/messages/template'),
+    )
+    await chatPage.sendTemplate()
+    const req = await sendRequest
+
+    const body = req.postDataJSON() as {
+      template_params?: Record<string, string>
+      header_params?: Record<string, string>
+    }
+    expect(body.header_params).toEqual({ season: 'Summer' })
+    expect(body.template_params).toEqual({ name: 'Alice' })
+  })
+})

--- a/frontend/e2e/tests/settings/template-text-header-param.spec.ts
+++ b/frontend/e2e/tests/settings/template-text-header-param.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test'
+import { ApiHelper, loginAsAdmin } from '../../helpers'
+import { createTestScope, SUPER_ADMIN } from '../../framework'
+
+const scope = createTestScope('tpl-text-header-param')
+
+/**
+ * Meta restricts TEXT headers to one variable. The template editor must
+ * surface this constraint inline and block save before the backend has to
+ * 400 the request — and before publishing a template Meta will reject.
+ *
+ * See:
+ *   - internal/templateutil.ValidateHeaderParamCount
+ *   - frontend/src/views/settings/TemplateDetailView.vue (hasTooManyHeaderVariables)
+ */
+
+test.describe('Template editor — TEXT header parameter', () => {
+  let api: ApiHelper
+  let accountName: string
+
+  test.beforeEach(async ({ request }) => {
+    api = new ApiHelper(request)
+    await api.login(SUPER_ADMIN.email, SUPER_ADMIN.password)
+
+    const accounts = await api.getWhatsAppAccounts()
+    accountName = accounts[0]?.name
+    if (!accountName) {
+      const acc = await api.createWhatsAppAccount({
+        name: scope.name('acct').toLowerCase().replace(/\s/g, '-'),
+        phone_id: `phone-tpl-text-${Date.now()}`,
+        business_id: `biz-tpl-text-${Date.now()}`,
+        access_token: 'test-token-e2e',
+      })
+      accountName = acc.name
+    }
+  })
+
+  test('editor surfaces an inline error when the TEXT header has 2+ variables', async ({ page, request }) => {
+    // Seed a clean DRAFT template with a single-variable TEXT header.
+    const tpl = await api.createTemplate({
+      name: scope.name('tpl').toLowerCase().replace(/\s/g, '_'),
+      body_content: 'Hi {{1}}',
+      whatsapp_account: accountName,
+      header_type: 'TEXT',
+      header_content: 'Hi {{1}}',
+      status: 'DRAFT',
+    })
+
+    await loginAsAdmin(page)
+    await page.goto(`/templates/${tpl.id}`)
+    await page.waitForLoadState('networkidle')
+
+    // Edit the header to two variables. The inline destructive hint should
+    // appear right below the input.
+    const headerInput = page.locator('#header-content')
+    await headerInput.fill('Order {{1}} for {{2}}')
+
+    await expect(
+      page.getByText(/at most one variable in a TEXT header/i),
+    ).toBeVisible()
+
+    // Backing this up with the API negative path — the handler also enforces
+    // the same constraint, so a direct PUT must 400 with the same wording.
+    const resp = await api.put(`/api/templates/${tpl.id}`, {
+      header_type: 'TEXT',
+      header_content: 'Order {{1}} for {{2}}',
+      body_content: 'Hi {{1}}',
+    })
+    expect(resp.status()).toBe(400)
+    expect(await resp.text()).toMatch(/at most one variable/i)
+  })
+
+  test('editor accepts a single-variable header and persists it', async ({ page, request }) => {
+    const tpl = await api.createTemplate({
+      name: scope.name('tpl-single').toLowerCase().replace(/\s/g, '_'),
+      body_content: 'Hi {{1}}',
+      whatsapp_account: accountName,
+      header_type: 'TEXT',
+      header_content: 'Welcome',
+      status: 'DRAFT',
+    })
+
+    await loginAsAdmin(page)
+    await page.goto(`/templates/${tpl.id}`)
+    await page.waitForLoadState('networkidle')
+
+    await page.locator('#header-content').fill('Our {{1}} sale')
+
+    // Destructive hint must NOT appear with one variable.
+    await expect(
+      page.getByText(/at most one variable in a TEXT header/i),
+    ).toBeHidden()
+
+    // API side-channel: PUT with one variable succeeds.
+    const resp = await api.put(`/api/templates/${tpl.id}`, {
+      header_type: 'TEXT',
+      header_content: 'Our {{1}} sale',
+      body_content: 'Hi {{1}}',
+    })
+    expect(resp.ok(), `PUT failed: ${resp.status()} ${await resp.text()}`).toBe(true)
+  })
+})

--- a/frontend/src/components/chat/TemplatePicker.vue
+++ b/frontend/src/components/chat/TemplatePicker.vue
@@ -89,18 +89,20 @@ function getBodyContent(tpl: any): string {
   return tpl.body_content || ''
 }
 
-function extractParamNames(bodyContent: string): string[] {
-  const matches = bodyContent.match(/\{\{([^}]+)\}\}/g)
+function extractParamNames(content: string): string[] {
+  const matches = content.match(/\{\{([^}]+)\}\}/g)
   if (!matches) return []
   return [...new Set(matches.map(m => m.replace(/\{\{|\}\}/g, '').trim()))]
 }
 
 function selectTemplate(tpl: any) {
-  const bodyContent = getBodyContent(tpl)
-  const paramNames = extractParamNames(bodyContent)
+  // Emit body variables only — the header variable is handled separately by
+  // the parent so positional {{1}} in header and body don't collapse into a
+  // single input (Meta indexes positional vars per component).
+  const bodyNames = extractParamNames(getBodyContent(tpl))
 
   // Always show preview dialog before sending
-  emit('select-with-params', tpl, paramNames)
+  emit('select-with-params', tpl, bodyNames)
 
   isOpen.value = false
   searchQuery.value = ''

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -260,13 +260,16 @@ export const messagesService = {
       }
     },
   ) => api.post(`/contacts/${contactId}/messages`, data),
-  sendTemplate: (contactId: string, data: { template_name: string; template_params?: Record<string, string>; button_params?: Record<string, string>; account_name?: string }, headerFile?: File) => {
+  sendTemplate: (contactId: string, data: { template_name: string; template_params?: Record<string, string>; header_params?: Record<string, string>; button_params?: Record<string, string>; account_name?: string }, headerFile?: File) => {
     if (headerFile) {
       const formData = new FormData()
       formData.append('contact_id', contactId)
       formData.append('template_name', data.template_name)
       if (data.template_params) {
         formData.append('template_params', JSON.stringify(data.template_params))
+      }
+      if (data.header_params) {
+        formData.append('header_params', JSON.stringify(data.header_params))
       }
       if (data.button_params) {
         formData.append('button_params', JSON.stringify(data.button_params))

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -258,12 +258,14 @@ export const useContactsStore = defineStore('contacts', () => {
     templateParams?: Record<string, string>,
     accountName?: string,
     headerFile?: File,
-    buttonParams?: Record<string, string>
+    buttonParams?: Record<string, string>,
+    headerParams?: Record<string, string>
   ) {
     try {
       const response = await messagesService.sendTemplate(contactId, {
         template_name: templateName,
         template_params: templateParams,
+        header_params: headerParams,
         button_params: buttonParams,
         account_name: accountName
       }, headerFile)

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -182,6 +182,11 @@ const templateDialogOpen = ref(false)
 const selectedTemplate = ref<any>(null)
 const templateParamNames = ref<string[]>([])
 const templateParamValues = ref<Record<string, string>>({})
+// Name of the TEXT-header variable (max 1 per Meta) and its value. Kept in
+// its own ref so a positional {{1}} in the header doesn't collide with a
+// {{1}} body parameter — both can be filled independently.
+const templateHeaderParamName = ref<string | null>(null)
+const templateHeaderParamValue = ref('')
 const templateButtonUrlParams = ref<{ index: number; text: string; value: string; type: string }[]>([])
 const isSendingTemplate = ref(false)
 const templateHeaderType = computed(() => selectedTemplate.value?.header_type)
@@ -995,6 +1000,14 @@ const templatePreview = computed(() => {
   })
 })
 
+// Show the header input only when the user has to fill it. Context-token
+// names (contact_name, phone_number, …) auto-resolve and stay hidden — same
+// rule body params follow via templateParamNames filtering.
+const showHeaderParamInput = computed(() =>
+  !!templateHeaderParamName.value &&
+  !AUTO_RESOLVED_CONTEXT_TOKENS.has(templateHeaderParamName.value)
+)
+
 function extractButtonUrlParams(buttons: any[]): { index: number; text: string; value: string; type: string }[] {
   if (!buttons?.length) return []
   return buttons
@@ -1012,10 +1025,10 @@ function extractButtonUrlParams(buttons: any[]): { index: number; text: string; 
 
 function handleTemplateWithParams(template: any, paramNames: string[]) {
   selectedTemplate.value = template
-  // Pre-fill context tokens from the conversation; keep them in the payload
-  // dict so the backend forwards them to Meta, but hide them from the dialog
-  // so the agent doesn't have to type values we already know — same pattern
-  // as canned responses (see handleCannedSelect).
+  // Pre-fill body context tokens from the conversation; keep them in the
+  // payload dict so the backend forwards them to Meta, but hide them from
+  // the dialog so the agent doesn't have to type values we already know —
+  // same pattern as canned responses (see handleCannedSelect).
   const initial: Record<string, string> = {}
   for (const name of paramNames) {
     const resolved = resolveContextToken(name)
@@ -1023,6 +1036,22 @@ function handleTemplateWithParams(template: any, paramNames: string[]) {
   }
   templateParamValues.value = initial
   templateParamNames.value = paramNames.filter(n => !AUTO_RESOLVED_CONTEXT_TOKENS.has(n))
+
+  // Identify the TEXT-header variable (max 1) and pre-fill from context.
+  // Context-token names (contact_name / phone_number / agent_name / user_name)
+  // resolve automatically and stay hidden from the dialog — same convention
+  // as body params.
+  templateHeaderParamName.value = null
+  templateHeaderParamValue.value = ''
+  if (template.header_type === 'TEXT' && template.header_content) {
+    const m = template.header_content.match(/\{\{([^}]+)\}\}/)
+    if (m) {
+      const name = m[1].trim()
+      templateHeaderParamName.value = name
+      templateHeaderParamValue.value = resolveContextToken(name) ?? ''
+    }
+  }
+
   clearTemplateHeaderMedia()
   templateButtonUrlParams.value = extractButtonUrlParams(template.buttons)
   templateDialogOpen.value = true
@@ -1030,6 +1059,14 @@ function handleTemplateWithParams(template: any, paramNames: string[]) {
 
 async function sendTemplateMessage() {
   if (!contactsStore.currentContact || !selectedTemplate.value) return
+
+  // Validate header param (separate ref so it can hold its own value even
+  // when the body has a {{1}} that would otherwise collide). Auto-resolved
+  // context tokens are exempt — their value comes from the conversation.
+  if (showHeaderParamInput.value && !templateHeaderParamValue.value.trim()) {
+    toast.error(t('chat.parameterRequired'))
+    return
+  }
 
   // Validate all body params are filled
   const missingBody = templateParamNames.value.some(n => !templateParamValues.value[n]?.trim())
@@ -1057,6 +1094,12 @@ async function sendTemplateMessage() {
       ? Object.fromEntries(templateButtonUrlParams.value.map(b => [String(b.index), b.value]))
       : undefined
 
+  // Header value goes in its own payload field so a positional {{1}} header
+  // doesn't overwrite a positional {{1}} body parameter in the flat map.
+  const headerParams: Record<string, string> | undefined =
+    templateHeaderParamName.value && templateHeaderParamValue.value
+      ? { [templateHeaderParamName.value]: templateHeaderParamValue.value }
+      : undefined
 
   isSendingTemplate.value = true
   try {
@@ -1066,13 +1109,16 @@ async function sendTemplateMessage() {
       templateParamValues.value,
       selectedAccount.value || undefined,
       templateHeaderFile.value || undefined,
-      buttonParams
+      buttonParams,
+      headerParams
     )
     toast.success(t('chat.templateSent'))
     templateDialogOpen.value = false
     selectedTemplate.value = null
     templateParamNames.value = []
     templateParamValues.value = {}
+    templateHeaderParamName.value = null
+    templateHeaderParamValue.value = ''
     clearTemplateHeaderMedia()
     templateButtonUrlParams.value = []
   } catch (error: any) {
@@ -2455,6 +2501,19 @@ async function sendMediaMessage() {
             @clear="clearTemplateHeaderMedia"
           />
 
+          <div v-if="showHeaderParamInput" class="space-y-1">
+            <label class="text-sm font-medium flex items-center gap-1.5">
+              <span>{{ templateHeaderParamName }}</span>
+              <span class="text-[10px] uppercase tracking-wider text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                {{ $t('chat.headerParamBadge', 'Header') }}
+              </span>
+            </label>
+            <Input
+              v-model="templateHeaderParamValue"
+              :placeholder="templateHeaderParamName ?? ''"
+              class="h-9"
+            />
+          </div>
           <div v-for="param in templateParamNames" :key="param" class="space-y-1">
             <label class="text-sm font-medium">{{ param }}</label>
             <Input

--- a/frontend/src/views/settings/CampaignDetailView.vue
+++ b/frontend/src/views/settings/CampaignDetailView.vue
@@ -74,6 +74,7 @@ import {
   Upload,
   FileSpreadsheet,
   ChevronDown,
+  Download,
 } from 'lucide-vue-next'
 
 interface Campaign {
@@ -211,48 +212,75 @@ const {
 } = useHeaderMedia(selectedTemplateHeaderType)
 const isUploadingMedia = ref(false)
 
-// Template parameter helpers
-function getTemplateParamNames(template: Template): string[] {
-  if (!template.body_content) return []
-  const matches = template.body_content.match(/\{\{([^}]+)\}\}/g) || []
+// Template parameter helpers. Header and body are tracked separately so that
+// a positional header {{1}} and body {{1}} (which Meta treats as distinct,
+// component-scoped variables) don't collapse to a single column.
+function extractParamNames(text?: string): string[] {
+  if (!text) return []
   const seen = new Set<string>()
-  const names: string[] = []
+  const out: string[] = []
+  const matches = text.match(/\{\{([^}]+)\}\}/g) || []
   for (const m of matches) {
     const name = m.replace(/[{}]/g, '').trim()
     if (name && !seen.has(name)) {
       seen.add(name)
-      names.push(name)
+      out.push(name)
     }
   }
-  return names
+  return out
 }
 
-const templateParamNames = computed(() => {
-  if (!selectedTemplate.value) return []
-  return getTemplateParamNames(selectedTemplate.value)
+const templateHeaderParamName = computed<string | null>(() => {
+  const tpl = selectedTemplate.value
+  if (!tpl || tpl.header_type !== 'TEXT') return null
+  const names = extractParamNames(tpl.header_content)
+  return names[0] || null
 })
+
+const templateBodyParamNames = computed<string[]>(() => {
+  if (!selectedTemplate.value) return []
+  return extractParamNames(selectedTemplate.value.body_content)
+})
+
+// Concatenated list (header first if present, then body). Used purely to
+// render the input slot count / example placeholders — the actual recipient
+// payload splits header and body back apart.
+const templateParamNames = computed<string[]>(() => {
+  const list: string[] = []
+  if (templateHeaderParamName.value) list.push('header')
+  list.push(...templateBodyParamNames.value)
+  return list
+})
+
+function exampleValue(name: string, index: number): string {
+  if (name === 'header') return 'Summer'
+  if (/^\d+$/.test(name)) return `value${index + 1}`
+  if (name.toLowerCase().includes('name')) return 'John Doe'
+  if (name.toLowerCase().includes('order')) return 'ORD-123'
+  if (name.toLowerCase().includes('date')) return '2024-01-15'
+  if (name.toLowerCase().includes('amount') || name.toLowerCase().includes('price')) return '99.99'
+  return `${name}_value`
+}
 
 const recipientPlaceholder = computed(() => {
   const params = templateParamNames.value
   if (params.length === 0) {
     return `+1234567890, John Doe\n+0987654321, Jane Smith\n+1122334455`
   }
-  const exampleValues = params.map((p, i) => {
-    if (/^\d+$/.test(p)) return `value${i + 1}`
-    if (p.toLowerCase().includes('name')) return 'John Doe'
-    if (p.toLowerCase().includes('order')) return 'ORD-123'
-    if (p.toLowerCase().includes('date')) return '2024-01-15'
-    if (p.toLowerCase().includes('amount') || p.toLowerCase().includes('price')) return '99.99'
-    return `${p}_value`
-  })
+  const exampleValues = params.map(exampleValue)
   return `+1234567890, John Doe, ${exampleValues.join(', ')}\n+0987654321, Jane Smith, ${exampleValues.join(', ')}`
 })
 
 const manualEntryFormat = computed(() => {
-  const params = templateParamNames.value
-  if (params.length === 0) return 'phone_number, name (optional)'
-  const paramLabels = params.map(p => /^\d+$/.test(p) ? `param${p}` : p)
-  return `phone_number, name, ${paramLabels.join(', ')}`
+  const labels: string[] = []
+  if (templateHeaderParamName.value) {
+    labels.push(`header (${templateHeaderParamName.value})`)
+  }
+  for (const p of templateBodyParamNames.value) {
+    labels.push(/^\d+$/.test(p) ? `param${p}` : p)
+  }
+  if (labels.length === 0) return 'phone_number, name (optional)'
+  return `phone_number, name, ${labels.join(', ')}`
 })
 
 // Status helpers
@@ -568,7 +596,7 @@ async function openAddRecipientsDialog() {
 }
 
 const manualInputValidation = computed(() => {
-  const params = templateParamNames.value
+  const expectedCount = templateParamNames.value.length
   const lines = recipientsInput.value.trim().split('\n').filter((line: string) => line.trim())
 
   if (lines.length === 0) {
@@ -576,6 +604,7 @@ const manualInputValidation = computed(() => {
   }
 
   const invalidLines: { lineNumber: number; reason: string }[] = []
+  const seenPhones = new Set<string>()
 
   for (let i = 0; i < lines.length; i++) {
     const parts = lines[i].split(',').map((p: string) => p.trim())
@@ -586,12 +615,29 @@ const manualInputValidation = computed(() => {
       continue
     }
 
-    // Params start from 3rd field (after phone + name)
-    const providedParams = parts.slice(2).filter((p: string) => p.length > 0).length
-    if (params.length > 0 && providedParams < params.length) {
+    if (seenPhones.has(phone)) {
+      invalidLines.push({ lineNumber: i + 1, reason: `Duplicate phone number (${phone})` })
+      continue
+    }
+    seenPhones.add(phone)
+
+    // Layout: phone, name, <header_value if any>, <body_val_1>, ..., <body_val_n>
+    // Name (parts[1]) is optional — accept blank — but the column count must
+    // match the template so values don't shift into the wrong slot.
+    const provided = parts.slice(2).filter((p: string) => p.length > 0).length
+    if (expectedCount > 0 && provided < expectedCount) {
       invalidLines.push({
         lineNumber: i + 1,
-        reason: `Missing template parameters (need ${params.length}, got ${providedParams})`
+        reason: `Need ${expectedCount} parameter value${expectedCount === 1 ? '' : 's'} after the name column, got ${provided}. Format: ${manualEntryFormat.value}`,
+      })
+      continue
+    }
+    if (expectedCount > 0 && parts.length - 2 > expectedCount) {
+      // Extra trailing columns usually mean an unquoted comma in a value —
+      // call it out instead of silently truncating.
+      invalidLines.push({
+        lineNumber: i + 1,
+        reason: `Too many columns: expected ${expectedCount + 2}, got ${parts.length}. If a value contains a comma, remove it.`,
       })
     }
   }
@@ -600,7 +646,7 @@ const manualInputValidation = computed(() => {
     isValid: invalidLines.length === 0 && lines.length > 0,
     totalLines: lines.length,
     validLines: lines.length - invalidLines.length,
-    invalidLines
+    invalidLines,
   }
 })
 
@@ -618,23 +664,39 @@ async function addRecipients() {
     return
   }
 
-  // Format: phone_number, name, param1, param2, ...
-  const paramNames = templateParamNames.value
+  // Layout: phone, name, <header value if any>, <body_val_1>, ..., <body_val_n>
+  // Header and body values are split into separate payload keys so a
+  // positional header {{1}} doesn't collide with body {{1}}.
+  const headerName = templateHeaderParamName.value
+  const bodyNames = templateBodyParamNames.value
   const recipientsList = lines.map(line => {
     const parts = line.split(',').map(p => p.trim())
-    const recipient: { phone_number: string; recipient_name?: string; template_params?: Record<string, any> } = {
+    const recipient: {
+      phone_number: string
+      recipient_name?: string
+      template_params?: Record<string, any>
+      header_params?: Record<string, any>
+    } = {
       phone_number: parts[0].replace(/[^\d+]/g, ''),
     }
-    // Second field is always recipient name
     if (parts[1]?.trim()) {
       recipient.recipient_name = parts[1].trim()
     }
-    // Template params start from third field
-    const params: Record<string, any> = {}
-    for (let i = 0; i < paramNames.length; i++) {
-      const val = parts[i + 2] // offset by 2 (phone + name)
+
+    let cursor = 2
+    if (headerName) {
+      const val = parts[cursor]
       if (val && val.length > 0) {
-        params[paramNames[i]] = val
+        recipient.header_params = { [headerName]: val }
+      }
+      cursor++
+    }
+
+    const params: Record<string, any> = {}
+    for (let i = 0; i < bodyNames.length; i++) {
+      const val = parts[cursor + i]
+      if (val && val.length > 0) {
+        params[bodyNames[i]] = val
       }
     }
     if (Object.keys(params).length > 0) {
@@ -666,6 +728,48 @@ function handleCSVFileSelect(event: Event) {
   }
 }
 
+// Header row of the sample CSV — mirrors what the parser accepts.
+const csvColumns = computed<string[]>(() => {
+  const cols = ['phone_number', 'name']
+  if (templateHeaderParamName.value) cols.push('header')
+  for (const p of templateBodyParamNames.value) cols.push(p)
+  return cols
+})
+
+const csvHeaderRow = computed(() => csvColumns.value.join(','))
+
+function downloadSampleCSV() {
+  const cols = csvColumns.value
+  const exampleRow = cols.map((c, idx) => {
+    if (idx === 0) return '+1234567890'
+    if (c === 'name') return 'John Doe'
+    if (c === 'header') return templateHeaderParamName.value
+      ? exampleValue(templateHeaderParamName.value, 0)
+      : 'Summer'
+    return exampleValue(c, idx)
+  })
+  const secondRow = cols.map((c, idx) => {
+    if (idx === 0) return '+0987654321'
+    if (c === 'name') return 'Jane Smith'
+    if (c === 'header') return templateHeaderParamName.value
+      ? exampleValue(templateHeaderParamName.value, 1)
+      : 'Winter'
+    return exampleValue(c, idx)
+  })
+  const csv = `${csvHeaderRow.value}\n${exampleRow.join(',')}\n${secondRow.join(',')}\n`
+
+  const filename = `recipients-${campaign.value?.name?.toLowerCase().replace(/\s+/g, '-') || 'sample'}.csv`
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
 async function addRecipientsFromCSV() {
   if (!campaign.value || !csvFile.value) return
 
@@ -695,31 +799,55 @@ async function addRecipientsFromCSV() {
       h === 'name' || h === 'recipient_name' || h === 'recipientname' || h === 'customer_name'
     )
 
-    const paramNames = templateParamNames.value
-    const recipientsList: { phone_number: string; recipient_name?: string; template_params?: Record<string, any> }[] = []
+    // Header parameter column — accept the reserved name 'header', or the
+    // variable's name itself when unambiguous (named templates only).
+    const headerName = templateHeaderParamName.value
+    let headerColIdx = -1
+    if (headerName) {
+      headerColIdx = headers.findIndex(h => h === 'header')
+      if (headerColIdx === -1 && !/^\d+$/.test(headerName)) {
+        headerColIdx = headers.findIndex(h => h === headerName.toLowerCase())
+      }
+    }
+
+    const bodyNames = templateBodyParamNames.value
+    const recipientsList: {
+      phone_number: string
+      recipient_name?: string
+      template_params?: Record<string, any>
+      header_params?: Record<string, any>
+    }[] = []
 
     for (let i = 1; i < lines.length; i++) {
       const values = lines[i].split(',').map(v => v.trim())
       const phone = values[phoneIndex]?.replace(/[^\d+]/g, '')
       if (!phone) continue
 
-      const recipient: { phone_number: string; recipient_name?: string; template_params?: Record<string, any> } = {
-        phone_number: phone,
-      }
+      const recipient: {
+        phone_number: string
+        recipient_name?: string
+        template_params?: Record<string, any>
+        header_params?: Record<string, any>
+      } = { phone_number: phone }
 
-      // Extract name if column exists
       if (nameIndex !== -1 && values[nameIndex]?.trim()) {
         recipient.recipient_name = values[nameIndex].trim()
       }
 
-      // Map remaining columns to template params by name match or position
-      if (paramNames.length > 0) {
+      const usedIndices = new Set<number>([phoneIndex])
+      if (nameIndex !== -1) usedIndices.add(nameIndex)
+
+      if (headerName && headerColIdx !== -1) {
+        const v = values[headerColIdx]?.trim()
+        if (v) recipient.header_params = { [headerName]: v }
+        usedIndices.add(headerColIdx)
+      }
+
+      if (bodyNames.length > 0) {
         const params: Record<string, any> = {}
-        const usedIndices = new Set<number>([phoneIndex])
-        if (nameIndex !== -1) usedIndices.add(nameIndex)
 
         // Try name matching first
-        for (const paramName of paramNames) {
+        for (const paramName of bodyNames) {
           const colIdx = headers.findIndex((h, idx) =>
             !usedIndices.has(idx) && h === paramName.toLowerCase()
           )
@@ -730,7 +858,7 @@ async function addRecipientsFromCSV() {
         }
 
         // Positional fallback for unmapped params
-        const unmapped = paramNames.filter(p => !(p in params))
+        const unmapped = bodyNames.filter(p => !(p in params))
         const remainingCols = headers.map((_, idx) => idx).filter(idx => !usedIndices.has(idx))
         for (let j = 0; j < unmapped.length && j < remainingCols.length; j++) {
           params[unmapped[j]] = values[remainingCols[j]]?.trim() || ''
@@ -1270,8 +1398,19 @@ onUnmounted(() => {
         <TabsContent value="csv" class="space-y-3 mt-3">
           <div class="space-y-1.5">
             <Label class="text-xs text-muted-foreground">
-              {{ $t('campaigns.csvFormatHint', 'CSV must include a phone_number (or phone, mobile, number) column. Optionally include a name (or recipient_name) column, followed by template parameter columns.') }}
+              {{ $t('campaigns.csvFormatHint', 'CSV must include a phone_number (or phone, mobile, number) column. Optionally include a name column. For templates with a TEXT header variable, add a "header" column. Then one column per body parameter.') }}
             </Label>
+            <div class="flex items-center justify-between text-xs">
+              <code class="bg-muted px-1.5 py-0.5 rounded">{{ csvHeaderRow }}</code>
+              <button
+                type="button"
+                class="text-primary hover:underline inline-flex items-center gap-1"
+                @click="downloadSampleCSV"
+              >
+                <Download class="h-3.5 w-3.5" />
+                {{ $t('campaigns.downloadSampleCsv', 'Download sample CSV') }}
+              </button>
+            </div>
             <div
               class="border-2 border-dashed rounded-lg p-6 text-center cursor-pointer hover:border-primary/50 transition-colors"
               @click="($refs.csvInput as HTMLInputElement)?.click()"

--- a/frontend/src/views/settings/TemplateDetailView.vue
+++ b/frontend/src/views/settings/TemplateDetailView.vue
@@ -87,6 +87,7 @@ const bodyHint = 'Use {{1}}, {{2}} for positional or {{name}}, {{email}} for nam
 const mixedVariablesHint = 'Cannot mix positional ({{1}}, {{2}}) and named ({{name}}) variables. Use one type only.'
 const duplicateVariablesHint = 'Duplicate variables found. Each variable should appear only once in the template.'
 const variablePositionHint = 'Variables cannot be at the very start or end of the template body.'
+const headerTooManyVariablesHint = 'Meta allows at most one variable in a TEXT header.'
 
 const templateId = computed(() => route.params.id as string)
 const isNew = computed(() => templateId.value === 'new')
@@ -230,6 +231,13 @@ const hasVariableAtEdge = computed(() => {
   const body = form.value.body_content.trim()
   if (!body) return false
   return /^\{\{[^}]+\}\}/.test(body) || /\{\{[^}]+\}\}$/.test(body)
+})
+
+// Meta allows at most one variable in a TEXT header. Count unique names so
+// {{name}} … {{name}} (same variable referenced twice) still passes.
+const hasTooManyHeaderVariables = computed(() => {
+  if (form.value.header_type !== 'TEXT') return false
+  return new Set(headerVariables.value).size > 1
 })
 
 // Build sample_values array from form inputs
@@ -465,6 +473,10 @@ async function save() {
     }
     if (hasVariableAtEdge.value) {
       toast.error(t('templates.variableAtEdge', 'Variables cannot be at the very start or end of the template body.'))
+      return
+    }
+    if (hasTooManyHeaderVariables.value) {
+      toast.error(t('templates.headerTooManyVariables', headerTooManyVariablesHint))
       return
     }
   }
@@ -760,6 +772,7 @@ onMounted(async () => {
         <div v-if="form.header_type === 'TEXT'" class="space-y-1.5">
           <Label class="text-xs" for="header-content">{{ $t('templates.headerContent', 'Header Content') }}</Label>
           <Input id="header-content" v-model="form.header_content" :disabled="!canWrite || !isEditable" />
+          <p v-if="hasTooManyHeaderVariables" class="text-xs text-destructive" v-text="headerTooManyVariablesHint" />
         </div>
 
         <!-- Header Media Upload for IMAGE/VIDEO/DOCUMENT -->

--- a/internal/handlers/campaigns.go
+++ b/internal/handlers/campaigns.go
@@ -60,6 +60,10 @@ type RecipientRequest struct {
 	PhoneNumber    string         `json:"phone_number" validate:"required"`
 	RecipientName  string         `json:"recipient_name"`
 	TemplateParams map[string]any `json:"template_params"`
+	// HeaderParams carries the value for a TEXT-header variable (max 1 per
+	// Meta), keyed by the variable's name. Kept separate from TemplateParams
+	// so a positional header {{1}} doesn't collide with body {{1}}.
+	HeaderParams map[string]any `json:"header_params"`
 }
 
 // ListCampaigns implements campaign listing
@@ -465,6 +469,7 @@ func (a *App) StartCampaign(r *fastglue.Request) error {
 			PhoneNumber:    recipient.PhoneNumber,
 			RecipientName:  recipient.RecipientName,
 			TemplateParams: recipient.TemplateParams,
+			HeaderParams:   recipient.HeaderParams,
 		}
 	}
 
@@ -626,6 +631,7 @@ func (a *App) RetryFailed(r *fastglue.Request) error {
 			PhoneNumber:    recipient.PhoneNumber,
 			RecipientName:  recipient.RecipientName,
 			TemplateParams: recipient.TemplateParams,
+			HeaderParams:   recipient.HeaderParams,
 		}
 	}
 
@@ -679,6 +685,7 @@ func (a *App) ImportRecipients(r *fastglue.Request) error {
 			PhoneNumber:    rec.PhoneNumber,
 			RecipientName:  rec.RecipientName,
 			TemplateParams: models.JSONB(rec.TemplateParams),
+			HeaderParams:   models.JSONB(rec.HeaderParams),
 			Status:         models.MessageStatusPending,
 		}
 	}

--- a/internal/handlers/campaigns_test.go
+++ b/internal/handlers/campaigns_test.go
@@ -719,6 +719,47 @@ func TestApp_ImportRecipients_WithTemplateParams(t *testing.T) {
 	assert.NotNil(t, recipient.TemplateParams)
 }
 
+// header_params must round-trip into the BulkMessageRecipient row so the
+// worker can hand it to BuildTemplateComponents at send time. Without this,
+// a positional {{1}} header collides with a positional {{1}} body parameter
+// in the flat TemplateParams map (per-component indexing on Meta side).
+func TestApp_ImportRecipients_WithHeaderParams(t *testing.T) {
+	mockQueue := testutil.NewMockQueue()
+	app := newTestApp(t, withQueue(mockQueue))
+	org := testutil.CreateTestOrganization(t, app.DB)
+	user := testutil.CreateTestUser(t, app.DB, org.ID, testutil.WithEmail(testutil.UniqueEmail("import-header-params")), testutil.WithPassword("password"))
+	account := testutil.CreateTestWhatsAppAccountWith(t, app.DB, org.ID, testutil.WithAccountName("import-header-account"))
+	template := testutil.CreateTestTemplate(t, app.DB, org.ID, account.Name)
+	campaign := createTestCampaign(t, app, org.ID, template.ID, user.ID, account.Name, models.CampaignStatusDraft)
+
+	req := testutil.NewJSONRequest(t, map[string]any{
+		"recipients": []map[string]any{
+			{
+				"phone_number":    "+1234567890",
+				"recipient_name":  "John Doe",
+				"template_params": map[string]any{"1": "John", "2": "SAVE20"},
+				"header_params":   map[string]any{"1": "Summer"},
+			},
+		},
+	})
+	testutil.SetAuthContext(req, org.ID, user.ID)
+	testutil.SetPathParam(req, "id", campaign.ID.String())
+
+	err := app.ImportRecipients(req)
+	require.NoError(t, err)
+	assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+	var recipient models.BulkMessageRecipient
+	require.NoError(t, app.DB.Where("campaign_id = ?", campaign.ID).First(&recipient).Error)
+	require.NotNil(t, recipient.HeaderParams)
+	assert.Equal(t, "Summer", recipient.HeaderParams["1"])
+	// TemplateParams stays separate from HeaderParams — same positional key
+	// "1" must not collide.
+	require.NotNil(t, recipient.TemplateParams)
+	assert.Equal(t, "John", recipient.TemplateParams["1"])
+	assert.Equal(t, "SAVE20", recipient.TemplateParams["2"])
+}
+
 func TestApp_ImportRecipients_NotDraft(t *testing.T) {
 	mockQueue := testutil.NewMockQueue()
 	app := newTestApp(t, withQueue(mockQueue))

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -59,6 +59,7 @@ type OutgoingMessageRequest struct {
 	// Template messages
 	Template            *models.Template
 	BodyParams          map[string]string // Parameter name -> value (supports both named and positional)
+	HeaderParams        map[string]string // Header-only param values; falls back to BodyParams if empty (used for TEXT headers with a {{var}})
 	HeaderMediaID       string            // WhatsApp media ID for template header (IMAGE/VIDEO/DOCUMENT)
 	HeaderMediaFilename string            // Filename — required by Meta for DOCUMENT headers
 	ButtonURLParams     map[string]string // Button index (as string) -> dynamic URL param value
@@ -202,7 +203,15 @@ func (a *App) SendOutgoingMessage(ctx context.Context, req OutgoingMessageReques
 			if req.Template == nil {
 				return "", fmt.Errorf("template is required for template messages")
 			}
-			components := whatsapp.BuildTemplateComponents(req.BodyParams, req.Template.HeaderType, req.HeaderMediaID, req.HeaderMediaFilename)
+			components, err := whatsapp.BuildTemplateComponents(
+				req.BodyParams,
+				req.Template.HeaderType, req.Template.HeaderContent,
+				req.HeaderParams,
+				req.HeaderMediaID, req.HeaderMediaFilename,
+			)
+			if err != nil {
+				return "", fmt.Errorf("failed to build template components: %w", err)
+			}
 			// Add auto-generated button components (Flow needs flow_token)
 			flowComponents := whatsapp.AutoButtonComponents(req.Template.Buttons)
 			components = append(components, flowComponents...)
@@ -630,6 +639,12 @@ type SendTemplateMessageRequest struct {
 	HeaderMediaID       string `json:"header_media_id"`       // Already-uploaded WhatsApp media ID
 	HeaderMediaURL      string `json:"header_media_url"`      // URL to download media from
 	HeaderMediaFilename string `json:"header_media_filename"` // Filename — required by Meta for DOCUMENT headers (#351)
+
+	// Header text parameter values for TEXT headers that contain a {{var}}.
+	// Meta only permits one variable in a TEXT header. Keyed by the variable's
+	// name (named templates) or by "1" (positional). Optional — if absent, the
+	// value is looked up in TemplateParams as a fallback.
+	HeaderParams map[string]string `json:"header_params"`
 }
 
 // SendTemplateMessage sends a template message to a contact or phone number.
@@ -677,6 +692,12 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		if v := form.Value["button_params"]; len(v) > 0 && v[0] != "" {
 			if err := json.Unmarshal([]byte(v[0]), &req.ButtonParams); err != nil {
 				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid button_params JSON", nil, "")
+			}
+		}
+		// Parse header_params from JSON string
+		if v := form.Value["header_params"]; len(v) > 0 && v[0] != "" {
+			if err := json.Unmarshal([]byte(v[0]), &req.HeaderParams); err != nil {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid header_params JSON", nil, "")
 			}
 		}
 		// Read header media file
@@ -807,6 +828,25 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		}
 	}
 
+	// Validate the header variable (TEXT headers only). Meta allows at most one
+	// variable in a TEXT header — surface a clean 400 if it's missing.
+	if template.HeaderType == "TEXT" {
+		headerNames := templateutil.ExtParamNames(template.HeaderContent)
+		if len(headerNames) > 1 {
+			return r.SendErrorEnvelope(fasthttp.StatusBadRequest,
+				fmt.Sprintf("Template header text contains %d variables; Meta allows at most 1", len(headerNames)),
+				nil, "")
+		}
+		if len(headerNames) == 1 {
+			name := headerNames[0]
+			if req.HeaderParams[name] == "" && req.TemplateParams[name] == "" {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest,
+					fmt.Sprintf("Missing header parameter %q. Pass it in header_params or template_params.", name),
+					nil, "")
+			}
+		}
+	}
+
 	// Resolve header media for templates with IMAGE/VIDEO/DOCUMENT headers.
 	// Priority: header_media_id > header_media_url > multipart header_file
 	var headerMediaID string
@@ -905,6 +945,7 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		Type:                models.MessageTypeTemplate,
 		Template:            &template,
 		BodyParams:          req.TemplateParams,
+		HeaderParams:        req.HeaderParams,
 		HeaderMediaID:       headerMediaID,
 		HeaderMediaFilename: headerMediaFilename,
 		MediaURL:            headerLocalPath,

--- a/internal/handlers/send_template_test.go
+++ b/internal/handlers/send_template_test.go
@@ -594,6 +594,158 @@ func TestApp_SendTemplateMessage(t *testing.T) {
 		assert.Equal(t, "button", dbMsg.InteractiveData["type"])
 	})
 
+	// --- TEXT header parameter (header_params field) ---
+
+	// createTestTemplateWithHeader builds an approved template with a TEXT
+	// header that has a {{var}} (named for clarity; positional is exercised
+	// separately by the unit tests on BuildTemplateComponents).
+	createTestTemplateWithHeader := func(t *testing.T, app *handlers.App, orgID uuid.UUID, accountName string) *models.Template {
+		t.Helper()
+		tpl := &models.Template{
+			BaseModel:       models.BaseModel{ID: uuid.New()},
+			OrganizationID:  orgID,
+			WhatsAppAccount: accountName,
+			Name:            "seasonal_" + uuid.New().String()[:8],
+			DisplayName:     "Seasonal Promo",
+			MetaTemplateID:  "meta-" + uuid.New().String()[:8],
+			Category:        "MARKETING",
+			Language:        "en",
+			Status:          string(models.TemplateStatusApproved),
+			HeaderType:      "TEXT",
+			HeaderContent:   "Our {{season}} sale",
+			BodyContent:     "Hi {{name}}, use code {{code}}.",
+		}
+		require.NoError(t, app.DB.Create(tpl).Error)
+		return tpl
+	}
+
+	t.Run("header_params forwards a TEXT header value to Meta", func(t *testing.T) {
+		t.Parallel()
+		mockServer := newMockWhatsAppServer()
+		defer mockServer.close()
+
+		app := newMsgTestApp(t, mockServer)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		adminRole := testutil.CreateAdminRole(t, app.DB, org.ID)
+		user := testutil.CreateTestUser(t, app.DB, org.ID, testutil.WithRoleID(&adminRole.ID))
+		account := createTestAccount(t, app, org.ID)
+		contact := testutil.CreateTestContactWith(t, app.DB, org.ID, testutil.WithContactAccount(account.Name))
+		tpl := createTestTemplateWithHeader(t, app, org.ID, account.Name)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"contact_id":    contact.ID.String(),
+			"template_name": tpl.Name,
+			"header_params": map[string]string{"season": "Summer"},
+			"template_params": map[string]string{
+				"name": "Alice",
+				"code": "SAVE20",
+			},
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		err := app.SendTemplateMessage(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+		app.WaitForBackgroundTasks()
+
+		require.Len(t, mockServer.sentMessages, 1)
+		tplPayload := mockServer.sentMessages[0]["template"].(map[string]any)
+		components := tplPayload["components"].([]any)
+
+		// Find the header component and assert it carries the supplied value.
+		var headerComp map[string]any
+		for _, c := range components {
+			if m := c.(map[string]any); m["type"] == "header" {
+				headerComp = m
+				break
+			}
+		}
+		require.NotNil(t, headerComp, "expected a header component in the Meta payload")
+		params := headerComp["parameters"].([]any)
+		require.Len(t, params, 1)
+		p0 := params[0].(map[string]any)
+		assert.Equal(t, "text", p0["type"])
+		assert.Equal(t, "Summer", p0["text"])
+		assert.Equal(t, "season", p0["parameter_name"], "named templates include parameter_name")
+	})
+
+	t.Run("header_params falls back to template_params lookup", func(t *testing.T) {
+		t.Parallel()
+		mockServer := newMockWhatsAppServer()
+		defer mockServer.close()
+
+		app := newMsgTestApp(t, mockServer)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		adminRole := testutil.CreateAdminRole(t, app.DB, org.ID)
+		user := testutil.CreateTestUser(t, app.DB, org.ID, testutil.WithRoleID(&adminRole.ID))
+		account := createTestAccount(t, app, org.ID)
+		contact := testutil.CreateTestContactWith(t, app.DB, org.ID, testutil.WithContactAccount(account.Name))
+		tpl := createTestTemplateWithHeader(t, app, org.ID, account.Name)
+
+		// header_params omitted entirely — value supplied in template_params
+		// under the same variable name. Convenient for named templates where
+		// the header variable name is unique.
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"contact_id":    contact.ID.String(),
+			"template_name": tpl.Name,
+			"template_params": map[string]string{
+				"season": "Winter",
+				"name":   "Bob",
+				"code":   "SAVE15",
+			},
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		err := app.SendTemplateMessage(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+		app.WaitForBackgroundTasks()
+
+		require.Len(t, mockServer.sentMessages, 1)
+		tplPayload := mockServer.sentMessages[0]["template"].(map[string]any)
+		components := tplPayload["components"].([]any)
+
+		var headerComp map[string]any
+		for _, c := range components {
+			if m := c.(map[string]any); m["type"] == "header" {
+				headerComp = m
+				break
+			}
+		}
+		require.NotNil(t, headerComp)
+		params := headerComp["parameters"].([]any)
+		assert.Equal(t, "Winter", params[0].(map[string]any)["text"])
+	})
+
+	t.Run("missing header value 400s before reaching Meta", func(t *testing.T) {
+		t.Parallel()
+		// No mock — request should fail validation before any send.
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		adminRole := testutil.CreateAdminRole(t, app.DB, org.ID)
+		user := testutil.CreateTestUser(t, app.DB, org.ID, testutil.WithRoleID(&adminRole.ID))
+		account := testutil.CreateTestWhatsAppAccount(t, app.DB, org.ID)
+		contact := testutil.CreateTestContactWith(t, app.DB, org.ID, testutil.WithContactAccount(account.Name))
+		tpl := createTestTemplateWithHeader(t, app, org.ID, account.Name)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"contact_id":    contact.ID.String(),
+			"template_name": tpl.Name,
+			// header value missing in both maps
+			"template_params": map[string]string{
+				"name": "Alice",
+				"code": "SAVE20",
+			},
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		err := app.SendTemplateMessage(req)
+		require.NoError(t, err)
+		testutil.AssertErrorResponse(t, req, fasthttp.StatusBadRequest, "header parameter")
+	})
+
 	t.Run("template without buttons has no interactive_data", func(t *testing.T) {
 		t.Parallel()
 		mockServer := newMockWhatsAppServer()

--- a/internal/handlers/templates.go
+++ b/internal/handlers/templates.go
@@ -143,6 +143,9 @@ func (a *App) CreateTemplate(r *fastglue.Request) error {
 			if err := templateutil.ValidateNoMixedParams(req.HeaderContent); err != nil {
 				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
 			}
+			if err := templateutil.ValidateHeaderParamCount(req.HeaderContent); err != nil {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
+			}
 		}
 	}
 
@@ -267,6 +270,9 @@ func (a *App) UpdateTemplate(r *fastglue.Request) error {
 		}
 		if req.HeaderType == "TEXT" && req.HeaderContent != "" {
 			if err := templateutil.ValidateNoMixedParams(req.HeaderContent); err != nil {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
+			}
+			if err := templateutil.ValidateHeaderParamCount(req.HeaderContent); err != nil {
 				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, "")
 			}
 		}

--- a/internal/handlers/templates_test.go
+++ b/internal/handlers/templates_test.go
@@ -513,6 +513,72 @@ func TestApp_CreateTemplate_InvalidJSON(t *testing.T) {
 	testutil.AssertErrorResponse(t, req, fasthttp.StatusBadRequest, "Invalid request body")
 }
 
+// Meta restricts TEXT headers to one variable. The handler must 400 before
+// hitting Meta — see internal/templateutil/ValidateHeaderParamCount.
+func TestApp_CreateTemplate_RejectsTooManyHeaderVariables(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t)
+	org := testutil.CreateTestOrganization(t, app.DB)
+	user := testutil.CreateTestUser(t, app.DB, org.ID)
+	account := testutil.CreateTestWhatsAppAccount(t, app.DB, org.ID)
+
+	body := map[string]any{
+		"whatsapp_account": account.Name,
+		"name":             "two_header_vars",
+		"language":         "en",
+		"category":         "MARKETING",
+		"body_content":     "Hi {{1}}",
+		"header_type":      "TEXT",
+		"header_content":   "Order {{1}} for {{2}}",
+	}
+
+	req := testutil.NewJSONRequest(t, body)
+	testutil.SetAuthContext(req, org.ID, user.ID)
+
+	err := app.CreateTemplate(req)
+	require.NoError(t, err)
+	testutil.AssertErrorResponse(t, req, fasthttp.StatusBadRequest, "at most one variable")
+}
+
+func TestApp_UpdateTemplate_RejectsTooManyHeaderVariables(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t)
+	org := testutil.CreateTestOrganization(t, app.DB)
+	user := testutil.CreateTestUser(t, app.DB, org.ID)
+	account := testutil.CreateTestWhatsAppAccount(t, app.DB, org.ID)
+
+	// Seed a valid template, then try to update its header to >1 var.
+	tpl := &models.Template{
+		BaseModel:       models.BaseModel{ID: uuid.New()},
+		OrganizationID:  org.ID,
+		WhatsAppAccount: account.Name,
+		Name:            "single_var_header",
+		DisplayName:     "Single Var Header",
+		Language:        "en",
+		Category:        "MARKETING",
+		Status:          "DRAFT",
+		HeaderType:      "TEXT",
+		HeaderContent:   "Hi {{1}}",
+		BodyContent:     "Hello world",
+	}
+	require.NoError(t, app.DB.Create(tpl).Error)
+
+	body := map[string]any{
+		"header_type":    "TEXT",
+		"header_content": "Hi {{1}} and {{2}}",
+		"body_content":   "Hello world",
+	}
+	req := testutil.NewJSONRequest(t, body)
+	testutil.SetAuthContext(req, org.ID, user.ID)
+	testutil.SetPathParam(req, "id", tpl.ID.String())
+
+	err := app.UpdateTemplate(req)
+	require.NoError(t, err)
+	testutil.AssertErrorResponse(t, req, fasthttp.StatusBadRequest, "at most one variable")
+}
+
 func TestApp_CreateTemplate_NameNormalization(t *testing.T) {
 	t.Parallel()
 

--- a/internal/models/bulk.go
+++ b/internal/models/bulk.go
@@ -48,6 +48,11 @@ type BulkMessageRecipient struct {
 	PhoneNumber       string        `gorm:"size:50;not null" json:"phone_number"`
 	RecipientName     string        `gorm:"size:255" json:"recipient_name"`
 	TemplateParams    JSONB         `gorm:"type:jsonb;default:'{}'" json:"template_params"`
+	// Header parameter values for TEXT-header templates with a {{var}}. Meta
+	// indexes positional vars per component, so header {{1}} and body {{1}}
+	// are separate values — keeping them in a dedicated map avoids that
+	// collision. Empty when the template has no header variable.
+	HeaderParams      JSONB         `gorm:"type:jsonb;default:'{}'" json:"header_params"`
 	Status            MessageStatus `gorm:"size:20;default:'pending'" json:"status"` // pending, sent, delivered, read, failed
 	WhatsAppMessageID string        `gorm:"column:whats_app_message_id;size:100;index" json:"whatsapp_message_id,omitempty"`
 	MessageID         *uuid.UUID    `gorm:"type:uuid" json:"message_id,omitempty"`

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -24,7 +24,11 @@ type RecipientJob struct {
 	PhoneNumber    string       `json:"phone_number"`
 	RecipientName  string       `json:"recipient_name"`
 	TemplateParams models.JSONB `json:"template_params"`
-	EnqueuedAt     time.Time    `json:"enqueued_at"`
+	// HeaderParams holds the TEXT-header variable's value (Meta restricts
+	// these headers to one variable). Sent separately from TemplateParams to
+	// avoid positional-key collisions between header and body.
+	HeaderParams models.JSONB `json:"header_params"`
+	EnqueuedAt   time.Time    `json:"enqueued_at"`
 }
 
 // Queue defines the interface for job queue operations

--- a/internal/templateutil/templateutil.go
+++ b/internal/templateutil/templateutil.go
@@ -19,6 +19,18 @@ func isPositionalParam(name string) bool {
 	return len(name) > 0
 }
 
+// ValidateHeaderParamCount enforces Meta's restriction that a TEXT header may
+// contain at most one variable ({{...}}); duplicate references to the same
+// variable name still count as one. Callers should only invoke this for
+// HeaderType == "TEXT".
+func ValidateHeaderParamCount(content string) error {
+	names := ExtParamNames(content)
+	if len(names) > 1 {
+		return fmt.Errorf("header text may contain at most one variable; found %d", len(names))
+	}
+	return nil
+}
+
 // ValidateNoMixedParams checks that content does not mix positional ({{1}}) and
 // named ({{name}}) parameters. Returns an error if both types are present.
 func ValidateNoMixedParams(content string) error {

--- a/internal/templateutil/templateutil_test.go
+++ b/internal/templateutil/templateutil_test.go
@@ -176,3 +176,33 @@ func TestValidateNoMixedParams_Empty(t *testing.T) {
 	err := ValidateNoMixedParams("")
 	assert.NoError(t, err)
 }
+
+func TestValidateHeaderParamCount_None(t *testing.T) {
+	assert.NoError(t, ValidateHeaderParamCount("Welcome to Whatomate"))
+}
+
+func TestValidateHeaderParamCount_OnePositional(t *testing.T) {
+	assert.NoError(t, ValidateHeaderParamCount("Order {{1}} update"))
+}
+
+func TestValidateHeaderParamCount_OneNamed(t *testing.T) {
+	assert.NoError(t, ValidateHeaderParamCount("Hi {{customer_name}}!"))
+}
+
+func TestValidateHeaderParamCount_OneNameRepeated(t *testing.T) {
+	// Same variable referenced twice still counts as a single variable.
+	assert.NoError(t, ValidateHeaderParamCount("{{name}}, hi {{name}}"))
+}
+
+func TestValidateHeaderParamCount_Two(t *testing.T) {
+	err := ValidateHeaderParamCount("Order {{1}} for {{2}}")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at most one variable")
+	assert.Contains(t, err.Error(), "found 2")
+}
+
+func TestValidateHeaderParamCount_TwoNamed(t *testing.T) {
+	err := ValidateHeaderParamCount("{{a}} and {{b}}")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at most one variable")
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -112,6 +112,7 @@ func (w *Worker) HandleRecipientJob(ctx context.Context, job *queue.RecipientJob
 		PhoneNumber:    job.PhoneNumber,
 		RecipientName:  job.RecipientName,
 		TemplateParams: job.TemplateParams,
+		HeaderParams:   job.HeaderParams,
 	}
 
 	// Send template message
@@ -266,8 +267,32 @@ func (w *Worker) sendTemplateMessage(ctx context.Context, account *models.WhatsA
 		}
 	}
 
-	// Use the shared component builder (same as chat template sending)
-	components := whatsapp.BuildTemplateComponents(bodyParams, template.HeaderType, campaignHeaderMediaID, campaignHeaderMediaFilename)
+	// Resolve the header text parameter (if any) into its own map. Prefer
+	// recipient.HeaderParams (new path, populated by AddRecipients) and fall
+	// back to a TemplateParams lookup for legacy recipient rows persisted
+	// before HeaderParams existed.
+	var headerParams map[string]string
+	if template.HeaderType == "TEXT" {
+		if hNames := templateutil.ExtParamNames(template.HeaderContent); len(hNames) == 1 {
+			name := hNames[0]
+			if raw, ok := recipient.HeaderParams[name]; ok {
+				headerParams = map[string]string{name: fmt.Sprintf("%v", raw)}
+			} else if raw, ok := recipient.TemplateParams[name]; ok {
+				headerParams = map[string]string{name: fmt.Sprintf("%v", raw)}
+			}
+		}
+	}
+
+	// Use the shared component builder (same as chat template sending).
+	components, err := whatsapp.BuildTemplateComponents(
+		bodyParams,
+		template.HeaderType, template.HeaderContent,
+		headerParams,
+		campaignHeaderMediaID, campaignHeaderMediaFilename,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to build template components: %w", err)
+	}
 	// Add auto-generated button components (Flow needs flow_token)
 	flowComponents := whatsapp.AutoButtonComponents(template.Buttons)
 	components = append(components, flowComponents...)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -512,6 +512,107 @@ func TestWorker_sendTemplateMessage_BuildsComponents(t *testing.T) {
 	assert.Equal(t, "World", params[1].(map[string]any)["text"])
 }
 
+// When the recipient has explicit HeaderParams, the worker must use them
+// for the TEXT-header component instead of falling back to TemplateParams.
+// This protects positional templates where header {{1}} and body {{1}}
+// would otherwise share the same value.
+func TestWorker_sendTemplateMessage_HeaderParamsTakePrecedence(t *testing.T) {
+	w := testWorker(t)
+
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(map[string]any{
+			"messages": []map[string]any{{"id": "wamid.hp-explicit"}},
+		})
+	}))
+	defer server.Close()
+	w.WhatsApp = whatsapp.NewWithBaseURL(w.Log, server.URL)
+
+	account := &models.WhatsAppAccount{PhoneID: "123", BusinessID: "456", AccessToken: "token", APIVersion: "v21.0"}
+	template := &models.Template{
+		Name:          "tpl_explicit_hp",
+		Language:      "en",
+		HeaderType:    "TEXT",
+		HeaderContent: "Code {{1}}",
+		BodyContent:   "Use {{1}} to redeem",
+	}
+	recipient := &models.BulkMessageRecipient{
+		PhoneNumber:    "1234567890",
+		HeaderParams:   models.JSONB{"1": "HEADER-VAL"},
+		TemplateParams: models.JSONB{"1": "BODY-VAL"},
+	}
+
+	_, err := w.sendTemplateMessage(context.Background(), account, template, recipient, "", "")
+	require.NoError(t, err)
+
+	components := capturedBody["template"].(map[string]any)["components"].([]any)
+	var headerComp, bodyComp map[string]any
+	for _, c := range components {
+		m := c.(map[string]any)
+		switch m["type"] {
+		case "header":
+			headerComp = m
+		case "body":
+			bodyComp = m
+		}
+	}
+	require.NotNil(t, headerComp)
+	require.NotNil(t, bodyComp)
+	assert.Equal(t, "HEADER-VAL", headerComp["parameters"].([]any)[0].(map[string]any)["text"])
+	assert.Equal(t, "BODY-VAL", bodyComp["parameters"].([]any)[0].(map[string]any)["text"],
+		"body {{1}} must keep its own value when HeaderParams is set")
+}
+
+// Legacy recipient rows persisted before HeaderParams existed only have
+// TemplateParams. For NAMED templates the var name is unique across
+// components, so the worker falls back to TemplateParams[name].
+func TestWorker_sendTemplateMessage_HeaderParamsFallbackToTemplateParams(t *testing.T) {
+	w := testWorker(t)
+
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(map[string]any{
+			"messages": []map[string]any{{"id": "wamid.hp-fallback"}},
+		})
+	}))
+	defer server.Close()
+	w.WhatsApp = whatsapp.NewWithBaseURL(w.Log, server.URL)
+
+	account := &models.WhatsAppAccount{PhoneID: "123", BusinessID: "456", AccessToken: "token", APIVersion: "v21.0"}
+	template := &models.Template{
+		Name:          "tpl_fallback_hp",
+		Language:      "en",
+		HeaderType:    "TEXT",
+		HeaderContent: "Our {{season}} sale",
+		BodyContent:   "Hi {{name}}",
+	}
+	recipient := &models.BulkMessageRecipient{
+		PhoneNumber: "1234567890",
+		// No HeaderParams — legacy row. season lives in TemplateParams.
+		TemplateParams: models.JSONB{"season": "Summer", "name": "Alex"},
+	}
+
+	_, err := w.sendTemplateMessage(context.Background(), account, template, recipient, "", "")
+	require.NoError(t, err)
+
+	components := capturedBody["template"].(map[string]any)["components"].([]any)
+	var headerComp map[string]any
+	for _, c := range components {
+		if m := c.(map[string]any); m["type"] == "header" {
+			headerComp = m
+			break
+		}
+	}
+	require.NotNil(t, headerComp, "header component must still be emitted via fallback")
+	params := headerComp["parameters"].([]any)[0].(map[string]any)
+	assert.Equal(t, "Summer", params["text"])
+	assert.Equal(t, "season", params["parameter_name"])
+}
+
 func TestWorker_sendTemplateMessage_NoParams(t *testing.T) {
 	w := testWorker(t)
 

--- a/pkg/whatsapp/message.go
+++ b/pkg/whatsapp/message.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/shridarpatil/whatomate/internal/templateutil"
 )
 
 // SendTextMessage sends a text message to a recipient with optional reply context
@@ -379,30 +381,95 @@ func BodyParamsToComponents(bodyParams map[string]string) []map[string]any {
 	}
 }
 
+// HeaderTextParamsComponent builds the header component for a TEXT header that
+// contains one variable. Meta restricts TEXT headers to at most one variable,
+// so this returns an error if `headerContent` has more.
+//
+// `params` is the caller's value map (e.g. {"order_id": "ORD-1"} or {"1": "ORD-1"}).
+// `fallback` is consulted if the value isn't found in `params` — useful for
+// callers that share one flat map across header + body.
+//
+// Returns (nil, nil) when the header has no variable.
+func HeaderTextParamsComponent(headerContent string, params, fallback map[string]string) (map[string]any, error) {
+	if !strings.Contains(headerContent, "{{") {
+		return nil, nil
+	}
+	names := templateutil.ExtParamNames(headerContent)
+	if len(names) == 0 {
+		return nil, nil
+	}
+	if len(names) > 1 {
+		return nil, fmt.Errorf("header text may contain at most one variable; found %d", len(names))
+	}
+
+	name := names[0]
+	value := params[name]
+	if value == "" {
+		value = fallback[name]
+	}
+
+	param := map[string]any{
+		"type": "text",
+		"text": value,
+	}
+	// Named params include parameter_name; positional ("1") don't.
+	if _, err := strconv.Atoi(name); err != nil {
+		param["parameter_name"] = name
+	}
+
+	return map[string]any{
+		"type":       "header",
+		"parameters": []map[string]any{param},
+	}, nil
+}
+
 // BuildTemplateComponents builds the full WhatsApp template components array,
-// including an optional header component (for IMAGE/VIDEO/DOCUMENT) and body parameters.
+// including an optional header component (TEXT with variable, or IMAGE/VIDEO/
+// DOCUMENT media) and body parameters.
 //
 // headerMediaFilename is required by Meta for DOCUMENT headers — without it, the
 // API returns error 132012 "Header Format Mismatch (Expected DOCUMENT, received
 // UNKNOWN)". It is ignored for IMAGE/VIDEO.
-func BuildTemplateComponents(bodyParams map[string]string, headerType, headerMediaID, headerMediaFilename string) []map[string]any {
+//
+// headerContent and headerParams are only consulted for TEXT headers. For media
+// headers (IMAGE/VIDEO/DOCUMENT) the existing headerMediaID/Filename path is used.
+// Returns an error if the TEXT header declares more than one variable.
+func BuildTemplateComponents(
+	bodyParams map[string]string,
+	headerType, headerContent string,
+	headerParams map[string]string,
+	headerMediaID, headerMediaFilename string,
+) ([]map[string]any, error) {
 	var components []map[string]any
 
-	// Add header component if media is provided
-	if headerMediaID != "" {
-		mediaType := strings.ToLower(headerType) // "image", "video", "document"
-		mediaObj := map[string]any{"id": headerMediaID}
-		if mediaType == "document" && headerMediaFilename != "" {
-			mediaObj["filename"] = headerMediaFilename
+	switch strings.ToUpper(headerType) {
+	case "TEXT":
+		// Build a text-header parameter component when the approved template
+		// declares a {{var}} in the header text. Without this, Meta rejects
+		// sends of templates with header variables.
+		headerComp, err := HeaderTextParamsComponent(headerContent, headerParams, bodyParams)
+		if err != nil {
+			return nil, err
 		}
-		headerParam := map[string]any{
-			"type":    mediaType,
-			mediaType: mediaObj,
+		if headerComp != nil {
+			components = append(components, headerComp)
 		}
-		components = append(components, map[string]any{
-			"type":       "header",
-			"parameters": []map[string]any{headerParam},
-		})
+	case "IMAGE", "VIDEO", "DOCUMENT":
+		if headerMediaID != "" {
+			mediaType := strings.ToLower(headerType)
+			mediaObj := map[string]any{"id": headerMediaID}
+			if mediaType == "document" && headerMediaFilename != "" {
+				mediaObj["filename"] = headerMediaFilename
+			}
+			headerParam := map[string]any{
+				"type":    mediaType,
+				mediaType: mediaObj,
+			}
+			components = append(components, map[string]any{
+				"type":       "header",
+				"parameters": []map[string]any{headerParam},
+			})
+		}
 	}
 
 	// Add body component with text parameters
@@ -410,9 +477,9 @@ func BuildTemplateComponents(bodyParams map[string]string, headerType, headerMed
 	components = append(components, bodyComponents...)
 
 	if len(components) == 0 {
-		return nil
+		return nil, nil
 	}
-	return components
+	return components, nil
 }
 
 // AutoButtonComponents generates button components for button types that require

--- a/pkg/whatsapp/message_test.go
+++ b/pkg/whatsapp/message_test.go
@@ -754,7 +754,8 @@ func TestBodyParamsToComponents_NamedParamsRetainLexicalOrder(t *testing.T) {
 // Document headers must include filename — Meta returns 132012 "Header
 // Format Mismatch" without it. Issue #351.
 func TestBuildTemplateComponents_DocumentHeaderIncludesFilename(t *testing.T) {
-	components := whatsapp.BuildTemplateComponents(nil, "DOCUMENT", "media-id-123", "invoice.pdf")
+	components, err := whatsapp.BuildTemplateComponents(nil, "DOCUMENT", "", nil, "media-id-123", "invoice.pdf")
+	require.NoError(t, err)
 	require.Len(t, components, 1)
 	assert.Equal(t, "header", components[0]["type"])
 
@@ -768,7 +769,8 @@ func TestBuildTemplateComponents_DocumentHeaderIncludesFilename(t *testing.T) {
 }
 
 func TestBuildTemplateComponents_ImageHeaderOmitsFilename(t *testing.T) {
-	components := whatsapp.BuildTemplateComponents(nil, "IMAGE", "media-id-456", "photo.jpg")
+	components, err := whatsapp.BuildTemplateComponents(nil, "IMAGE", "", nil, "media-id-456", "photo.jpg")
+	require.NoError(t, err)
 	require.Len(t, components, 1)
 	params := components[0]["parameters"].([]map[string]any)
 	img := params[0]["image"].(map[string]any)
@@ -780,11 +782,81 @@ func TestBuildTemplateComponents_ImageHeaderOmitsFilename(t *testing.T) {
 func TestBuildTemplateComponents_DocumentHeaderEmptyFilename(t *testing.T) {
 	// If no filename was supplied, don't include the key — better than sending
 	// an empty string Meta might reject.
-	components := whatsapp.BuildTemplateComponents(nil, "DOCUMENT", "media-id-789", "")
+	components, err := whatsapp.BuildTemplateComponents(nil, "DOCUMENT", "", nil, "media-id-789", "")
+	require.NoError(t, err)
 	require.Len(t, components, 1)
 	params := components[0]["parameters"].([]map[string]any)
 	doc := params[0]["document"].(map[string]any)
 	assert.Equal(t, "media-id-789", doc["id"])
 	_, hasFilename := doc["filename"]
 	assert.False(t, hasFilename, "empty filename should not be set")
+}
+
+// TEXT header with a positional {{1}} variable must emit a header component
+// with a single text parameter (no parameter_name). The value is resolved
+// from headerParams first, then falls back to bodyParams.
+func TestBuildTemplateComponents_TextHeaderPositional(t *testing.T) {
+	bodyParams := map[string]string{"1": "John", "2": "ORD-1"}
+	headerParams := map[string]string{"1": "Summer Sale"}
+	components, err := whatsapp.BuildTemplateComponents(
+		bodyParams,
+		"TEXT", "Our {{1}} is on!",
+		headerParams,
+		"", "",
+	)
+	require.NoError(t, err)
+	require.Len(t, components, 2) // header + body
+	assert.Equal(t, "header", components[0]["type"])
+
+	params := components[0]["parameters"].([]map[string]any)
+	require.Len(t, params, 1)
+	assert.Equal(t, "text", params[0]["type"])
+	assert.Equal(t, "Summer Sale", params[0]["text"])
+	_, hasName := params[0]["parameter_name"]
+	assert.False(t, hasName, "positional params must not include parameter_name")
+}
+
+// TEXT header with a named {{order_id}} variable must include parameter_name.
+// When headerParams is nil, the value comes from bodyParams (single flat map).
+func TestBuildTemplateComponents_TextHeaderNamedFallback(t *testing.T) {
+	bodyParams := map[string]string{"customer_name": "Alex", "order_id": "ORD-9"}
+	components, err := whatsapp.BuildTemplateComponents(
+		bodyParams,
+		"TEXT", "Order {{order_id}}",
+		nil,
+		"", "",
+	)
+	require.NoError(t, err)
+	require.Len(t, components, 2)
+
+	headerParams := components[0]["parameters"].([]map[string]any)
+	require.Len(t, headerParams, 1)
+	assert.Equal(t, "ORD-9", headerParams[0]["text"])
+	assert.Equal(t, "order_id", headerParams[0]["parameter_name"])
+}
+
+// A TEXT header with no {{var}} should not emit a header component.
+func TestBuildTemplateComponents_TextHeaderNoVariable(t *testing.T) {
+	bodyParams := map[string]string{"1": "Hello"}
+	components, err := whatsapp.BuildTemplateComponents(
+		bodyParams,
+		"TEXT", "Welcome",
+		nil,
+		"", "",
+	)
+	require.NoError(t, err)
+	require.Len(t, components, 1)
+	assert.Equal(t, "body", components[0]["type"])
+}
+
+// A TEXT header with >1 variable is invalid (Meta restriction).
+func TestBuildTemplateComponents_TextHeaderTooManyVariables(t *testing.T) {
+	_, err := whatsapp.BuildTemplateComponents(
+		nil,
+		"TEXT", "Order {{1}} for {{2}}",
+		map[string]string{"1": "ORD-1", "2": "John"},
+		"", "",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at most one variable")
 }


### PR DESCRIPTION
Adds header_params handling so TEXT headers with a {{var}} actually render on Meta (BuildTemplateComponents was previously skipping the component). Threads it through send-template API, chat composer, and campaigns (CSV 'header' column, sample download); enforces Meta's one-variable-per-header limit on create/update; docs updated.

fixes https://github.com/shridarpatil/whatomate/issues/418