### PR TITLE
fix: use double underscore as env var hierarchy separator

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,9 +152,10 @@ func Load(configPath string) (*Config, error) {
 	}
 
 	// Load from environment variables (WHATOMATE_ prefix)
-	// e.g., WHATOMATE_DATABASE_HOST -> database.host
+	// Uses __ (double underscore) as hierarchy separator so single underscores in
+	// key names are preserved. e.g., WHATOMATE_DATABASE__SSL_MODE -> database.ssl_mode
 	if err := k.Load(env.Provider("WHATOMATE_", ".", func(s string) string {
-		return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(s, "WHATOMATE_")), "_", ".")
+		return strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(s, "WHATOMATE_"), "__", "."))
 	}), nil); err != nil {
 		return nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,8 +98,8 @@ secure = false
 }
 
 func TestLoad_EnvVarsOverrideFile(t *testing.T) {
-	t.Setenv("WHATOMATE_DATABASE_HOST", "from-env")
-	t.Setenv("WHATOMATE_SERVER_PORT", "1234")
+	t.Setenv("WHATOMATE_DATABASE__HOST", "from-env")
+	t.Setenv("WHATOMATE_SERVER__PORT", "1234")
 
 	cfg, err := config.Load(writeConfig(t, `
 [database]
@@ -109,8 +109,20 @@ host = "from-file"
 port = 8080
 `))
 	require.NoError(t, err)
-	assert.Equal(t, "from-env", cfg.Database.Host, "WHATOMATE_DATABASE_HOST must override file")
-	assert.Equal(t, 1234, cfg.Server.Port, "WHATOMATE_SERVER_PORT must override file")
+	assert.Equal(t, "from-env", cfg.Database.Host, "WHATOMATE_DATABASE__HOST must override file")
+	assert.Equal(t, 1234, cfg.Server.Port, "WHATOMATE_SERVER__PORT must override file")
+}
+
+func TestLoad_EnvVarsWithUnderscoreKeys(t *testing.T) {
+	t.Setenv("WHATOMATE_DATABASE__SSL_MODE", "require")
+	t.Setenv("WHATOMATE_JWT__ACCESS_EXPIRY_MINS", "60")
+	t.Setenv("WHATOMATE_RATE_LIMIT__LOGIN_MAX_ATTEMPTS", "5")
+
+	cfg, err := config.Load(writeConfig(t, ""))
+	require.NoError(t, err)
+	assert.Equal(t, "require", cfg.Database.SSLMode)
+	assert.Equal(t, 60, cfg.JWT.AccessExpiryMins)
+	assert.Equal(t, 5, cfg.RateLimit.LoginMaxAttempts)
 }
 
 func TestLoad_EmptyConfigPathStillLoadsDefaults(t *testing.T) {


### PR DESCRIPTION
The env var override mapping replaced every `_` with `.`, which broke any config key containing an underscore (ssl_mode, read_timeout, access_expiry_mins, etc.). Switch to `__` as the hierarchy separator so single underscores in key names are preserved.

Also update docker-compose.yml to support running without config.toml (env-vars-only mode), which is needed for container platforms like Dokploy or Railway where file mounts aren't practical.