### PR TITLE
fix(media): grant media access to directly transfer-assigned agents

### DIFF
--- a/internal/handlers/media.go
+++ b/internal/handlers/media.go
@@ -152,12 +152,15 @@ func (a *App) ServeMedia(r *fastglue.Request) error {
 		return nil
 	}
 
-	// Users without contacts:read permission can only access media from their assigned contacts
-	// or from contacts with an active team transfer where the user is a team member.
+	// Users without contacts:read permission can only access media from contacts
+	// assigned to them — the persistent owner or an active transfer assigned
+	// directly to them (via scopeAssignedContact) — or from contacts with an
+	// active team transfer where the user is a team member.
 	if !a.HasPermission(userID, models.ResourceContacts, models.ActionRead, orgID) {
 		var contact models.Contact
-		if err := a.DB.Where("id = ? AND assigned_user_id = ?", message.ContactID, userID).First(&contact).Error; err != nil {
-			// Not directly assigned — check team membership via active transfer
+		q := a.scopeAssignedContact(a.DB.Where("id = ? AND organization_id = ?", message.ContactID, orgID), userID, orgID)
+		if err := q.First(&contact).Error; err != nil {
+			// Not owner / not directly assigned — check team membership via active transfer
 			var transfer models.AgentTransfer
 			if err := a.DB.Where("contact_id = ? AND organization_id = ? AND status = ? AND team_id IS NOT NULL",
 				message.ContactID, orgID, models.TransferStatusActive).First(&transfer).Error; err != nil {

--- a/internal/handlers/media_test.go
+++ b/internal/handlers/media_test.go
@@ -228,6 +228,35 @@ func TestApp_ServeMedia_AgentWithoutAssignmentDenied(t *testing.T) {
 	assert.Equal(t, fasthttp.StatusForbidden, testutil.GetResponseStatusCode(req))
 }
 
+// --- ServeMedia: agent reaches via a direct (agent_id) active transfer ---
+
+func TestApp_ServeMedia_AgentViaDirectTransfer(t *testing.T) {
+	app := newTestApp(t)
+	org := testutil.CreateTestOrganization(t, app.DB)
+	role := testutil.CreateTestRoleExact(t, app.DB, org.ID, "direct-transfer", false, false, nil)
+	user := testutil.CreateTestUser(t, app.DB, org.ID, testutil.WithRoleID(&role.ID))
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+	// No assigned_user_id — the agent's only claim is an active transfer to them.
+	require.NoError(t, app.DB.Create(&models.AgentTransfer{
+		BaseModel:      models.BaseModel{ID: uuid.New()},
+		OrganizationID: org.ID,
+		ContactID:      contact.ID,
+		AgentID:        &user.ID,
+		Status:         models.TransferStatusActive,
+	}).Error)
+
+	rel := withStorageDir(t, app, "images/direct.png", []byte("direct data"))
+	msg := makeMediaMessage(t, app, org.ID, contact.ID, rel)
+
+	req := testutil.NewGETRequest(t)
+	testutil.SetAuthContext(req, org.ID, user.ID)
+	testutil.SetPathParam(req, "message_id", msg.ID.String())
+
+	require.NoError(t, app.ServeMedia(req))
+	assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req),
+		"agent with an active direct transfer should access the contact's media")
+}
+
 // --- ServeMedia: agent reaches via team-transfer membership ---
 
 func TestApp_ServeMedia_AgentViaTeamTransfer(t *testing.T) {


### PR DESCRIPTION
ServeMedia scoped media access to assigned_user_id or active team-transfer membership, missing agents holding an active transfer assigned directly to them. Route the lookup through scopeAssignedContact so it matches the other contact endpoints.