### PR TITLE
fix(chatbot): handle start node in flow preview

### DIFF
--- a/frontend/src/composables/useFlowGraphSimulation.ts
+++ b/frontend/src/composables/useFlowGraphSimulation.ts
@@ -253,6 +253,10 @@ export function useFlowGraphSimulation(
     }
 
     switch (node.type) {
+      case 'start':
+        // Entry sentinel — no side effect; advance through the default edge,
+        // matching the backend runner's ChatNodeStart handling.
+        return 'default'
       case 'message':
         return execMessage(node)
       case 'buttons':


### PR DESCRIPTION
## Problem
Previewing a chatbot flow errors with `Unknown node type "start"`.

The flow-preview simulation (`useFlowGraphSimulation.ts`) switches on node type but has no case for the `start` sentinel. Previews begin at the `__start__` entry node, which falls through to the `default` case and emits the error.

## Fix
Add a `start` case that returns `'default'` — the start node is a no-op entry sentinel that advances through its default edge to the first real node, matching the backend runner's `ChatNodeStart` handling.

Lint and typecheck clean.