### PR TITLE
feat(calling): support HMAC shared secret for TURN credentials

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -113,6 +113,16 @@ udp_port_max = 10100          # WebRTC UDP port range end
 # username = "user"
 # credential = "password"
 
+# Option D: TURN with a shared secret (coturn "use-auth-secret" / TURN REST API).
+# When `secret` is set it takes priority over username/credential: short-lived
+# credentials are generated per request (username = expiry timestamp, credential
+# = base64(HMAC-SHA1(secret, username))). Match `secret` to coturn's
+# `static-auth-secret`. `credential_ttl` (seconds) sets lifetime (default 86400).
+# [[calling.ice_servers]]
+# urls = ["turn:your-turn-server.com:3478"]
+# secret = "your-coturn-static-auth-secret"
+# credential_ttl = 86400
+
 # Default admin credentials (only used during initial setup when no users exist)
 [default_admin]
 email = "admin@admin.com"

--- a/internal/calling/webrtc.go
+++ b/internal/calling/webrtc.go
@@ -212,12 +212,13 @@ func createOpusTrack(pc *webrtc.PeerConnection, streamID string) (*webrtc.TrackL
 
 // createPeerConnection creates a new WebRTC peer connection with Opus codec support
 func (m *Manager) createPeerConnection() (*webrtc.PeerConnection, error) {
+	now := time.Now()
 	iceServers := make([]webrtc.ICEServer, 0, len(m.config.ICEServers))
 	for _, s := range m.config.ICEServers {
 		ice := webrtc.ICEServer{URLs: s.URLs}
-		if s.Username != "" {
-			ice.Username = s.Username
-			ice.Credential = s.Credential
+		if username, credential := s.ResolveCredentials(now); username != "" {
+			ice.Username = username
+			ice.Credential = credential
 			ice.CredentialType = webrtc.ICECredentialTypePassword
 		}
 		iceServers = append(iceServers, ice)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,12 @@
 package config
 
 import (
+	"crypto/hmac"
+	"crypto/sha1" //nolint:gosec // SHA-1 is mandated by the coturn TURN REST API (RFC draft)
+	"encoding/base64"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/knadh/koanf/parsers/toml"
 	"github.com/knadh/koanf/providers/env"
@@ -32,10 +37,49 @@ type TTSConfig struct {
 	OpusencBinary string `koanf:"opusenc_binary"` // path to opusenc (defaults to "opusenc")
 }
 
+// defaultTURNCredentialTTLSecs is the lifetime of generated coturn REST
+// credentials when an ICE server has a secret but no explicit credential_ttl.
+const defaultTURNCredentialTTLSecs = 86400 // 24h
+
 type ICEServerConfig struct {
 	URLs       []string `koanf:"urls"`
 	Username   string   `koanf:"username"`
 	Credential string   `koanf:"credential"`
+	// Secret enables coturn's "use-auth-secret" (TURN REST API) mode. When set,
+	// short-lived credentials are generated per request instead of using the
+	// static Username/Credential above.
+	Secret string `koanf:"secret"`
+	// CredentialTTL is the lifetime (seconds) of generated credentials. Defaults
+	// to defaultTURNCredentialTTLSecs when <= 0. Only used when Secret is set.
+	CredentialTTL int `koanf:"credential_ttl"`
+}
+
+// ResolveCredentials returns the username and credential to advertise for this
+// ICE server. When Secret is set it derives short-lived coturn REST credentials
+// (use-auth-secret): the username is "<expiry-unix>" — optionally prefixed onto
+// any configured Username as "<expiry-unix>:<username>" — and the credential is
+// the base64-encoded HMAC-SHA1 of that username keyed by the secret. When Secret
+// is empty, the static Username/Credential are returned unchanged.
+func (s ICEServerConfig) ResolveCredentials(now time.Time) (username, credential string) {
+	if s.Secret == "" {
+		return s.Username, s.Credential
+	}
+
+	ttl := s.CredentialTTL
+	if ttl <= 0 {
+		ttl = defaultTURNCredentialTTLSecs
+	}
+
+	expiry := now.Add(time.Duration(ttl) * time.Second).Unix()
+	username = strconv.FormatInt(expiry, 10)
+	if s.Username != "" {
+		username = username + ":" + s.Username
+	}
+
+	mac := hmac.New(sha1.New, []byte(s.Secret))
+	mac.Write([]byte(username))
+	credential = base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return username, credential
 }
 
 type CallingConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,13 @@
 package config_test
 
 import (
+	"crypto/hmac"
+	"crypto/sha1" //nolint:gosec // matches the coturn TURN REST API derivation under test
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/shridarpatil/whatomate/internal/config"
 	"github.com/stretchr/testify/assert"
@@ -132,4 +136,44 @@ func TestLoad_RateLimitDefaults(t *testing.T) {
 	assert.Equal(t, 10, cfg.RateLimit.RegisterMaxAttempts)
 	assert.Equal(t, 30, cfg.RateLimit.RefreshMaxAttempts)
 	assert.Equal(t, 10, cfg.RateLimit.SSOMaxAttempts)
+}
+
+func TestResolveCredentials_StaticWhenNoSecret(t *testing.T) {
+	s := config.ICEServerConfig{Username: "user", Credential: "pass"}
+	username, credential := s.ResolveCredentials(time.Now())
+	assert.Equal(t, "user", username)
+	assert.Equal(t, "pass", credential)
+}
+
+func TestResolveCredentials_GeneratesRESTCredentials(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s := config.ICEServerConfig{Secret: "topsecret", CredentialTTL: 3600}
+
+	username, credential := s.ResolveCredentials(now)
+
+	// Username is the expiry unix timestamp (now + ttl).
+	require.Equal(t, "1003600", username)
+
+	// Credential is base64(HMAC-SHA1(secret, username)) — computed independently.
+	mac := hmac.New(sha1.New, []byte("topsecret"))
+	mac.Write([]byte(username))
+	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	assert.Equal(t, want, credential)
+}
+
+func TestResolveCredentials_SecretTakesPriorityAndPrefixesUsername(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s := config.ICEServerConfig{Username: "alice", Credential: "static", Secret: "topsecret", CredentialTTL: 3600}
+
+	username, credential := s.ResolveCredentials(now)
+
+	require.Equal(t, "1003600:alice", username)
+	assert.NotEqual(t, "static", credential)
+}
+
+func TestResolveCredentials_DefaultsTTLWhenUnset(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s := config.ICEServerConfig{Secret: "topsecret"}
+	username, _ := s.ResolveCredentials(now)
+	assert.Equal(t, "1086400", username) // now + default 86400s
 }

--- a/internal/handlers/outgoing_calls.go
+++ b/internal/handlers/outgoing_calls.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/shridarpatil/whatomate/internal/models"
 	"github.com/shridarpatil/whatomate/pkg/whatsapp"
@@ -193,12 +195,14 @@ func (a *App) GetICEServers(r *fastglue.Request) error {
 		Credential string   `json:"credential,omitempty"`
 	}
 
+	now := time.Now()
 	servers := make([]iceServer, 0, len(a.Config.Calling.ICEServers))
 	for _, s := range a.Config.Calling.ICEServers {
+		username, credential := s.ResolveCredentials(now)
 		servers = append(servers, iceServer{
 			URLs:       s.URLs,
-			Username:   s.Username,
-			Credential: s.Credential,
+			Username:   username,
+			Credential: credential,
 		})
 	}
 


### PR DESCRIPTION
When an ICE server has a secret set, generate short-lived coturn REST credentials instead of using the static username/password.