### PR TITLE
feat(calls): looping ringtone for incoming call transfers

### DIFF
--- a/frontend/src/services/ringtone.ts
+++ b/frontend/src/services/ringtone.ts
@@ -1,0 +1,53 @@
+// Synthetic telephone ringtone via the Web Audio API — no audio asset needed.
+// Plays a 440+480 Hz ringback burst (~1s) on a 3s cadence until stopped, so an
+// incoming call rings continuously like a phone instead of a single short beep.
+
+let audioCtx: AudioContext | null = null
+let cadenceTimer: ReturnType<typeof setInterval> | null = null
+let ringing = false
+
+// Emit one ~1s dual-tone ring burst with a click-free amplitude envelope.
+function ringBurst(ctx: AudioContext): void {
+  const now = ctx.currentTime
+  const gain = ctx.createGain()
+  gain.connect(ctx.destination)
+  gain.gain.setValueAtTime(0.0001, now)
+  gain.gain.exponentialRampToValueAtTime(0.2, now + 0.04)
+  gain.gain.setValueAtTime(0.2, now + 0.9)
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 1.0)
+  for (const freq of [440, 480]) {
+    const osc = ctx.createOscillator()
+    osc.type = 'sine'
+    osc.frequency.value = freq
+    osc.connect(gain)
+    osc.start(now)
+    osc.stop(now + 1.0)
+  }
+}
+
+// Start ringing (idempotent). Safe to call repeatedly; only one cadence runs.
+export function startRingtone(): void {
+  if (ringing) return
+  ringing = true
+  try {
+    if (!audioCtx) {
+      const Ctx = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+      audioCtx = new Ctx()
+    }
+    if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => { /* needs a user gesture */ })
+    const ctx = audioCtx
+    ringBurst(ctx) // ring immediately, then repeat (1s ring + 2s pause)
+    cadenceTimer = setInterval(() => ringBurst(ctx), 3000)
+  } catch {
+    ringing = false
+  }
+}
+
+// Stop ringing (idempotent).
+export function stopRingtone(): void {
+  ringing = false
+  if (cadenceTimer !== null) {
+    clearInterval(cadenceTimer)
+    cadenceTimer = null
+  }
+}

--- a/frontend/src/stores/calling.ts
+++ b/frontend/src/stores/calling.ts
@@ -1,8 +1,9 @@
 import { defineStore } from 'pinia'
-import { ref, reactive, computed } from 'vue'
+import { ref, reactive, computed, watch } from 'vue'
 import { callLogsService, ivrFlowsService, callTransfersService, outgoingCallsService, type CallLog, type IVRFlow, type CallTransfer } from '@/services/api'
 import { toast } from 'vue-sonner'
 import { i18n } from '@/i18n'
+import { startRingtone, stopRingtone } from '@/services/ringtone'
 
 export const useCallingStore = defineStore('calling', () => {
   // Call Logs state
@@ -33,6 +34,14 @@ export const useCallingStore = defineStore('calling', () => {
 
   // Call permission state (in-memory only, cleared on refresh)
   const callPermissions = reactive(new Map<string, { status: string, expiresAt?: string }>())
+
+  // Ring the agent's softphone continuously while one or more incoming call
+  // transfers are waiting to be answered; stop as soon as the queue clears
+  // (accepted, taken by another agent, abandoned, no-answer, or completed).
+  watch(() => waitingTransfers.value.length, (count) => {
+    if (count > 0) startRingtone()
+    else stopRingtone()
+  })
 
   // Outgoing call state
   const outgoingCallLogId = ref<string | null>(null)


### PR DESCRIPTION
## What
Adds a **looping ringtone** for incoming call transfers. Until now the agent only saw a visual call card (`call_transfer_waiting` pushed to a list) with, at most, the generic notification beep once — easy to miss.

A small synthetic Web Audio ringtone (440+480 Hz ringback burst on a 3s cadence, **no audio asset**) now rings continuously while one or more call transfers are waiting, and stops the instant the queue clears (accepted, taken by another agent, abandoned, no-answer, or completed).

## Changes
- `frontend/src/services/ringtone.ts` (new): `startRingtone()` / `stopRingtone()`, idempotent, AudioContext-based.
- `frontend/src/stores/calling.ts`: a `watch` on `waitingTransfers.length` drives start/stop.

## Notes
- No backend changes, no binary assets.
- Autoplay: the agent has interacted with the app (so AudioContext resumes); falls back silently otherwise.

## Testing
`vite build` passes; full image builds and serves. Verified by ear on a live deployment: incoming call rings continuously until answered/ended.
