### PR TITLE
fix(contacts): let transfer-assigned agents access their chats

### DIFF
--- a/internal/handlers/contacts.go
+++ b/internal/handlers/contacts.go
@@ -20,6 +20,7 @@ import (
 	"github.com/shridarpatil/whatomate/pkg/whatsapp"
 	"github.com/valyala/fasthttp"
 	"github.com/zerodha/fastglue"
+	"gorm.io/gorm"
 )
 
 // ContactResponse represents a contact with additional fields for the frontend
@@ -100,14 +101,7 @@ func (a *App) ListContacts(r *fastglue.Request) error {
 
 	// Users without contacts:read permission can only see contacts assigned to them
 	// or contacts with an active chat transfer to them
-	if !a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
-		query = query.Where("assigned_user_id = ? OR id IN (?)",
-			userID,
-			a.DB.Model(&models.AgentTransfer{}).
-				Select("contact_id").
-				Where("agent_id = ? AND organization_id = ? AND status = ?", userID, orgID, models.TransferStatusActive),
-		)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 
 	if search != "" {
 		// Limit search string length to prevent abuse
@@ -210,6 +204,25 @@ func (a *App) ListContacts(r *fastglue.Request) error {
 	})
 }
 
+// scopeAssignedContact narrows a contact query for users who lack the
+// contacts:read permission: they may only access contacts assigned to them
+// (assigned_user_id) or contacts with an active agent transfer to them. With
+// the permission, the query is returned unchanged. Keeping this in one place
+// ensures every contact endpoint enforces the same visibility — assignment
+// via an active transfer counts even when assigned_user_id is unset (which it
+// is unless the AssignToSameAgent setting is on).
+func (a *App) scopeAssignedContact(query *gorm.DB, userID, orgID uuid.UUID) *gorm.DB {
+	if a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
+		return query
+	}
+	return query.Where("assigned_user_id = ? OR id IN (?)",
+		userID,
+		a.DB.Model(&models.AgentTransfer{}).
+			Select("contact_id").
+			Where("agent_id = ? AND organization_id = ? AND status = ?", userID, orgID, models.TransferStatusActive),
+	)
+}
+
 // GetContact returns a single contact
 // Users without contacts:read permission can only access contacts assigned to them
 func (a *App) GetContact(r *fastglue.Request) error {
@@ -227,14 +240,7 @@ func (a *App) GetContact(r *fastglue.Request) error {
 
 	// Users without contacts:read permission can only access their assigned contacts
 	// or contacts with an active chat transfer to them
-	if !a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
-		query = query.Where("assigned_user_id = ? OR id IN (?)",
-			userID,
-			a.DB.Model(&models.AgentTransfer{}).
-				Select("contact_id").
-				Where("agent_id = ? AND organization_id = ? AND status = ?", userID, orgID, models.TransferStatusActive),
-		)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 
 	if err := query.First(&contact).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
@@ -302,9 +308,7 @@ func (a *App) GetMessages(r *fastglue.Request) error {
 	// Verify contact belongs to org (and to user if no contacts:read permission)
 	var contact models.Contact
 	query := a.DB.Where("id = ? AND organization_id = ?", contactID, orgID)
-	if !hasContactsReadPermission {
-		query = query.Where("assigned_user_id = ?", userID)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 	if err := query.First(&contact).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
 	}
@@ -492,13 +496,9 @@ func (a *App) MarkContactRead(r *fastglue.Request) error {
 		return nil
 	}
 
-	hasContactsReadPermission := a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID)
-
 	var contact models.Contact
 	query := a.DB.Where("id = ? AND organization_id = ?", contactID, orgID)
-	if !hasContactsReadPermission {
-		query = query.Where("assigned_user_id = ?", userID)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 	if err := query.First(&contact).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
 	}
@@ -603,9 +603,7 @@ func (a *App) SendMessage(r *fastglue.Request) error {
 	// Get contact (users without full read permission can only message their assigned contacts)
 	var contact models.Contact
 	query := a.DB.Where("id = ? AND organization_id = ?", contactID, orgID)
-	if !a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
-		query = query.Where("assigned_user_id = ?", userID)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 	if err := query.First(&contact).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
 	}
@@ -831,9 +829,7 @@ func (a *App) SendMediaMessage(r *fastglue.Request) error {
 	// Get contact (users without full read permission can only message their assigned contacts)
 	var contact models.Contact
 	query := a.DB.Where("id = ? AND organization_id = ?", contactID, orgID)
-	if !a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
-		query = query.Where("assigned_user_id = ?", userID)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 	if err := query.First(&contact).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
 	}
@@ -974,9 +970,7 @@ func (a *App) SendReaction(r *fastglue.Request) error {
 	// Get contact (users without full read permission can only react to messages in their assigned contacts)
 	var contact models.Contact
 	query := a.DB.Where("id = ? AND organization_id = ?", contactID, orgID)
-	if !a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
-		query = query.Where("assigned_user_id = ?", userID)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 	if err := query.First(&contact).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
 	}
@@ -1194,9 +1188,7 @@ func (a *App) GetContactSessionData(r *fastglue.Request) error {
 	// Verify contact belongs to org (users without full read permission can only access assigned contacts)
 	var contact models.Contact
 	query := a.DB.Where("id = ? AND organization_id = ?", contactID, orgID)
-	if !a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
-		query = query.Where("assigned_user_id = ?", userID)
-	}
+	query = a.scopeAssignedContact(query, userID, orgID)
 	if err := query.First(&contact).Error; err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
 	}

--- a/internal/handlers/contacts_test.go
+++ b/internal/handlers/contacts_test.go
@@ -1422,6 +1422,63 @@ func TestApp_ListContacts_Page2(t *testing.T) {
 
 // --- GetContact additional tests ---
 
+// TestApp_GetMessages_AssignedViaActiveTransfer verifies the agent-visibility
+// rules for a user without contacts:read:
+//   - an active agent transfer grants access (even when assigned_user_id is unset),
+//   - resuming the chatbot ends that access,
+//   - a persistent assigned_user_id keeps access after the transfer is resumed.
+func TestApp_GetMessages_AssignedViaActiveTransfer(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t)
+	org := testutil.CreateTestOrganization(t, app.DB)
+
+	// Agent role WITHOUT contacts:read — agents only see assigned chats.
+	role := testutil.CreateTestRoleWithKeys(t, app.DB, org.ID, "agent-no-read",
+		[]string{"chat:read", "chat:write", "transfers:read", "transfers:pickup"})
+	agent := testutil.CreateTestUser(t, app.DB, org.ID, testutil.WithRoleID(&role.ID))
+
+	account := testutil.CreateTestWhatsAppAccount(t, app.DB, org.ID)
+	contact := testutil.CreateTestContactWith(t, app.DB, org.ID, testutil.WithContactAccount(account.Name))
+	// assigned_user_id intentionally nil — assignment is via the transfer only.
+
+	msg := &models.Message{
+		BaseModel:       models.BaseModel{ID: uuid.New()},
+		OrganizationID:  org.ID,
+		WhatsAppAccount: account.Name,
+		ContactID:       contact.ID,
+		Direction:       models.DirectionIncoming,
+		MessageType:     models.MessageTypeText,
+		Content:         "Hi",
+		Status:          models.MessageStatusDelivered,
+	}
+	require.NoError(t, app.DB.Create(msg).Error)
+
+	transfer := createTestTransfer(t, app, org.ID, contact.ID, account.Name, models.TransferStatusActive, &agent.ID)
+
+	getMessagesStatus := func() int {
+		req := testutil.NewGETRequest(t)
+		testutil.SetAuthContext(req, org.ID, agent.ID)
+		testutil.SetPathParam(req, "id", contact.ID.String())
+		require.NoError(t, app.GetMessages(req))
+		return testutil.GetResponseStatusCode(req)
+	}
+
+	// Active transfer → agent can load messages despite no contacts:read.
+	assert.Equal(t, fasthttp.StatusOK, getMessagesStatus(),
+		"active transfer should grant the agent access to the assigned contact")
+
+	// Resume the chatbot → transfer no longer active → access ends.
+	require.NoError(t, app.DB.Model(transfer).Update("status", models.TransferStatusResumed).Error)
+	assert.Equal(t, fasthttp.StatusNotFound, getMessagesStatus(),
+		"resuming the chatbot should end transfer-only access")
+
+	// Persistent assignment → agent retains access even after resume.
+	require.NoError(t, app.DB.Model(contact).Update("assigned_user_id", agent.ID).Error)
+	assert.Equal(t, fasthttp.StatusOK, getMessagesStatus(),
+		"a persistent assigned_user_id should keep access after resume")
+}
+
 func TestApp_GetContact_WithAssignedUser(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Apply a shared assigned-or-active-transfer scope across all contact endpoints so agents without contacts:read can load and reply to chats assigned via transfer, not just via assigned_user_id.