### PR TITLE
Support Receiving WhatsApp Stickers

### DIFF
--- a/frontend/e2e/tests/chat/message-bubbles.spec.ts
+++ b/frontend/e2e/tests/chat/message-bubbles.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, request as playwrightRequest } from '@playwright/test'
 import { Client } from 'pg'
+import fs from 'node:fs'
+import path from 'node:path'
 import { loginAsAdmin, ApiHelper } from '../../helpers'
 import { ChatPage } from '../../pages'
 import { createTestScope } from '../../framework'
@@ -336,6 +338,14 @@ test.describe('Chat sticker bubble', () => {
   let accountName: string
 
   test.beforeAll(async () => {
+    // Create the uploads/images directory and a dummy sticker WebP file
+    const uploadsDir = path.resolve(__dirname, '../../../../uploads/images')
+    if (!fs.existsSync(uploadsDir)) {
+      fs.mkdirSync(uploadsDir, { recursive: true })
+    }
+    const webpBase64 = 'UklGRkAAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAIAAAAAAFZQOCAYAAAAUA0AnQEqAQABAAFAObwlhAL4APgA/vwAAA=='
+    fs.writeFileSync(path.join(uploadsDir, 'test-sticker.webp'), Buffer.from(webpBase64, 'base64'))
+
     const ctx = await playwrightRequest.newContext()
     const api = new ApiHelper(ctx)
     await api.loginAsAdmin()
@@ -367,6 +377,13 @@ test.describe('Chat sticker bubble', () => {
     )
 
     await ctx.dispose()
+  })
+
+  test.afterAll(async () => {
+    const filePath = path.resolve(__dirname, '../../../../uploads/images/test-sticker.webp')
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath)
+    }
   })
 
   test('incoming sticker message renders as an image bubble with sticker attributes', async ({ page }) => {

--- a/frontend/e2e/tests/chat/message-bubbles.spec.ts
+++ b/frontend/e2e/tests/chat/message-bubbles.spec.ts
@@ -2,9 +2,12 @@ import { test, expect, request as playwrightRequest } from '@playwright/test'
 import { Client } from 'pg'
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'url'
 import { loginAsAdmin, ApiHelper } from '../../helpers'
 import { ChatPage } from '../../pages'
 import { createTestScope } from '../../framework'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /**
  * Chat bubble rendering — driven through the chat UI.

--- a/frontend/e2e/tests/chat/message-bubbles.spec.ts
+++ b/frontend/e2e/tests/chat/message-bubbles.spec.ts
@@ -326,3 +326,68 @@ test.describe('Sending a text message via the UI', () => {
     await expect(composer).toHaveValue('')
   })
 })
+
+test.describe('Chat sticker bubble', () => {
+  test.describe.configure({ mode: 'serial' })
+  test.setTimeout(60_000)
+
+  let contactId: string
+  let orgId: string
+  let accountName: string
+
+  test.beforeAll(async () => {
+    const ctx = await playwrightRequest.newContext()
+    const api = new ApiHelper(ctx)
+    await api.loginAsAdmin()
+
+    const phone = scope.phone()
+    const contact = await api.createContact(phone, scope.name('stk-contact'))
+    contactId = contact.id
+
+    const orgRows = await execSQL(
+      `SELECT organization_id FROM contacts WHERE id = '${contactId}'`,
+    )
+    orgId = orgRows[0]!.organization_id as string
+
+    // Reuse or create a WhatsApp account
+    const accounts = await api.getWhatsAppAccounts().catch(() => [] as { name: string }[])
+    if (accounts.length > 0) {
+      accountName = accounts[0]!.name
+    } else {
+      const acc = await api.createWhatsAppAccount({
+        name: scope.name('acc').toLowerCase().replace(/\s/g, '-'),
+        phone_id: `phone-${Date.now()}`,
+        business_id: `biz-${Date.now()}`,
+        access_token: 'test-token-bubbles',
+      })
+      accountName = acc.name
+    }
+    await execSQL(
+      `UPDATE contacts SET whats_app_account = '${accountName}' WHERE id = '${contactId}'`,
+    )
+
+    await ctx.dispose()
+  })
+
+  test('incoming sticker message renders as an image bubble with sticker attributes', async ({ page }) => {
+    const rows = await execSQL(`
+      INSERT INTO messages (id, organization_id, whats_app_account, contact_id, direction, message_type, content, media_url, media_mime_type, status, created_at, updated_at)
+      VALUES (gen_random_uuid(), '${orgId}', '${accountName}', '${contactId}', 'incoming', 'sticker', '', 'images/test-sticker.webp', 'image/webp', 'received', NOW() - INTERVAL '5 minutes', NOW())
+      RETURNING id::text AS id
+    `)
+    const stickerMessageId = rows[0]!.id as string
+
+    await loginAsAdmin(page)
+    const chatPage = new ChatPage(page)
+    await chatPage.goto(contactId)
+
+    const bubble = page.locator(`#message-${stickerMessageId} .chat-bubble`)
+    await expect(bubble).toBeVisible({ timeout: 10_000 })
+    await expect(bubble).toHaveClass(/chat-bubble-incoming/)
+
+    const img = bubble.locator('img[alt="Sticker"]')
+    await expect(img).toBeVisible()
+    const src = await img.getAttribute('src')
+    expect(src).toContain(`/api/media/${stickerMessageId}`)
+  })
+})

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -1502,7 +1502,7 @@ function getFlowButtonText(message: Message): string | null {
 }
 
 function isMediaMessage(message: Message): boolean {
-  return ['image', 'video', 'audio', 'document'].includes(message.message_type)
+  return ['image', 'video', 'audio', 'document', 'sticker'].includes(message.message_type)
 }
 
 function getMediaUrl(message: Message): string {

--- a/internal/handlers/chatbot_processor_test.go
+++ b/internal/handlers/chatbot_processor_test.go
@@ -606,6 +606,30 @@ func TestSaveIncomingMessage_WithMedia(t *testing.T) {
 	assert.Equal(t, "[image]", dbContact.LastMessagePreview)
 }
 
+func TestSaveIncomingMessage_WithSticker(t *testing.T) {
+	app := newProcessorTestApp(t)
+	org, account := createProcessorTestOrg(t, app)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+
+	waMsgID := "wamid." + uuid.New().String()[:16]
+	media := &MediaInfo{
+		MediaURL:      "/uploads/test-sticker.webp",
+		MediaMimeType: "image/webp",
+	}
+	app.saveIncomingMessage(account, contact, waMsgID, "sticker", "", media, "")
+
+	var msg models.Message
+	require.NoError(t, app.DB.Where("whats_app_message_id = ?", waMsgID).First(&msg).Error)
+	assert.Equal(t, "/uploads/test-sticker.webp", msg.MediaURL)
+	assert.Equal(t, "image/webp", msg.MediaMimeType)
+	assert.Equal(t, models.MessageTypeSticker, msg.MessageType)
+
+	// Non-text messages show type in preview
+	var dbContact models.Contact
+	require.NoError(t, app.DB.First(&dbContact, contact.ID).Error)
+	assert.Equal(t, "[sticker]", dbContact.LastMessagePreview)
+}
+
 func TestSaveIncomingMessage_WithReplyContext(t *testing.T) {
 	app := newProcessorTestApp(t)
 	org, account := createProcessorTestOrg(t, app)

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -598,6 +598,8 @@ func (a *App) getMessagePreview(req OutgoingMessageRequest) string {
 		return "[Video]"
 	case models.MessageTypeAudio:
 		return "[Audio]"
+	case models.MessageTypeSticker:
+		return "[Sticker]"
 	case models.MessageTypeDocument:
 		if req.MediaFilename != "" {
 			return "[Document: " + req.MediaFilename + "]"

--- a/internal/handlers/webhook_test.go
+++ b/internal/handlers/webhook_test.go
@@ -5,12 +5,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/shridarpatil/whatomate/internal/models"
 	"github.com/shridarpatil/whatomate/internal/websocket"
+	"github.com/shridarpatil/whatomate/pkg/whatsapp"
 	"github.com/shridarpatil/whatomate/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -518,4 +522,103 @@ func TestUpdateMessageStatus_DeliveredBroadcastsViaWebSocket_NoErrorMessage(t *t
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for WebSocket broadcast")
 	}
+}
+
+func TestWebhookHandler_IncomingSticker(t *testing.T) {
+	app := webhookTestApp(t)
+
+	// Create test org and account
+	uid := uuid.New().String()[:8]
+	org := models.Organization{
+		BaseModel: models.BaseModel{ID: uuid.New()},
+		Name:      "sticker-org-" + uid,
+		Slug:      "sticker-org-" + uid,
+	}
+	require.NoError(t, app.DB.Create(&org).Error)
+
+	waAccount := models.WhatsAppAccount{
+		BaseModel:      models.BaseModel{ID: uuid.New()},
+		OrganizationID: org.ID,
+		Name:           "sticker-acct-" + uid,
+		PhoneID:        "phone-sticker-" + uid,
+		BusinessID:     "biz-sticker-" + uid,
+		AccessToken:    "token",
+	}
+	require.NoError(t, app.DB.Create(&waAccount).Error)
+
+	// Set up mock server for media endpoints
+	waServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "media-id-123") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"url": "http://" + r.Host + "/download/sticker",
+				"mime_type": "image/webp",
+			})
+		} else {
+			_, _ = w.Write([]byte("fake webp sticker data"))
+		}
+	}))
+	defer waServer.Close()
+	app.WhatsApp = whatsapp.NewWithBaseURL(app.Log, waServer.URL)
+
+	// Construct incoming sticker message payload
+	body := []byte(`{
+		"object": "whatsapp_business_account",
+		"entry": [{
+			"id": "` + waAccount.BusinessID + `",
+			"changes": [{
+				"field": "messages",
+				"value": {
+					"messaging_product": "whatsapp",
+					"metadata": {
+						"display_phone_number": "15551234567",
+						"phone_number_id": "` + waAccount.PhoneID + `"
+					},
+					"messages": [{
+						"from": "9199998888",
+						"id": "wamid.sticker_incoming_test_12345",
+						"timestamp": "1716152000",
+						"type": "sticker",
+						"sticker": {
+							"id": "media-id-123",
+							"mime_type": "image/webp",
+							"sha256": "abcdef"
+						}
+					}],
+					"contacts": [{
+						"profile": {
+							"name": "Sticker Tester"
+						},
+						"wa_id": "9199998888"
+					}]
+				}
+			}]
+		}]
+	}`)
+
+	req := testutil.NewRequest(t)
+	req.RequestCtx.Request.Header.SetMethod("POST")
+	req.RequestCtx.Request.Header.SetContentType("application/json")
+	req.RequestCtx.Request.SetBody(body)
+
+	// Execute WebhookHandler
+	require.NoError(t, app.WebhookHandler(req))
+
+	// Allow goroutine to run
+	time.Sleep(150 * time.Millisecond)
+
+	// Verify contact was created
+	var contact models.Contact
+	err := app.DB.Where("organization_id = ? AND phone_number = ?", org.ID, "9199998888").First(&contact).Error
+	require.NoError(t, err)
+	assert.Equal(t, "Sticker Tester", contact.ProfileName)
+
+	// Verify sticker message was saved in DB
+	var message models.Message
+	err = app.DB.Where("organization_id = ? AND whats_app_message_id = ?", org.ID, "wamid.sticker_incoming_test_12345").First(&message).Error
+	require.NoError(t, err)
+	assert.Equal(t, models.DirectionIncoming, message.Direction)
+	assert.Equal(t, models.MessageTypeSticker, message.MessageType)
+	assert.Equal(t, "image/webp", message.MediaMimeType)
+	assert.NotEmpty(t, message.MediaURL)
 }

--- a/internal/models/constants.go
+++ b/internal/models/constants.go
@@ -40,6 +40,7 @@ const (
 	MessageTypeReaction    MessageType = "reaction"
 	MessageTypeLocation    MessageType = "location"
 	MessageTypeContact     MessageType = "contact"
+	MessageTypeSticker     MessageType = "sticker"
 )
 
 // MessageStatus represents the delivery status of a message


### PR DESCRIPTION
## Overview
This PR implements support for receiving and rendering WhatsApp stickers in Whatomate. Sticker messages received via incoming webhooks are now correctly downloaded, persisted to the database, previewed in the contacts sidebar, and rendered inline in the chat bubble UI.

## Changes

### 1. Go Backend (API & Webhook Processing)
* **Model Constants**: Added `MessageTypeSticker MessageType = "sticker"` in `internal/models/constants.go` to officially support the sticker type.
* **Preview Generator**: Updated `getMessagePreview` in `internal/handlers/messages.go` to return `"[Sticker]"` for sticker messages.

### 2. Vue Frontend (Chat UI)
* **Media Categorization**: Updated `isMediaMessage` in `frontend/src/views/chat/ChatView.vue` to include `sticker`. This ensures sticker messages are correctly handled as media, allowing the UI to render the sticker WebP bubble cleanly.

### 3. Tests
* **Model Unit Test**: Added `TestSaveIncomingMessage_WithSticker` in `internal/handlers/chatbot_processor_test.go` to verify sticker saving and contact last-message preview updates.
* **Webhook Unit Test**: Added `TestWebhookHandler_IncomingSticker` in `internal/handlers/webhook_test.go` to mock Meta's media download APIs and verify correct webhook processing.
* **Playwright E2E Test**: Added a new `Chat sticker bubble` test block in `frontend/e2e/tests/chat/message-bubbles.spec.ts` to verify correct frontend rendering of incoming stickers.

---

# The Importance of Receiving Stickers in Customer Support

In modern messaging channels like WhatsApp, stickers are a primary form of communication. Support platforms must display received stickers for the following reasons:

1. **Preserving Conversational Context**: Stickers are frequently used by users to express sentiment or quick replies (e.g., thumbs-up, checkmarks, hearts, thank you stickers). If these are hidden or shown as generic placeholders, support agents lose critical context and can misinterpret the customer's intent.
2. **Improving Customer Experience**: When agents can view and react to stickers, they can maintain a natural, humanized, and engaging conversation flow, rather than asking the user to re-state what they sent.
3. **Sentiment Analysis**: Stickers carry immediate emotional data (frustration, gratitude, joy). Enabling agents to see them helps gauge the customer's mood instantly.
4. **Chatbot Compatibility**: Properly handling sticker payloads ensures that incoming stickers do not trigger bot errors or block structured conversational flows, enabling a smooth transition to human agents.
