### PR TITLE
fix(docker): give develop image an ENTRYPOINT matching the release image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,5 +88,10 @@ RUN mkdir -p /app/uploads /app/audio
 # Expose port
 EXPOSE 8080
 
-# Run the binary
-CMD ["./whatomate", "server", "-config", "config.toml", "-migrate"]
+# Match the GoReleaser image's launch convention so the same orchestrator
+# args work against both tags: the binary is the ENTRYPOINT and CMD holds
+# only the default subcommand/flags. A Nomad job that sets
+# `args = ["server", "-migrate", ...]` (no `command`) then appends to the
+# entrypoint instead of replacing the binary with "server".
+ENTRYPOINT ["./whatomate"]
+CMD ["server", "-config", "config.toml", "-migrate"]


### PR DESCRIPTION
The develop Dockerfile baked the full command into CMD with no ENTRYPOINT, while the GoReleaser image uses ENTRYPOINT ["./whatomate"]. A Nomad job passing args = ["server", "-migrate", ...] (no command) replaced CMD entirely on the develop image, so the container tried to exec "server" and failed with 'no binary found'. Align both images.