### PR TITLE
fix(config): map multi-word env keys via __ separator (#476)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,10 +198,17 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
-	// Load from environment variables (WHATOMATE_ prefix)
-	// e.g., WHATOMATE_DATABASE_HOST -> database.host
+	// Load from environment variables (WHATOMATE_ prefix). A DOUBLE underscore
+	// separates config levels; single underscores are preserved as part of the
+	// key. This is required because both section and field names contain
+	// underscores (e.g. default_admin, rate_limit, whatsapp.app_id) — collapsing
+	// every "_" to "." would mangle them (whatsapp.app_id -> whatsapp.app.id), so
+	// those keys could never be set via env.
+	// e.g. WHATOMATE_DATABASE__HOST -> database.host
+	//      WHATOMATE_WHATSAPP__APP_ID -> whatsapp.app_id
+	//      WHATOMATE_DEFAULT_ADMIN__EMAIL -> default_admin.email
 	if err := k.Load(env.Provider("WHATOMATE_", ".", func(s string) string {
-		return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(s, "WHATOMATE_")), "_", ".")
+		return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(s, "WHATOMATE_")), "__", ".")
 	}), nil); err != nil {
 		return nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -102,8 +102,8 @@ secure = false
 }
 
 func TestLoad_EnvVarsOverrideFile(t *testing.T) {
-	t.Setenv("WHATOMATE_DATABASE_HOST", "from-env")
-	t.Setenv("WHATOMATE_SERVER_PORT", "1234")
+	t.Setenv("WHATOMATE_DATABASE__HOST", "from-env")
+	t.Setenv("WHATOMATE_SERVER__PORT", "1234")
 
 	cfg, err := config.Load(writeConfig(t, `
 [database]
@@ -113,8 +113,8 @@ host = "from-file"
 port = 8080
 `))
 	require.NoError(t, err)
-	assert.Equal(t, "from-env", cfg.Database.Host, "WHATOMATE_DATABASE_HOST must override file")
-	assert.Equal(t, 1234, cfg.Server.Port, "WHATOMATE_SERVER_PORT must override file")
+	assert.Equal(t, "from-env", cfg.Database.Host, "WHATOMATE_DATABASE__HOST must override file")
+	assert.Equal(t, 1234, cfg.Server.Port, "WHATOMATE_SERVER__PORT must override file")
 }
 
 func TestLoad_EmptyConfigPathStillLoadsDefaults(t *testing.T) {
@@ -176,4 +176,26 @@ func TestResolveCredentials_DefaultsTTLWhenUnset(t *testing.T) {
 	s := config.ICEServerConfig{Secret: "topsecret"}
 	username, _ := s.ResolveCredentials(now)
 	assert.Equal(t, "1086400", username) // now + default 86400s
+}
+
+// TestLoad_EnvMapsMultiWordKeys is the regression for the embedded-signup bug
+// (whatomate#476): env vars for keys whose section OR field name contains an
+// underscore must map correctly. Levels are separated by "__"; single
+// underscores stay part of the key. This exercises config.Load()'s env path,
+// which the handler-level tests bypass by setting the struct directly.
+func TestLoad_EnvMapsMultiWordKeys(t *testing.T) {
+	t.Setenv("WHATOMATE_WHATSAPP__APP_ID", "env-app-id")
+	t.Setenv("WHATOMATE_WHATSAPP__CONFIG_ID", "env-config-id")
+	t.Setenv("WHATOMATE_WHATSAPP__API_VERSION", "v21.0")
+	t.Setenv("WHATOMATE_DEFAULT_ADMIN__EMAIL", "admin@example.com")
+	t.Setenv("WHATOMATE_DATABASE__HOST", "db.internal")
+
+	cfg, err := config.Load("") // no file; env-only
+	require.NoError(t, err)
+
+	assert.Equal(t, "env-app-id", cfg.WhatsApp.AppID)
+	assert.Equal(t, "env-config-id", cfg.WhatsApp.ConfigID)
+	assert.Equal(t, "v21.0", cfg.WhatsApp.APIVersion)
+	assert.Equal(t, "admin@example.com", cfg.DefaultAdmin.Email)
+	assert.Equal(t, "db.internal", cfg.Database.Host)
 }


### PR DESCRIPTION
## Problem

`GET /api/embedded-signup/config` returns no `app_id`/`config_id` (only the default `whatsapp_api_version: v18.0`), so the Embedded Signup UI never appears — even though `config.toml` has them. Reported in #476.

## Root cause

The env-var provider in `internal/config/config.go` collapsed **every** `_` to `.`:

```go
strings.ReplaceAll(..., "_", ".")
```

So any key whose **section or field name contains an underscore** is mangled and dropped:

| Env var | Became | Needed |
|---|---|---|
| `WHATOMATE_WHATSAPP_APP_ID` | `whatsapp.app.id` | `whatsapp.app_id` ❌ |
| `WHATOMATE_WHATSAPP_CONFIG_ID` | `whatsapp.config.id` | `whatsapp.config_id` ❌ |
| `WHATOMATE_WHATSAPP_API_VERSION` | `whatsapp.api.version` | `whatsapp.api_version` ❌ |

Every field under `[whatsapp]` is multi-word, so an **env-configured** deploy gets an entirely empty whatsapp config — which is why `api_version` falls back to the hardcoded `v18.0` default and `app_id`/`config_id` are omitted. (File-based `config.toml` parses fine, so this only bit env-configured deployments.)

A single-underscore convention can't disambiguate, because section names also contain underscores (`default_admin`, `rate_limit`).

## Fix

Separate config levels with a **double underscore** (the listmonk convention this codebase follows); single underscores stay part of the key:

```go
strings.ReplaceAll(..., "__", ".")
```

- `WHATOMATE_WHATSAPP__APP_ID` → `whatsapp.app_id` ✓
- `WHATOMATE_DEFAULT_ADMIN__EMAIL` → `default_admin.email` ✓
- `WHATOMATE_DATABASE__HOST` → `database.host` ✓

## Tests

- Adds `TestLoad_EnvMapsMultiWordKeys` — exercises `config.Load()`'s env path with multi-word section/field keys. The existing handler test (`client_config_test.go`) set the struct fields directly and never went through `Load()`, which is why this slipped past CI.
- Updates `TestLoad_EnvVarsOverrideFile` to the `__` convention.

## ⚠️ Breaking change

Env vars now use `__` between config levels (`WHATOMATE_DATABASE_HOST` → `WHATOMATE_DATABASE__HOST`). **File-based `config.toml` is unaffected**, and the stock `docker-compose.yml` mounts a `config.toml` (not env), so the default deploy path is unchanged.

Related to #476.

> [!NOTE]
> Scope: this fixes the **env-var** config path. File-based `config.toml` loading of `app_id`/`config_id` was verified to already work, so this likely does NOT resolve #476 if the reporter is file-configured (their root cause would be the edited config.toml not being the effective one the container loads). Kept as a real latent bug fix; not auto-closing #476 until the reporter confirms env vs file.