### PR TITLE
Feat/ Canned Responses with Images

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -754,6 +754,7 @@ func setupRoutes(g *fastglue.Fastglue, app *handlers.App, lo logf.Logger, basePa
 	g.PUT("/api/canned-responses/{id}", app.UpdateCannedResponse)
 	g.DELETE("/api/canned-responses/{id}", app.DeleteCannedResponse)
 	g.POST("/api/canned-responses/{id}/use", app.IncrementCannedResponseUsage)
+	g.POST("/api/canned-responses/upload-media", app.UploadCannedResponseMedia)
 
 	// Sessions (admin/debug)
 	g.GET("/api/chatbot/sessions", app.ListChatbotSessions)

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -391,7 +391,8 @@ export class ApiHelper {
     content: string
     shortcut?: string
     category?: string
-  }): Promise<{ id: string; name: string; shortcut: string; content: string; category: string }> {
+    image_url?: string
+  }): Promise<{ id: string; name: string; shortcut: string; content: string; category: string; image_url?: string }> {
     const response = await this.request.post(`${BASE_URL}/api/canned-responses`, {
       headers: this.csrfHeaders,
       data: { category: 'general', ...data }

--- a/frontend/e2e/tests/chat/chat.spec.ts
+++ b/frontend/e2e/tests/chat/chat.spec.ts
@@ -347,6 +347,7 @@ test.describe('Canned Response Preview', () => {
   let plain: { id: string; name: string; shortcut: string }
   let withParam: { id: string; name: string; shortcut: string }
   let withContactName: { id: string; name: string; shortcut: string }
+  let withImage: { id: string; name: string; shortcut: string }
 
   test.beforeEach(async ({ page, request }) => {
     api = new ApiHelper(request)
@@ -374,6 +375,13 @@ test.describe('Canned Response Preview', () => {
       shortcut: greetName.toLowerCase(),
       content: 'Hi {{contact_name}}, how can I help?',
     })
+    const imageName = cannedScope.name()
+    withImage = await api.createCannedResponse({
+      name: imageName,
+      shortcut: imageName.toLowerCase(),
+      content: 'Canned response caption',
+      image_url: 'images/test-canned-response.png',
+    })
 
     await login(page, ADMIN_USER)
     chatPage = new ChatPage(page)
@@ -381,7 +389,7 @@ test.describe('Canned Response Preview', () => {
   })
 
   test.afterEach(async () => {
-    for (const id of [plain?.id, withParam?.id, withContactName?.id]) {
+    for (const id of [plain?.id, withParam?.id, withContactName?.id, withImage?.id]) {
       if (id) await api.deleteCannedResponse(id).catch(() => {})
     }
   })
@@ -452,5 +460,55 @@ test.describe('Canned Response Preview', () => {
 
     await chatPage.cancelCannedDialog()
     await expect(chatPage.messageInput).toHaveValue('')
+  })
+
+  test('renders image preview and posts to media send endpoint', async ({ page }) => {
+    // Intercept media fetch
+    await page.route('**/api/chatbot/media/images/test-canned-response.png', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/png',
+        body: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==', 'base64'),
+      })
+    })
+    let postedBody: any = null
+    // Intercept messages media POST
+    await page.route(`**/api/messages/media`, async (route) => {
+      postedBody = route.request().postData()
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'success',
+          data: {
+            id: 'msg-media-123',
+            direction: 'outgoing',
+            type: 'image',
+            content: {
+              media_url: 'images/test-canned-response.png',
+              caption: 'Canned response caption',
+            },
+            timestamp: new Date().toISOString(),
+          },
+        }),
+      })
+    })
+    await chatPage.openCannedResponses()
+    await chatPage.selectCannedPickerItem(withImage.name)
+    await chatPage.cannedDialog.waitFor({ state: 'visible' })
+    // Check preview image is visible
+    const previewImg = chatPage.cannedDialog.locator('img')
+    await expect(previewImg).toBeVisible()
+    const imgSrc = await previewImg.getAttribute('src')
+    expect(imgSrc).toContain('/api/chatbot/media/images/test-canned-response.png')
+    // Click send
+    await chatPage.sendCannedDialog()
+    // Verify media POST was triggered
+    await expect.poll(() => postedBody, { timeout: 5000 }).not.toBeNull()
+    expect(postedBody).toContain('name="contact_id"')
+    expect(postedBody).toContain('name="type"')
+    expect(postedBody).toContain('image')
+    expect(postedBody).toContain('name="caption"')
+    expect(postedBody).toContain('Canned response caption')
   })
 })

--- a/frontend/src/components/chat/CannedResponsePicker.vue
+++ b/frontend/src/components/chat/CannedResponsePicker.vue
@@ -9,7 +9,10 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { cannedResponsesService, type CannedResponse } from '@/services/api'
-import { MessageSquareText, Search, Loader2 } from 'lucide-vue-next'
+import { MessageSquareText, Search, Loader2, ImageIcon } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   externalOpen?: boolean
@@ -72,7 +75,7 @@ const filteredResponses = computed(() => {
   const query = searchQuery.value.toLowerCase()
   return responses.value.filter(r =>
     r.name.toLowerCase().includes(query) ||
-    r.content.toLowerCase().includes(query) ||
+    (r.content && r.content.toLowerCase().includes(query)) ||
     (r.shortcut && r.shortcut.toLowerCase().includes(query))
   )
 })
@@ -151,12 +154,22 @@ function selectResponse(response: CannedResponse) {
             >
               <div class="flex items-center justify-between">
                 <span class="font-medium text-sm">{{ response.name }}</span>
-                <span v-if="response.shortcut" class="text-xs font-mono text-muted-foreground">
-                  /{{ response.shortcut }}
-                </span>
+                <div class="flex items-center gap-1.5">
+                  <!-- Image badge -->
+                  <span
+                    v-if="response.image_url"
+                    class="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground bg-muted rounded px-1 py-0.5"
+                    :title="t('cannedResponses.hasImage')"
+                  >
+                    <ImageIcon class="h-3 w-3" />
+                  </span>
+                  <span v-if="response.shortcut" class="text-xs font-mono text-muted-foreground">
+                    /{{ response.shortcut }}
+                  </span>
+                </div>
               </div>
               <p class="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-                {{ response.content }}
+                {{ response.content || t('cannedResponses.hasImage') }}
               </p>
             </button>
           </template>

--- a/frontend/src/components/chat/CannedResponsePicker.vue
+++ b/frontend/src/components/chat/CannedResponsePicker.vue
@@ -9,7 +9,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { cannedResponsesService, type CannedResponse } from '@/services/api'
-import { MessageSquareText, Search, Loader2, ImageIcon } from 'lucide-vue-next'
+import { MessageSquareText, Search, Loader2, Image as ImageIcon } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -443,6 +443,7 @@ export interface CannedResponse {
   is_active: boolean
   usage_count: number
   buttons?: CannedResponseButton[]
+  image_url?: string
   created_at: string
   updated_at: string
 }
@@ -454,18 +455,26 @@ interface CannedResponseUpsertPayload {
   category?: string
   is_active?: boolean
   buttons?: CannedResponseButton[]
+  image_url?: string
 }
 
 export const cannedResponsesService = {
   list: (params?: { category?: string; search?: string; active_only?: string; page?: number; limit?: number }) =>
     api.get<{ canned_responses: CannedResponse[]; total?: number }>('/canned-responses', { params }),
   get: (id: string) => api.get<CannedResponse>(`/canned-responses/${id}`),
-  create: (data: CannedResponseUpsertPayload & { name: string; content: string }) =>
+  create: (data: CannedResponseUpsertPayload & { name: string }) =>
     api.post('/canned-responses', data),
   update: (id: string, data: CannedResponseUpsertPayload) =>
     api.put(`/canned-responses/${id}`, data),
   delete: (id: string) => api.delete(`/canned-responses/${id}`),
-  use: (id: string) => api.post(`/canned-responses/${id}/use`)
+  use: (id: string) => api.post(`/canned-responses/${id}/use`),
+  uploadMedia: (file: File) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    return api.post<{ image_url: string }>('/canned-responses/upload-media', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+  }
 }
 
 export const agentAnalyticsService = {

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -115,6 +115,8 @@ const tagsStore = useTagsStore()
 const notesStore = useNotesStore()
 const { isDark } = useColorMode()
 
+const basePath = ((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')
+
 const canWriteContacts = authStore.hasPermission('contacts', 'write')
 
 const messageInput = ref('')
@@ -2640,7 +2642,7 @@ async function sendMediaMessage() {
           <!-- Image preview in dialog -->
           <div v-if="selectedCannedResponse?.image_url" class="rounded-lg overflow-hidden border border-white/10">
             <img
-              :src="`${((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')}/api/chatbot/media/${selectedCannedResponse?.image_url?.replace(/\\/g, '/') || ''}`"
+              :src="`${basePath}/api/chatbot/media/${selectedCannedResponse?.image_url?.replace(/\\/g, '/') || ''}`"
               class="w-full max-h-48 object-contain bg-black/40"
               alt=""
             />

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -805,8 +805,9 @@ function scrollToMessage(messageId: string | undefined) {
   }
 }
 
-function extractCannedTokens(content: string): string[] {
+function extractCannedTokens(content: string | null | undefined): string[] {
   const seen = new Set<string>()
+  if (!content) return []
   const matches = content.matchAll(/\{\{\s*([\w.-]+)\s*\}\}/g)
   for (const m of matches) seen.add(m[1])
   return Array.from(seen)
@@ -814,8 +815,7 @@ function extractCannedTokens(content: string): string[] {
 
 // Collect tokens from the message body AND every button field, so the param
 // dialog prompts for custom tokens used anywhere on the response.
-function extractCannedTokens(content: string | null | undefined): string[] {
-  if (!content) return []
+function extractCannedTokensFromResponse(r: CannedResponse): string[] {
   const seen = new Set<string>(extractCannedTokens(r.content))
   for (const btn of r.buttons || []) {
     for (const t of extractCannedTokens(btn.title || '')) seen.add(t)

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -814,7 +814,8 @@ function extractCannedTokens(content: string): string[] {
 
 // Collect tokens from the message body AND every button field, so the param
 // dialog prompts for custom tokens used anywhere on the response.
-function extractCannedTokensFromResponse(r: CannedResponse): string[] {
+function extractCannedTokens(content: string | null | undefined): string[] {
+  if (!content) return []
   const seen = new Set<string>(extractCannedTokens(r.content))
   for (const btn of r.buttons || []) {
     for (const t of extractCannedTokens(btn.title || '')) seen.add(t)
@@ -2639,7 +2640,7 @@ async function sendMediaMessage() {
           <!-- Image preview in dialog -->
           <div v-if="selectedCannedResponse?.image_url" class="rounded-lg overflow-hidden border border-white/10">
             <img
-              :src="`${((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')}/api/chatbot/media/${selectedCannedResponse.image_url.replace(/\\/g, '/')}`"
+              :src="`${((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')}/api/chatbot/media/${selectedCannedResponse?.image_url?.replace(/\\/g, '/') || ''}`"
               class="w-full max-h-48 object-contain bg-black/40"
               alt=""
             />

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -890,80 +890,118 @@ async function sendCannedResponse() {
 
   const body = cannedPreview.value
   const responseId = selectedCannedResponse.value.id
-  // Substitute {{...}} tokens in every button field — same rules as the body —
-  // so URLs like https://x.com/u/{{phone_number}} resolve at send time.
-  const buttons = (selectedCannedResponse.value.buttons || []).map(b => ({
-    ...b,
-    title: resolveCannedTokens(b.title),
-    ...(b.url !== undefined ? { url: resolveCannedTokens(b.url) } : {}),
-    ...(b.phone_number !== undefined ? { phone_number: resolveCannedTokens(b.phone_number) } : {}),
-  }))
-  const replyButtons = buttons.filter(b => !b.type || b.type === 'reply')
-  const urlButtons = buttons.filter(b => b.type === 'url')
-
-  // WhatsApp Cloud API supports: 1-3 reply buttons (interactive.button),
-  // 4-10 reply rows (interactive.list — backend's SendInteractiveButtons
-  // auto-picks the right shape), a single cta_url, or a single voice_call
-  // (Business Calling click-to-call). Phone buttons and multi-URL / mixed
-  // combos aren't representable; the detail-page validator blocks save for
-  // those, so the text fallback here is just a safety net.
-  const voiceCallButtons = buttons.filter(b => b.type === 'voice_call')
-  const flowButtons = buttons.filter(b => b.type === 'flow')
-  let sendType: 'text' | 'interactive' = 'text'
-  let interactive: {
-    type: 'button' | 'list' | 'cta_url' | 'voice_call' | 'flow'
-    body: string
-    buttons?: Array<{ id: string; title: string }>
-    button_text?: string
-    url?: string
-    display_text?: string
-    ttl_minutes?: number
-    flow_id?: string
-    first_screen?: string
-  } | undefined
-
-  if (buttons.length === 1 && flowButtons.length === 1) {
-    const f = flowButtons[0]
-    sendType = 'interactive'
-    interactive = {
-      type: 'flow',
-      body,
-      // The button title is the CTA label shown to the customer.
-      button_text: resolveCannedTokens(f.title),
-      flow_id: f.flow_id,
-      first_screen: f.screen,
-    }
-  } else if (buttons.length === 1 && voiceCallButtons.length === 1) {
-    const vc = voiceCallButtons[0]
-    sendType = 'interactive'
-    interactive = {
-      type: 'voice_call',
-      body,
-      // {{...}} tokens already resolved in the canned-preview path; the
-      // button title is what becomes Meta's display_text. Backend
-      // truncates to 20 chars and stamps the agent-id payload.
-      display_text: resolveCannedTokens(vc.title),
-      ttl_minutes: vc.ttl_minutes ?? 15,
-    }
-  } else if (buttons.length > 0 && replyButtons.length === buttons.length && replyButtons.length <= 10) {
-    sendType = 'interactive'
-    interactive = {
-      type: replyButtons.length <= 3 ? 'button' : 'list',
-      body,
-      buttons: replyButtons.map(b => ({ id: b.id, title: b.title })),
-    }
-  } else if (buttons.length === 1 && urlButtons.length === 1) {
-    sendType = 'interactive'
-    interactive = {
-      type: 'cta_url',
-      body,
-      button_text: urlButtons[0].title,
-      url: urlButtons[0].url || '',
-    }
-  }
+  const imageUrl = selectedCannedResponse.value.image_url
 
   isSendingCanned.value = true
   try {
+    // ---- Image path: fetch stored image and send as media message ----
+    if (imageUrl) {
+      const mediaSrcUrl = `${((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')}/api/chatbot/media/${imageUrl.replace(/\\/g, '/')}`
+      const imgRes = await fetch(mediaSrcUrl, { credentials: 'include' })
+      if (!imgRes.ok) throw new Error('Failed to fetch canned response image')
+      const blob = await imgRes.blob()
+      const filename = imageUrl.split('/').pop() || 'image.jpg'
+      const file = new File([blob], filename, { type: blob.type || 'image/jpeg' })
+
+      const formData = new FormData()
+      formData.append('file', file)
+      formData.append('contact_id', contactsStore.currentContact.id)
+      formData.append('type', 'image')
+      if (body.trim()) {
+        formData.append('caption', body.trim())
+      }
+      if (selectedAccount.value) {
+        formData.append('whatsapp_account', selectedAccount.value)
+      }
+
+      const mediaRes = await fetch(`${((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')}/api/messages/media`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: getRequestHeaders({ csrf: true }),
+        body: formData,
+      })
+      if (!mediaRes.ok) {
+        const err = await mediaRes.json().catch(() => ({}))
+        throw new Error(err.message || 'Failed to send image')
+      }
+      const mediaResult = await mediaRes.json()
+      if (mediaResult.data) {
+        contactsStore.addMessage(mediaResult.data)
+        scrollToBottom()
+      }
+      cannedResponsesService.use(responseId).catch(() => {})
+      contactsStore.clearReplyingTo()
+      cannedDialogOpen.value = false
+      selectedCannedResponse.value = null
+      cannedParamNames.value = []
+      cannedParamValues.value = {}
+      await nextTick()
+      scrollToBottom()
+      return
+    }
+
+    // ---- Text / interactive path (no image) ----
+    // Substitute {{...}} tokens in every button field — same rules as the body —
+    // so URLs like https://x.com/u/{{phone_number}} resolve at send time.
+    const buttons = (selectedCannedResponse.value.buttons || []).map(b => ({
+      ...b,
+      title: resolveCannedTokens(b.title),
+      ...(b.url !== undefined ? { url: resolveCannedTokens(b.url) } : {}),
+      ...(b.phone_number !== undefined ? { phone_number: resolveCannedTokens(b.phone_number) } : {}),
+    }))
+    const replyButtons = buttons.filter(b => !b.type || b.type === 'reply')
+    const urlButtons = buttons.filter(b => b.type === 'url')
+    const voiceCallButtons = buttons.filter(b => b.type === 'voice_call')
+    const flowButtons = buttons.filter(b => b.type === 'flow')
+    let sendType: 'text' | 'interactive' = 'text'
+    let interactive: {
+      type: 'button' | 'list' | 'cta_url' | 'voice_call' | 'flow'
+      body: string
+      buttons?: Array<{ id: string; title: string }>
+      button_text?: string
+      url?: string
+      display_text?: string
+      ttl_minutes?: number
+      flow_id?: string
+      first_screen?: string
+    } | undefined
+
+    if (buttons.length === 1 && flowButtons.length === 1) {
+      const f = flowButtons[0]
+      sendType = 'interactive'
+      interactive = {
+        type: 'flow',
+        body,
+        button_text: resolveCannedTokens(f.title),
+        flow_id: f.flow_id,
+        first_screen: f.screen,
+      }
+    } else if (buttons.length === 1 && voiceCallButtons.length === 1) {
+      const vc = voiceCallButtons[0]
+      sendType = 'interactive'
+      interactive = {
+        type: 'voice_call',
+        body,
+        display_text: resolveCannedTokens(vc.title),
+        ttl_minutes: vc.ttl_minutes ?? 15,
+      }
+    } else if (buttons.length > 0 && replyButtons.length === buttons.length && replyButtons.length <= 10) {
+      sendType = 'interactive'
+      interactive = {
+        type: replyButtons.length <= 3 ? 'button' : 'list',
+        body,
+        buttons: replyButtons.map(b => ({ id: b.id, title: b.title })),
+      }
+    } else if (buttons.length === 1 && urlButtons.length === 1) {
+      sendType = 'interactive'
+      interactive = {
+        type: 'cta_url',
+        body,
+        button_text: urlButtons[0].title,
+        url: urlButtons[0].url || '',
+      }
+    }
+
     await contactsStore.sendMessage(
       contactsStore.currentContact.id,
       sendType,
@@ -2596,6 +2634,14 @@ async function sendMediaMessage() {
               v-model="cannedParamValues[param]"
               :placeholder="param"
               class="h-9 canned-response-param"
+            />
+          </div>
+          <!-- Image preview in dialog -->
+          <div v-if="selectedCannedResponse?.image_url" class="rounded-lg overflow-hidden border border-white/10">
+            <img
+              :src="`${((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')}/api/chatbot/media/${selectedCannedResponse.image_url.replace(/\\/g, '/')}`"
+              class="w-full max-h-48 object-contain bg-black/40"
+              alt=""
             />
           </div>
           <div v-if="cannedPreview || cannedPreviewButtons.length" class="space-y-1">

--- a/frontend/src/views/settings/CannedResponseDetailView.vue
+++ b/frontend/src/views/settings/CannedResponseDetailView.vue
@@ -38,7 +38,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { MessageSquareText, Trash2, Save } from 'lucide-vue-next'
+import { MessageSquareText, Trash2, Save, ImagePlus, X as XIcon } from 'lucide-vue-next'
 import { CANNED_RESPONSE_CATEGORIES } from '@/lib/constants'
 
 const route = useRoute()
@@ -67,7 +67,24 @@ const form = ref({
   category: '',
   is_active: true,
   buttons: [] as ButtonConfig[],
+  image_url: '',
 })
+
+// Image upload state
+const imageInputRef = ref<HTMLInputElement | null>(null)
+const pendingImageFile = ref<File | null>(null)
+const imagePreviewUrl = ref<string | null>(null)
+const isUploadingImage = ref(false)
+
+// Build a displayable URL for the saved image_url path
+const basePath = ((window as any).__BASE_PATH__ ?? '').replace(/\/$/, '')
+const savedImageDisplayUrl = computed(() => {
+  if (!form.value.image_url) return null
+  return `${basePath}/api/chatbot/media/${form.value.image_url.replace(/\\/g, '/')}`
+})
+
+// The preview shown in the card: pending file takes priority over the saved URL
+const displayImageUrl = computed(() => imagePreviewUrl.value ?? savedImageDisplayUrl.value)
 
 const breadcrumbs = computed(() => [
   { label: t('nav.settings'), href: '/settings' },
@@ -109,6 +126,13 @@ function syncForm() {
     category: response.value.category || '',
     is_active: response.value.is_active,
     buttons: (response.value.buttons || []).map(b => ({ ...b })),
+    image_url: response.value.image_url || '',
+  }
+  // Clear any pending (unsaved) image selection when reloading
+  pendingImageFile.value = null
+  if (imagePreviewUrl.value) {
+    URL.revokeObjectURL(imagePreviewUrl.value)
+    imagePreviewUrl.value = null
   }
 }
 
@@ -211,8 +235,54 @@ const buttonsValidationError = computed<string | null>(() => {
 
 const canSave = computed(() => !buttonsValidationError.value)
 
+// ---- Image helpers ----
+function openImagePicker() {
+  imageInputRef.value?.click()
+}
+
+function handleImageSelect(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  if (!file.type.startsWith('image/')) {
+    toast.error(t('cannedResponses.imageOnly'))
+    input.value = ''
+    return
+  }
+  const maxSize = 5 * 1024 * 1024
+  if (file.size > maxSize) {
+    toast.error(t('cannedResponses.imageTooLarge'))
+    input.value = ''
+    return
+  }
+
+  // Revoke previous preview
+  if (imagePreviewUrl.value) URL.revokeObjectURL(imagePreviewUrl.value)
+  pendingImageFile.value = file
+  imagePreviewUrl.value = URL.createObjectURL(file)
+  // Mark form dirty so the unsaved-changes guard fires
+  hasChanges.value = true
+  input.value = ''
+}
+
+function removeImage() {
+  if (imagePreviewUrl.value) {
+    URL.revokeObjectURL(imagePreviewUrl.value)
+    imagePreviewUrl.value = null
+  }
+  pendingImageFile.value = null
+  form.value.image_url = ''
+  hasChanges.value = true
+}
+
 async function save() {
-  if (!form.value.name.trim() || !form.value.content.trim()) {
+  if (!form.value.name.trim()) {
+    toast.error(t('cannedResponses.nameContentRequired'))
+    return
+  }
+  // Content is required only when no image is set (including pending upload)
+  if (!form.value.content.trim() && !form.value.image_url && !pendingImageFile.value) {
     toast.error(t('cannedResponses.nameContentRequired'))
     return
   }
@@ -222,6 +292,22 @@ async function save() {
   }
   isSaving.value = true
   try {
+    // Upload the image first if a new one was selected
+    let finalImageUrl = form.value.image_url
+    if (pendingImageFile.value) {
+      isUploadingImage.value = true
+      try {
+        const uploadRes = await cannedResponsesService.uploadMedia(pendingImageFile.value)
+        const uploadData = (uploadRes.data as any).data || uploadRes.data
+        finalImageUrl = uploadData.image_url
+      } catch (uploadErr) {
+        toast.error(t('cannedResponses.imageUploadFailed'))
+        return
+      } finally {
+        isUploadingImage.value = false
+      }
+    }
+
     if (isNew.value) {
       const res = await cannedResponsesService.create({
         name: form.value.name,
@@ -229,12 +315,10 @@ async function save() {
         content: form.value.content,
         category: form.value.category || undefined,
         buttons: form.value.buttons,
+        image_url: finalImageUrl || undefined,
       })
       toast.success(t('common.createdSuccess', { resource: t('resources.CannedResponse') }))
       const created = (res.data as any).data || res.data
-      // Set the response locally so the (reused) component switches to edit
-      // mode without re-fetching. responseId watcher below guards against a
-      // duplicate load when the route param flips from "new" to the new UUID.
       response.value = created
       await nextTick()
       hasChanges.value = false
@@ -247,6 +331,7 @@ async function save() {
         category: form.value.category,
         is_active: form.value.is_active,
         buttons: form.value.buttons,
+        image_url: finalImageUrl,
       })
       toast.success(t('common.updatedSuccess', { resource: t('resources.CannedResponse') }))
       await loadResponse()
@@ -353,7 +438,11 @@ onMounted(() => { loadResponse() })
             </div>
           </div>
           <div class="space-y-1.5">
-            <Label class="text-xs">{{ $t('cannedResponses.content') }} <span class="text-destructive">*</span></Label>
+            <Label class="text-xs">
+              {{ $t('cannedResponses.content') }}
+              <span v-if="!displayImageUrl" class="text-destructive">*</span>
+              <span v-else class="text-muted-foreground">({{ $t('chat.mediaCaption') }})</span>
+            </Label>
             <Textarea v-model="form.content" :placeholder="$t('cannedResponses.contentPlaceholder')" :rows="6" :disabled="!canWrite" />
             <p class="text-[11px] text-muted-foreground">{{ $t('cannedResponses.placeholderHint') }}</p>
           </div>
@@ -365,6 +454,56 @@ onMounted(() => { loadResponse() })
               :disabled="!canWrite"
             />
           </div>
+        </CardContent>
+      </Card>
+
+      <!-- Image Upload -->
+      <Card>
+        <CardHeader class="pb-3">
+          <CardTitle class="text-sm font-medium">{{ $t('cannedResponses.image') }}</CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-3">
+          <!-- Hidden file input -->
+          <input
+            ref="imageInputRef"
+            type="file"
+            accept="image/*"
+            class="hidden"
+            @change="handleImageSelect"
+          />
+
+          <!-- Image preview -->
+          <div v-if="displayImageUrl" class="relative inline-block">
+            <img
+              :src="displayImageUrl"
+              class="max-h-48 rounded-lg object-contain border border-border"
+              alt=""
+            />
+            <button
+              v-if="canWrite"
+              type="button"
+              class="absolute top-1 right-1 h-6 w-6 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center shadow-sm hover:bg-destructive/80 transition-colors"
+              @click="removeImage"
+              :title="$t('cannedResponses.removeImage')"
+            >
+              <XIcon class="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          <!-- Upload / change button -->
+          <Button
+            v-if="canWrite"
+            type="button"
+            variant="outline"
+            size="sm"
+            :disabled="isUploadingImage"
+            @click="openImagePicker"
+          >
+            <ImagePlus class="h-4 w-4 mr-1.5" />
+            {{ displayImageUrl ? $t('cannedResponses.changeImage') : $t('cannedResponses.uploadImage') }}
+          </Button>
+
+          <p class="text-[11px] text-muted-foreground">{{ $t('cannedResponses.imageHint') }}</p>
         </CardContent>
       </Card>
 

--- a/internal/handlers/canned_responses.go
+++ b/internal/handlers/canned_responses.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -41,6 +42,7 @@ type CannedResponseRequest struct {
 	Category string                 `json:"category"`
 	IsActive bool                   `json:"is_active"`
 	Buttons  []CannedResponseButton `json:"buttons"`
+	ImageURL string                 `json:"image_url"`
 }
 
 // CannedResponseResponse represents the API response for a canned response
@@ -53,6 +55,7 @@ type CannedResponseResponse struct {
 	IsActive   bool                   `json:"is_active"`
 	UsageCount int                    `json:"usage_count"`
 	Buttons    []CannedResponseButton `json:"buttons"`
+	ImageURL   string                 `json:"image_url"`
 	CreatedAt  string                 `json:"created_at"`
 	UpdatedAt  string                 `json:"updated_at"`
 }
@@ -123,9 +126,13 @@ func (a *App) CreateCannedResponse(r *fastglue.Request) error {
 		return nil
 	}
 
-	if req.Name == "" || req.Content == "" {
+	// name is always required; content is required only when there's no image
+	if req.Name == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "name is required", nil, "")
+	}
+	if req.Content == "" && req.ImageURL == "" {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest,
-			"name and content are required", nil, "")
+			"content is required when no image is attached", nil, "")
 	}
 
 	if err := validateCannedResponseButtons(req.Buttons); err != nil {
@@ -148,6 +155,7 @@ func (a *App) CreateCannedResponse(r *fastglue.Request) error {
 		Category:       req.Category,
 		IsActive:       true,
 		Buttons:        buttonsToJSONBArray(req.Buttons),
+		ImageURL:       req.ImageURL,
 		CreatedByID:    userID,
 	}
 
@@ -226,6 +234,7 @@ func (a *App) UpdateCannedResponse(r *fastglue.Request) error {
 	cannedResponse.Category = req.Category
 	cannedResponse.IsActive = req.IsActive
 	cannedResponse.Buttons = buttonsToJSONBArray(req.Buttons)
+	cannedResponse.ImageURL = req.ImageURL
 
 	if err := a.DB.Save(&cannedResponse).Error; err != nil {
 		a.Log.Error("Failed to update canned response", "error", err)
@@ -311,6 +320,7 @@ func cannedResponseAuditSnapshot(cr *models.CannedResponse) map[string]any {
 		"content":       cr.Content,
 		"category":      cr.Category,
 		"is_active":     cr.IsActive,
+		"image_url":     cr.ImageURL,
 		"button_config": buttonsToAuditString(cr.Buttons),
 	}
 }
@@ -325,9 +335,67 @@ func cannedResponseToResponse(cr models.CannedResponse) CannedResponseResponse {
 		IsActive:   cr.IsActive,
 		UsageCount: cr.UsageCount,
 		Buttons:    jsonbArrayToButtons(cr.Buttons),
+		ImageURL:   cr.ImageURL,
 		CreatedAt:  cr.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:  cr.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}
+}
+
+// UploadCannedResponseMedia handles image uploads for canned responses.
+// The stored relative path (e.g. "images/uuid.jpg") is returned as image_url
+// and should be saved on the canned response record via the create/update API.
+func (a *App) UploadCannedResponseMedia(r *fastglue.Request) error {
+	_, err := a.getOrgID(r)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
+	}
+
+	form, err := r.RequestCtx.MultipartForm()
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid multipart form", nil, "")
+	}
+
+	files := form.File["file"]
+	if len(files) == 0 {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "No file provided", nil, "")
+	}
+
+	fileHeader := files[0]
+
+	// Only allow image files
+	mimeType := fileHeader.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	if !strings.HasPrefix(mimeType, "image/") {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Only image files are allowed", nil, "")
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Failed to open file", nil, "")
+	}
+	defer func() { _ = file.Close() }()
+
+	const maxMediaSize = 5 << 20 // 5 MB for images
+	data, err := io.ReadAll(io.LimitReader(file, maxMediaSize+1))
+	if err != nil {
+		a.Log.Error("Failed to read canned response image", "error", err)
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file", nil, "")
+	}
+	if len(data) > maxMediaSize {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Image too large. Maximum size is 5MB", nil, "")
+	}
+
+	relativePath, err := a.saveMediaLocally(data, mimeType, fileHeader.Filename)
+	if err != nil {
+		a.Log.Error("Failed to save canned response image", "error", err)
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to save image", nil, "")
+	}
+
+	return r.SendEnvelope(map[string]any{
+		"image_url": relativePath,
+	})
 }
 
 // buttonsToJSONBArray converts the typed request shape into the JSONBArray

--- a/internal/handlers/canned_responses_test.go
+++ b/internal/handlers/canned_responses_test.go
@@ -1435,3 +1435,77 @@ func TestApp_IncrementCannedResponseUsage(t *testing.T) {
 		assert.Equal(t, fasthttp.StatusUnauthorized, testutil.GetResponseStatusCode(req))
 	})
 }
+
+func TestApp_CannedResponse_WithImage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create success with image only", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"name":      "Image Only Response",
+			"image_url": "images/test-image.jpg",
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		err := app.CreateCannedResponse(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+		var resp struct {
+			Data handlers.CannedResponseResponse `json:"data"`
+		}
+		err = json.Unmarshal(testutil.GetResponseBody(req), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "Image Only Response", resp.Data.Name)
+		assert.Equal(t, "images/test-image.jpg", resp.Data.ImageURL)
+		assert.Equal(t, "", resp.Data.Content)
+	})
+
+	t.Run("create fails when both content and image_url are empty", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"name": "Empty Response",
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+
+		err := app.CreateCannedResponse(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusBadRequest, testutil.GetResponseStatusCode(req))
+	})
+
+	t.Run("update success with image", func(t *testing.T) {
+		app := newTestApp(t)
+		org := testutil.CreateTestOrganization(t, app.DB)
+		user := testutil.CreateTestUser(t, app.DB, org.ID)
+
+		cr := createTestCannedResponse(t, app, org.ID, user.ID, "Original Text", "/orig", "Original content", "general")
+
+		req := testutil.NewJSONRequest(t, map[string]any{
+			"name":      "Original Text",
+			"content":   "Caption for image",
+			"image_url": "images/updated-image.jpg",
+			"is_active": true,
+		})
+		testutil.SetAuthContext(req, org.ID, user.ID)
+		testutil.SetPathParam(req, "id", cr.ID.String())
+
+		err := app.UpdateCannedResponse(req)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusOK, testutil.GetResponseStatusCode(req))
+
+		var resp struct {
+			Data handlers.CannedResponseResponse `json:"data"`
+		}
+		err = json.Unmarshal(testutil.GetResponseBody(req), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "Caption for image", resp.Data.Content)
+		assert.Equal(t, "images/updated-image.jpg", resp.Data.ImageURL)
+	})
+}
+

--- a/internal/models/canned_responses.go
+++ b/internal/models/canned_responses.go
@@ -18,7 +18,11 @@ type CannedResponse struct {
 	// [{id, title, type:'reply'|'url'|'phone'|'voice_call', url?, phone_number?, ttl_minutes?}]
 	// 'voice_call' is canned-response-only (chatbot flows don't support it) and
 	// is exclusive — it can't coexist with other button types in the same row.
-	Buttons     JSONBArray `gorm:"type:jsonb;default:'[]'" json:"buttons"`
+	Buttons  JSONBArray `gorm:"type:jsonb;default:'[]'" json:"buttons"`
+	// ImageURL stores the local relative media path (e.g. "images/uuid.jpg") of an
+	// optional image that is sent together with this canned response. Empty string
+	// means no image. The content/body field acts as caption when an image is set.
+	ImageURL    string    `gorm:"size:500" json:"image_url"`
 	CreatedByID uuid.UUID  `gorm:"type:uuid" json:"created_by_id"`
 
 	// Relations


### PR DESCRIPTION
# Pull Request Summary - Canned Responses with Images

This Pull Request introduces image attachment support for Canned Responses. Users can upload an image alongside their pre-defined responses, which will be sent to customers as WhatsApp media messages.

## Backend Changes

### Models

#### [canned_responses.go](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/internal/models/canned_responses.go)
- Added `ImageURL` field (string) to `CannedResponse` model to hold relative image media paths.

### Handlers & Routes

#### [canned_responses.go](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/internal/handlers/canned_responses.go)
- Updated `CreateCannedResponse` and `UpdateCannedResponse` handlers to accept `image_url`.
- Loosened validations so a response is valid with a name and either content OR an image.
- Implemented `/api/canned-responses/upload-media` handler to handle image media upload.

#### [main.go](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/cmd/whatomate/main.go)
- Registered POST endpoint `/api/canned-responses/upload-media` for media uploads.

### Backend Tests

#### [canned_responses_test.go](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/internal/handlers/canned_responses_test.go)
- Added `TestApp_CannedResponse_WithImage` covering:
  - Create canned response with image only (success).
  - Create canned response validation checks (failure when both content and image are empty).
  - Update canned response with image and caption.

---

## Frontend Changes

### Localization

#### [en.json](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/frontend/src/i18n/locales/en.json) & [ar.json](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/frontend/src/i18n/locales/ar.json)
- Added 9 new localization keys (`image`, `imageHint`, `uploadImage`, `changeImage`, `removeImage`, `imageUploadFailed`, `imageOnly`, `imageTooLarge`, `hasImage`).
- Updated validation keys (e.g. `nameContentRequired` to reflect image-only availability).

### Components

#### [ChatView.vue](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/frontend/src/views/chat/ChatView.vue)
- Updated `sendCannedResponse` to detect if an image is present.
- If `image_url` is set, fetches the locally uploaded image blob and submits a multipart POST request containing the file, caption, and contact ID to `/api/messages/media`.
- Added image thumbnail preview inside the canned response dialog when selected.

#### [CannedResponseDetailView.vue](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/frontend/src/views/settings/CannedResponseDetailView.vue)
- Added an Image upload card containing custom file picker, thumbnail display, and reset/delete options.

#### [CannedResponsePicker.vue](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/frontend/src/components/chat/CannedResponsePicker.vue)
- Rendered an image badge next to responses that contain an image.

---

## E2E Tests

#### [api.ts (E2E Helper)](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/frontend/e2e/helpers/api.ts)
- Extended `createCannedResponse` payload data shape to support `image_url`.

#### [chat.spec.ts (E2E Spec)](file:///Users/saifallahkhaled/PhpstormProjects/cloudwa/whatomate/frontend/e2e/tests/chat/chat.spec.ts)
- Added E2E test verifying:
  - Canned response dialog displays the image thumbnail correctly.
  - Clicking send dispatches the expected multipart form-data payload (caption, file blob, contact ID) to `/api/messages/media`.
