### PR TITLE
Fix Contact view endpoint to show same as list contacts.

### DIFF
--- a/internal/handlers/contacts.go
+++ b/internal/handlers/contacts.go
@@ -246,46 +246,7 @@ func (a *App) GetContact(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
 	}
 
-	// Count unread messages
-	var unreadCount int64
-	a.DB.Model(&models.Message{}).
-		Where("contact_id = ? AND direction = ? AND status != ?", contact.ID, models.DirectionIncoming, models.MessageStatusRead).
-		Count(&unreadCount)
-
-	tags := []string{}
-	if contact.Tags != nil {
-		for _, t := range contact.Tags {
-			if s, ok := t.(string); ok {
-				tags = append(tags, s)
-			}
-		}
-	}
-
-	phoneNumber := contact.PhoneNumber
-	profileName := contact.ProfileName
-	shouldMask := a.ShouldMaskPhoneNumbers(orgID)
-	if shouldMask {
-		phoneNumber = utils.MaskPhoneNumber(phoneNumber)
-		profileName = utils.MaskIfPhoneNumber(profileName)
-	}
-
-	response := ContactResponse{
-		ID:                 contact.ID,
-		PhoneNumber:        phoneNumber,
-		Name:               profileName,
-		ProfileName:        profileName,
-		Status:             "active",
-		Tags:               tags,
-		Metadata:           contact.Metadata,
-		LastMessageAt:      contact.LastMessageAt,
-		LastMessagePreview: contact.LastMessagePreview,
-		UnreadCount:        int(unreadCount),
-		AssignedUserID:     contact.AssignedUserID,
-		WhatsAppAccount:    contact.WhatsAppAccount,
-		MarketingOptOut:    contact.MarketingOptOut,
-		CreatedAt:          contact.CreatedAt,
-		UpdatedAt:          contact.UpdatedAt,
-	}
+	response := a.buildContactResponse(&contact, orgID)
 
 	return r.SendEnvelope(response)
 }


### PR DESCRIPTION
Identified the issue: Found that `GetContact` manually built the ContactResponse struct but missed last_inbound_at and service_window_open, whereas other endpoints used the helper `buildContactResponse`.

Fixed the code: Refactored the manual builder in `GetContact` to use `buildContactResponse`, which correctly populates these fields.

Validated: Verified that all tests under internal/handlers pass successfully.



------


Summary

Issue: When retrieving a single contact via the GET /api/contacts/:id endpoint, the service_window_open and last_inbound_at fields were returned with default values (false and null), even though they were correctly populated when retrieving the contact list via GET /api/contacts. The root cause was that the GetContact handler manually constructed the ContactResponse object without assigning these fields, causing them to fall back to their zero values.

Solution: Updated the GetContact handler to use the shared buildContactResponse helper (already used by other endpoints such as create and update). This ensures that service_window_open and last_inbound_at are computed and populated consistently from the database while eliminating duplicate response-building logic.

Exact Changes

Modified file:
📄 internal/handlers/contacts.go

Replaced the manual response construction in the GetContact handler with a call to the shared buildContactResponse helper.