### PR TITLE
feat(canned-responses): support sending a WhatsApp Flow

### DIFF
--- a/frontend/src/components/shared/MessageButtonsEditor.vue
+++ b/frontend/src/components/shared/MessageButtonsEditor.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
-import { Reply, ExternalLink, Phone, PhoneCall, Trash2 } from 'lucide-vue-next'
+import { Reply, ExternalLink, Phone, PhoneCall, Workflow, Trash2 } from 'lucide-vue-next'
 import type { ButtonConfig } from '@/types/flow-preview'
+import { flowsService } from '@/services/api'
 
-type ButtonType = 'reply' | 'url' | 'phone' | 'voice_call'
+type ButtonType = 'reply' | 'url' | 'phone' | 'voice_call' | 'flow'
 
 const props = withDefaults(
   defineProps<{
@@ -47,9 +48,26 @@ const ctaCount = computed(() =>
 const hasCtaButtons = computed(() => ctaCount.value > 0)
 const ctaLimitReached = computed(() => ctaCount.value >= 2)
 const hasVoiceCallButton = computed(() => props.buttons.some((b) => b.type === 'voice_call'))
+// flow, like voice_call, renders as the whole interactive message — exclusive.
+const hasFlowButton = computed(() => props.buttons.some((b) => b.type === 'flow'))
+const isExclusive = computed(() => hasVoiceCallButton.value || hasFlowButton.value)
+
+// Published flows for the picker. Loaded once when the flow type is allowed.
+const publishedFlows = ref<{ meta_flow_id: string; name: string }[]>([])
+onMounted(async () => {
+  if (!props.allowedTypes.includes('flow')) return
+  try {
+    const res = await flowsService.list({ limit: 100 })
+    publishedFlows.value = (res.data?.flows || [])
+      .filter((f: any) => f.status === 'PUBLISHED' && f.meta_flow_id)
+      .map((f: any) => ({ meta_flow_id: f.meta_flow_id, name: f.name }))
+  } catch {
+    publishedFlows.value = []
+  }
+})
 
 const effectiveMax = computed(() => {
-  if (hasVoiceCallButton.value) return 1
+  if (isExclusive.value) return 1
   if (hasCtaButtons.value) return 2
   return props.maxButtons
 })
@@ -69,6 +87,10 @@ function addButton(type: ButtonType) {
   if (type === 'url') newButton.url = ''
   else if (type === 'phone') newButton.phone_number = ''
   else if (type === 'voice_call') newButton.ttl_minutes = 15
+  else if (type === 'flow') {
+    newButton.flow_id = ''
+    if (!newButton.title) newButton.title = 'Open'
+  }
   emitButtons([...props.buttons, newButton])
 }
 
@@ -85,8 +107,9 @@ function updateButton(index: number, patch: Partial<ButtonConfig>) {
 
 function canAdd(type: ButtonType): boolean {
   if (props.disabled) return false
-  if (hasVoiceCallButton.value) return false
-  if (type === 'voice_call') return props.buttons.length === 0
+  if (isExclusive.value) return false
+  // Exclusive types can only be the sole button on the message.
+  if (type === 'voice_call' || type === 'flow') return props.buttons.length === 0
   if (props.buttons.length >= effectiveMax.value) return false
   if (type === 'reply') return !hasCtaButtons.value
   // url / phone
@@ -97,6 +120,7 @@ function typeLabel(type?: string): string {
   if (type === 'url') return 'URL'
   if (type === 'phone') return t('flowBuilder.phoneButton', 'Phone')
   if (type === 'voice_call') return t('flowBuilder.voiceCallButton', 'Call')
+  if (type === 'flow') return t('flowBuilder.flowButton', 'Flow')
   return t('flowBuilder.replyButton', 'Reply')
 }
 
@@ -104,6 +128,7 @@ function typeIcon(type?: string) {
   if (type === 'url') return ExternalLink
   if (type === 'phone') return Phone
   if (type === 'voice_call') return PhoneCall
+  if (type === 'flow') return Workflow
   return Reply
 }
 </script>
@@ -158,6 +183,17 @@ function typeIcon(type?: string) {
         >
           <PhoneCall class="h-3 w-3 mr-1" />
           {{ $t('flowBuilder.voiceCallButton', 'Call') }}
+        </Button>
+        <Button
+          v-if="allowedTypes.includes('flow')"
+          variant="outline"
+          size="sm"
+          class="h-6 text-xs"
+          :disabled="!canAdd('flow')"
+          @click="addButton('flow')"
+        >
+          <Workflow class="h-3 w-3 mr-1" />
+          {{ $t('flowBuilder.flowButton', 'Flow') }}
         </Button>
       </div>
     </div>
@@ -225,6 +261,23 @@ function typeIcon(type?: string) {
           <span class="text-[10px] text-muted-foreground">
             {{ $t('flowBuilder.voiceCallTtlSuffix', 'minutes (1–60)') }}
           </span>
+        </div>
+        <div v-else-if="btn.type === 'flow'" class="space-y-1">
+          <select
+            :value="btn.flow_id || ''"
+            class="h-7 w-full rounded-md border bg-background px-2 text-xs"
+            :disabled="disabled"
+            @change="updateButton(idx, { flow_id: ($event.target as HTMLSelectElement).value })"
+          >
+            <option value="" disabled>{{ $t('flowBuilder.selectFlow', 'Select a published flow…') }}</option>
+            <option v-for="f in publishedFlows" :key="f.meta_flow_id" :value="f.meta_flow_id">{{ f.name }}</option>
+          </select>
+          <p v-if="publishedFlows.length === 0" class="text-[10px] text-muted-foreground">
+            {{ $t('flowBuilder.noPublishedFlows', 'No published flows available. Publish a flow first.') }}
+          </p>
+          <p v-else class="text-[10px] text-muted-foreground">
+            {{ $t('flowBuilder.flowCtaHint', 'The title above is the button label shown to the customer.') }}
+          </p>
         </div>
         <div v-else-if="showIdField">
           <Input

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -272,13 +272,20 @@ export const messagesService = {
       content: any
       reply_to_message_id?: string
       whatsapp_account?: string
-      // Interactive button / cta_url payload. Mirrors backend InteractiveContent.
+      // Interactive payload. Mirrors backend InteractiveContent.
       interactive?: {
-        type: 'button' | 'cta_url' | 'list'
+        type: 'button' | 'cta_url' | 'list' | 'voice_call' | 'flow'
         body: string
         buttons?: Array<{ id: string; title: string }>
         button_text?: string
         url?: string
+        // voice_call only
+        display_text?: string
+        ttl_minutes?: number
+        // flow only
+        flow_id?: string
+        first_screen?: string
+        header?: string
       }
     },
   ) => api.post(`/contacts/${contactId}/messages`, data),
@@ -419,9 +426,12 @@ export const chatbotService = {
 export interface CannedResponseButton {
   id: string
   title: string
-  type?: 'reply' | 'url' | 'phone'
+  type?: 'reply' | 'url' | 'phone' | 'voice_call' | 'flow'
   url?: string
   phone_number?: string
+  ttl_minutes?: number
+  flow_id?: string
+  screen?: string
 }
 
 export interface CannedResponse {

--- a/frontend/src/types/flow-preview.ts
+++ b/frontend/src/types/flow-preview.ts
@@ -3,11 +3,14 @@
 export interface ButtonConfig {
   id: string
   title: string
-  type?: 'reply' | 'url' | 'phone' | 'voice_call'
+  type?: 'reply' | 'url' | 'phone' | 'voice_call' | 'flow'
   url?: string
   phone_number?: string
   /** voice_call only: how long the button stays clickable; 0 = Meta default (15m). */
   ttl_minutes?: number
+  /** flow only: the Meta flow to launch and the first screen to open. */
+  flow_id?: string
+  screen?: string
 }
 
 export interface ApiConfig {

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -908,18 +908,32 @@ async function sendCannedResponse() {
   // combos aren't representable; the detail-page validator blocks save for
   // those, so the text fallback here is just a safety net.
   const voiceCallButtons = buttons.filter(b => b.type === 'voice_call')
+  const flowButtons = buttons.filter(b => b.type === 'flow')
   let sendType: 'text' | 'interactive' = 'text'
   let interactive: {
-    type: 'button' | 'list' | 'cta_url' | 'voice_call'
+    type: 'button' | 'list' | 'cta_url' | 'voice_call' | 'flow'
     body: string
     buttons?: Array<{ id: string; title: string }>
     button_text?: string
     url?: string
     display_text?: string
     ttl_minutes?: number
+    flow_id?: string
+    first_screen?: string
   } | undefined
 
-  if (buttons.length === 1 && voiceCallButtons.length === 1) {
+  if (buttons.length === 1 && flowButtons.length === 1) {
+    const f = flowButtons[0]
+    sendType = 'interactive'
+    interactive = {
+      type: 'flow',
+      body,
+      // The button title is the CTA label shown to the customer.
+      button_text: resolveCannedTokens(f.title),
+      flow_id: f.flow_id,
+      first_screen: f.screen,
+    }
+  } else if (buttons.length === 1 && voiceCallButtons.length === 1) {
     const vc = voiceCallButtons[0]
     sendType = 'interactive'
     interactive = {

--- a/frontend/src/views/settings/CannedResponseDetailView.vue
+++ b/frontend/src/views/settings/CannedResponseDetailView.vue
@@ -163,6 +163,25 @@ const buttonsValidationError = computed<string | null>(() => {
       )
     }
   }
+  const flow = list.filter(b => b.type === 'flow')
+  if (flow.length > 1) {
+    return t('cannedResponses.errorMultiFlow', 'Only one Flow button is allowed per message.')
+  }
+  if (flow.length > 0 && list.length > flow.length) {
+    return t(
+      'cannedResponses.errorFlowExclusive',
+      'A Flow button cannot be combined with other button types — remove the other buttons or the Flow button.',
+    )
+  }
+  if (flow.length === 1) {
+    const f = flow[0]
+    if (!f.title?.trim()) {
+      return t('cannedResponses.errorFlowTitle', 'The Flow button needs a label (shown on the button face).')
+    }
+    if (!f.flow_id) {
+      return t('cannedResponses.errorFlowId', 'Select a published flow for the Flow button.')
+    }
+  }
   if (phone.length > 0) {
     return t(
       'cannedResponses.errorPhoneUnsupported',
@@ -357,7 +376,7 @@ onMounted(() => { loadResponse() })
         <CardContent class="space-y-4">
           <MessageButtonsEditor
             :buttons="form.buttons"
-            :allowed-types="['reply', 'url', 'voice_call']"
+            :allowed-types="['reply', 'url', 'voice_call', 'flow']"
             :disabled="!canWrite"
             @update:buttons="form.buttons = $event"
           />

--- a/internal/handlers/canned_responses.go
+++ b/internal/handlers/canned_responses.go
@@ -15,10 +15,11 @@ import (
 )
 
 // CannedResponseButton mirrors the chatbot flow ButtonConfig shape.
-// type is one of "reply", "url", "phone", "voice_call". For voice_call,
+// type is one of "reply", "url", "phone", "voice_call", "flow". For voice_call,
 // Title is the on-button label (Meta's display_text, 20-char cap applied at
 // send time) and TTLMinutes is how long the button stays clickable (0 ⇒
-// Meta default, 15 min).
+// Meta default, 15 min). For flow, Title is the CTA label, FlowID is the Meta
+// flow id to launch and Screen is the first screen to open.
 type CannedResponseButton struct {
 	ID          string `json:"id"`
 	Title       string `json:"title"`
@@ -26,6 +27,10 @@ type CannedResponseButton struct {
 	URL         string `json:"url,omitempty"`
 	PhoneNumber string `json:"phone_number,omitempty"`
 	TTLMinutes  int    `json:"ttl_minutes,omitempty"`
+	// flow only. Like voice_call, a flow button is exclusive — it can't share
+	// a message with other button types.
+	FlowID string `json:"flow_id,omitempty"`
+	Screen string `json:"screen,omitempty"`
 }
 
 // CannedResponseRequest represents the request body for creating/updating a canned response
@@ -426,9 +431,11 @@ func validateCannedResponseButtons(buttons []CannedResponseButton) error {
 		return nil
 	}
 	voiceCalls := 0
+	flows := 0
 	others := 0
 	for _, b := range buttons {
-		if strings.ToLower(b.Type) == "voice_call" {
+		switch strings.ToLower(b.Type) {
+		case "voice_call":
 			voiceCalls++
 			if strings.TrimSpace(b.Title) == "" {
 				return fmt.Errorf("voice_call button needs a title")
@@ -436,15 +443,28 @@ func validateCannedResponseButtons(buttons []CannedResponseButton) error {
 			if b.TTLMinutes < 0 || b.TTLMinutes > 60 {
 				return fmt.Errorf("voice_call ttl_minutes must be between 0 and 60")
 			}
-			continue
+		case "flow":
+			flows++
+			if strings.TrimSpace(b.Title) == "" {
+				return fmt.Errorf("flow button needs a CTA title")
+			}
+			if strings.TrimSpace(b.FlowID) == "" {
+				return fmt.Errorf("flow button needs a flow_id")
+			}
+		default:
+			others++
 		}
-		others++
 	}
 	if voiceCalls > 1 {
 		return fmt.Errorf("only one voice_call button is allowed per message")
 	}
-	if voiceCalls > 0 && others > 0 {
-		return fmt.Errorf("voice_call cannot be combined with other button types")
+	if flows > 1 {
+		return fmt.Errorf("only one flow button is allowed per message")
+	}
+	// voice_call and flow each render as the whole interactive message, so
+	// they can't be combined with each other or with reply/url/phone buttons.
+	if (voiceCalls > 0 || flows > 0) && (others > 0 || (voiceCalls > 0 && flows > 0)) {
+		return fmt.Errorf("voice_call and flow buttons cannot be combined with other button types")
 	}
 	return nil
 }

--- a/internal/handlers/canned_responses_test.go
+++ b/internal/handlers/canned_responses_test.go
@@ -259,6 +259,61 @@ func TestApp_CreateCannedResponse(t *testing.T) {
 		assert.Equal(t, fasthttp.StatusBadRequest, testutil.GetResponseStatusCode(req))
 	})
 
+	t.Run("flow button without flow_id is rejected", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"name":    "Flow no id",
+			"content": "Open the form",
+			"buttons": []map[string]any{
+				{"id": "b1", "title": "Open", "type": "flow"},
+			},
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		require.NoError(t, app.CreateCannedResponse(req))
+		assert.Equal(t, fasthttp.StatusBadRequest, testutil.GetResponseStatusCode(req))
+	})
+
+	t.Run("flow button cannot be combined with reply buttons", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"name":    "Flow plus reply",
+			"content": "Pick",
+			"buttons": []map[string]any{
+				{"id": "b1", "title": "Open", "type": "flow", "flow_id": "1234567890"},
+				{"id": "b2", "title": "No thanks", "type": "reply"},
+			},
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		require.NoError(t, app.CreateCannedResponse(req))
+		assert.Equal(t, fasthttp.StatusBadRequest, testutil.GetResponseStatusCode(req))
+	})
+
+	t.Run("valid flow button is accepted", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"name":    "Flow ok",
+			"content": "Open the form",
+			"buttons": []map[string]any{
+				{"id": "b1", "title": "Open", "type": "flow", "flow_id": "1234567890"},
+			},
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		require.NoError(t, app.CreateCannedResponse(req))
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+	})
+
 	t.Run("validation error missing content", func(t *testing.T) {
 		app := newTestApp(t)
 		org := testutil.CreateTestOrganization(t, app.DB)

--- a/internal/handlers/contacts.go
+++ b/internal/handlers/contacts.go
@@ -563,10 +563,10 @@ type SendMessageRequest struct {
 
 // InteractiveContent holds interactive message data
 type InteractiveContent struct {
-	Type       string          `json:"type"`                  // "button", "list", "cta_url", "voice_call"
+	Type       string          `json:"type"`                  // "button", "list", "cta_url", "voice_call", "flow"
 	Body       string          `json:"body"`                  // Body text
 	Buttons    []ButtonContent `json:"buttons,omitempty"`     // For button type
-	ButtonText string          `json:"button_text,omitempty"` // For cta_url type
+	ButtonText string          `json:"button_text,omitempty"` // CTA label for cta_url and flow
 	URL        string          `json:"url,omitempty"`         // For cta_url type
 	// voice_call only: button face label and clickable TTL.
 	// The payload (round-trip opaque string Meta echoes back on the incoming-
@@ -574,6 +574,11 @@ type InteractiveContent struct {
 	// request body — to prevent agent-id spoofing.
 	DisplayText string `json:"display_text,omitempty"`
 	TTLMinutes  int    `json:"ttl_minutes,omitempty"`
+	// flow only: the Meta flow to launch, an optional first screen, and an
+	// optional header. Body holds the message text, ButtonText the CTA label.
+	FlowID      string `json:"flow_id,omitempty"`
+	FirstScreen string `json:"first_screen,omitempty"`
+	Header      string `json:"header,omitempty"`
 }
 
 // ButtonContent represents a button in interactive messages
@@ -655,6 +660,33 @@ func (a *App) SendMessage(r *fastglue.Request) error {
 					Title: btn.Title,
 				}
 			}
+		}
+
+		if req.Interactive.Type == "flow" {
+			if req.Interactive.FlowID == "" {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "flow_id is required to send a flow", nil, "")
+			}
+			// Ensure the flow belongs to this org so an agent can't send another
+			// org's flow by supplying its Meta id.
+			var waFlow models.WhatsAppFlow
+			if err := a.DB.Where("meta_flow_id = ? AND organization_id = ?", req.Interactive.FlowID, orgID).First(&waFlow).Error; err != nil {
+				return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Flow not found for this organization", nil, "")
+			}
+			cta := req.Interactive.ButtonText
+			if cta == "" {
+				cta = "Open"
+			}
+			body := req.Interactive.Body
+			if body == "" {
+				body = req.Content.Body
+			}
+			msgReq.Type = models.MessageTypeFlow
+			msgReq.FlowID = req.Interactive.FlowID
+			msgReq.FlowCTA = cta
+			msgReq.FlowHeader = req.Interactive.Header
+			msgReq.FlowFirstScreen = req.Interactive.FirstScreen
+			msgReq.BodyText = body
+			msgReq.FlowToken = fmt.Sprintf("agent_%s_%d", contact.ID, time.Now().UnixNano())
 		}
 
 		if req.Interactive.Type == "voice_call" {


### PR DESCRIPTION
Add a flow button type (exclusive, like voice_call) to canned responses: pick a published flow + CTA label in the editor, and the agent send path launches it as an interactive flow message. Reuses the existing flow send infrastructure.

fixes: https://github.com/shridarpatil/whatomate/pull/405