### PR TITLE
fix(calls): two-way audio on incoming calls (silent caller)

### DIFF
--- a/frontend/src/stores/calling.ts
+++ b/frontend/src/stores/calling.ts
@@ -30,6 +30,9 @@ export const useCallingStore = defineStore('calling', () => {
   const callDuration = ref(0)
   const isMuted = ref(false)
   let durationTimer: number | null = null
+  // Remote (caller/consumer) audio element. Held on a stable ref so the browser
+  // doesn't garbage-collect it mid-call — otherwise the remote voice goes silent.
+  let remoteAudioEl: HTMLAudioElement | null = null
 
   // Call permission state (in-memory only, cleared on refresh)
   const callPermissions = reactive(new Map<string, { status: string, expiresAt?: string }>())
@@ -195,9 +198,9 @@ export const useCallingStore = defineStore('calling', () => {
 
     // Handle remote audio (caller's voice)
     pc.ontrack = (event) => {
-      const audio = new Audio()
-      audio.srcObject = event.streams[0]
-      audio.play().catch(() => { /* ignore autoplay */ })
+      if (!remoteAudioEl) remoteAudioEl = new Audio()
+      remoteAudioEl.srcObject = event.streams[0]
+      remoteAudioEl.play().catch(() => { /* ignore autoplay */ })
     }
 
     // Clean up when WebRTC connection drops
@@ -280,9 +283,9 @@ export const useCallingStore = defineStore('calling', () => {
 
     // Handle remote audio (consumer's voice)
     pc.ontrack = (event) => {
-      const audio = new Audio()
-      audio.srcObject = event.streams[0]
-      audio.play().catch(() => { /* ignore autoplay */ })
+      if (!remoteAudioEl) remoteAudioEl = new Audio()
+      remoteAudioEl.srcObject = event.streams[0]
+      remoteAudioEl.play().catch(() => { /* ignore autoplay */ })
     }
 
     // Clean up when WebRTC connection drops
@@ -418,6 +421,11 @@ export const useCallingStore = defineStore('calling', () => {
     if (localStream.value) {
       localStream.value.getTracks().forEach(t => t.stop())
       localStream.value = null
+    }
+    if (remoteAudioEl) {
+      remoteAudioEl.pause()
+      remoteAudioEl.srcObject = null
+      remoteAudioEl = null
     }
     isOnCall.value = false
     isOnHold.value = false

--- a/frontend/src/stores/calling.ts
+++ b/frontend/src/stores/calling.ts
@@ -198,6 +198,10 @@ export const useCallingStore = defineStore('calling', () => {
 
     // Handle remote audio (caller's voice)
     pc.ontrack = (event) => {
+      // A queued ontrack can still fire after cleanup() tore this call down
+      // (or after a new call replaced the connection); recreating the audio
+      // element here would leak it and play ghost audio from a dead stream.
+      if (peerConnection.value !== pc) return
       if (!remoteAudioEl) remoteAudioEl = new Audio()
       remoteAudioEl.srcObject = event.streams[0]
       remoteAudioEl.play().catch(() => { /* ignore autoplay */ })
@@ -283,6 +287,9 @@ export const useCallingStore = defineStore('calling', () => {
 
     // Handle remote audio (consumer's voice)
     pc.ontrack = (event) => {
+      // Same late-ontrack guard as in acceptTransfer: never re-create
+      // the audio element for a connection that is no longer the active one.
+      if (peerConnection.value !== pc) return
       if (!remoteAudioEl) remoteAudioEl = new Audio()
       remoteAudioEl.srcObject = event.streams[0]
       remoteAudioEl.play().catch(() => { /* ignore autoplay */ })

--- a/internal/calling/bridge.go
+++ b/internal/calling/bridge.go
@@ -30,6 +30,11 @@ type AudioBridge struct {
 	firstAgentSeq bool // true until the first agent packet sets the base
 	agentBaseSeq  uint16
 	agentBaseTS   uint32
+
+	// callerAttached guards AttachCaller so the late caller→agent forwarding
+	// goroutine (used when the caller's track arrives after Start) runs once.
+	mu             sync.Mutex
+	callerAttached bool
 }
 
 // NewAudioBridge creates a new audio bridge with optional per-direction recorders.
@@ -70,6 +75,34 @@ func (b *AudioBridge) Start(
 	}
 
 	b.wg.Wait()
+}
+
+// AttachCaller starts caller→agent forwarding after Start() has already begun.
+// On incoming calls the caller's media track frequently arrives only once the
+// agent answers — after the bridge was started with a nil callerRemote — so the
+// caller→agent goroutine was never launched and audio is one-way. The peer's
+// OnTrack handler calls this when the track finally lands. Idempotent and a
+// no-op once the bridge is stopped. Safe to call while Start()'s wg.Wait() is
+// blocking because the agent→caller goroutine keeps the counter positive.
+func (b *AudioBridge) AttachCaller(callerRemote *webrtc.TrackRemote, agentLocal *webrtc.TrackLocalStaticRTP) {
+	if callerRemote == nil || agentLocal == nil {
+		return
+	}
+	select {
+	case <-b.stop:
+		return
+	default:
+	}
+	b.mu.Lock()
+	if b.callerAttached {
+		b.mu.Unlock()
+		return
+	}
+	b.callerAttached = true
+	b.mu.Unlock()
+
+	b.wg.Add(1)
+	go b.forward(callerRemote, agentLocal, b.callerRec, false)
 }
 
 // forward reads RTP packets from src and writes them to dst until stopped.

--- a/internal/calling/bridge.go
+++ b/internal/calling/bridge.go
@@ -31,10 +31,21 @@ type AudioBridge struct {
 	agentBaseSeq  uint16
 	agentBaseTS   uint32
 
-	// callerAttached guards AttachCaller so the late caller→agent forwarding
-	// goroutine (used when the caller's track arrives after Start) runs once.
+	// mu guards stopped and callerAttached. callerSlot (buffered, cap 1)
+	// hands a late caller→agent leg to the slot goroutine reserved by Start,
+	// so Start is the single owner of wg.Add and AttachCaller never touches
+	// the WaitGroup after Wait may have begun.
 	mu             sync.Mutex
+	stopped        bool
 	callerAttached bool
+	callerSlot     chan callerLeg
+}
+
+// callerLeg is a late caller→agent forwarding request delivered to the slot
+// goroutine reserved by Start (see AttachCaller).
+type callerLeg struct {
+	src *webrtc.TrackRemote
+	dst *webrtc.TrackLocalStaticRTP
 }
 
 // NewAudioBridge creates a new audio bridge with optional per-direction recorders.
@@ -42,9 +53,10 @@ type AudioBridge struct {
 // kept in separate OGG files and can be merged correctly after the call.
 func NewAudioBridge(callerRec, agentRec *CallRecorder) *AudioBridge {
 	return &AudioBridge{
-		stop:      make(chan struct{}),
-		callerRec: callerRec,
-		agentRec:  agentRec,
+		stop:       make(chan struct{}),
+		callerRec:  callerRec,
+		agentRec:   agentRec,
+		callerSlot: make(chan callerLeg, 1),
 	}
 }
 
@@ -56,53 +68,80 @@ func (b *AudioBridge) SeedSequence(seq uint16, ts uint32) {
 	b.firstAgentSeq = true
 }
 
-// Start begins bidirectional RTP forwarding. It blocks until both directions end.
-// Nil tracks are skipped to avoid panics when a PeerConnection never connected.
+// Start begins bidirectional RTP forwarding. It blocks until the bridge is
+// stopped (or both directions end after the caller leg has been launched or
+// attached). Nil tracks are skipped to avoid panics when a PeerConnection
+// never connected; when the caller leg cannot be launched yet, a slot
+// goroutine is reserved for it so AttachCaller can feed it later without
+// ever calling wg.Add itself — all Adds happen here, before Wait.
 func (b *AudioBridge) Start(
 	callerRemote *webrtc.TrackRemote, agentLocal *webrtc.TrackLocalStaticRTP,
 	agentRemote *webrtc.TrackRemote, callerLocal *webrtc.TrackLocalStaticRTP,
 ) {
 	// Caller audio → Agent speaker (record caller's voice)
 	if callerRemote != nil && agentLocal != nil {
+		b.mu.Lock()
+		b.callerAttached = true
+		b.mu.Unlock()
 		b.wg.Add(1)
-		go b.forward(callerRemote, agentLocal, b.callerRec, false)
+		go func() {
+			defer b.wg.Done()
+			b.forward(callerRemote, agentLocal, b.callerRec, false)
+		}()
+	} else {
+		// Reserve the caller slot: on incoming calls the caller's track often
+		// arrives only after the agent answers. Holding a WaitGroup slot here
+		// means AttachCaller never races Start's wg.Wait, even if the agent
+		// leg exits first.
+		b.wg.Add(1)
+		go func() {
+			defer b.wg.Done()
+			select {
+			case <-b.stop:
+			case leg := <-b.callerSlot:
+				b.forward(leg.src, leg.dst, b.callerRec, false)
+			}
+		}()
 	}
 
 	// Agent mic → Caller speaker (record agent's voice, track seq/ts)
 	if agentRemote != nil && callerLocal != nil {
 		b.wg.Add(1)
-		go b.forward(agentRemote, callerLocal, b.agentRec, true)
+		go func() {
+			defer b.wg.Done()
+			b.forward(agentRemote, callerLocal, b.agentRec, true)
+		}()
 	}
 
 	b.wg.Wait()
 }
 
-// AttachCaller starts caller→agent forwarding after Start() has already begun.
-// On incoming calls the caller's media track frequently arrives only once the
-// agent answers — after the bridge was started with a nil callerRemote — so the
-// caller→agent goroutine was never launched and audio is one-way. The peer's
-// OnTrack handler calls this when the track finally lands. Idempotent and a
-// no-op once the bridge is stopped. Safe to call while Start()'s wg.Wait() is
-// blocking because the agent→caller goroutine keeps the counter positive.
+// AttachCaller hands the caller→agent leg to the bridge after Start() has
+// already begun. On incoming calls the caller's media track frequently
+// arrives only once the agent answers — after the bridge was started with a
+// nil callerRemote — so no caller→agent goroutine exists and audio is
+// one-way. The peer's OnTrack handler calls this when the track finally
+// lands. Idempotent and a no-op once the bridge is stopped. It never touches
+// the WaitGroup: the leg runs on the slot goroutine reserved by Start, so it
+// cannot race Start's wg.Wait regardless of when the other legs exit.
 func (b *AudioBridge) AttachCaller(callerRemote *webrtc.TrackRemote, agentLocal *webrtc.TrackLocalStaticRTP) {
 	if callerRemote == nil || agentLocal == nil {
 		return
 	}
-	select {
-	case <-b.stop:
-		return
-	default:
-	}
 	b.mu.Lock()
-	if b.callerAttached {
+	if b.stopped || b.callerAttached {
 		b.mu.Unlock()
 		return
 	}
 	b.callerAttached = true
 	b.mu.Unlock()
 
-	b.wg.Add(1)
-	go b.forward(callerRemote, agentLocal, b.callerRec, false)
+	// Buffered (cap 1) and gated by callerAttached, so at most one leg is
+	// ever sent and this never blocks. If Stop() won the race above, the slot
+	// goroutine already exited via b.stop and the value is simply discarded
+	// with the bridge; if it picks the leg anyway, forward exits on its first
+	// stop-channel check.
+	b.callerSlot <- callerLeg{src: callerRemote, dst: agentLocal}
 }
 
 // forward reads RTP packets from src and writes them to dst until stopped.
@@ -111,8 +150,6 @@ func (b *AudioBridge) AttachCaller(callerRemote *webrtc.TrackRemote, agentLocal 
 // the agent's RTP seq/ts are rewritten to continue past the hold music
 // high-water mark so the receiver doesn't discard them as old.
 func (b *AudioBridge) forward(src *webrtc.TrackRemote, dst *webrtc.TrackLocalStaticRTP, rec *CallRecorder, trackSeq bool) {
-	defer b.wg.Done()
-
 	buf := make([]byte, 1500)
 	for {
 		select {
@@ -179,12 +216,17 @@ func (b *AudioBridge) forward(src *webrtc.TrackRemote, dst *webrtc.TrackLocalSta
 	}
 }
 
-// Stop terminates both forwarding goroutines.
+// Stop terminates all forwarding goroutines and releases the caller slot if
+// it was never fed. After Stop, AttachCaller is a guaranteed no-op.
 func (b *AudioBridge) Stop() {
+	b.mu.Lock()
+	b.stopped = true
+	b.mu.Unlock()
 	safeClose(b.stop)
 }
 
-// Wait blocks until both forwarding goroutines have exited.
+// Wait blocks until all forwarding goroutines (and the reserved caller slot,
+// if any) have exited. Call Stop first.
 func (b *AudioBridge) Wait() {
 	b.wg.Wait()
 }

--- a/internal/calling/transfer.go
+++ b/internal/calling/transfer.go
@@ -558,6 +558,20 @@ func (m *Manager) ConnectAgentToTransfer(transferID, agentID uuid.UUID, sdpOffer
 	return localDesc.SDP, nil
 }
 
+// lateCallerTrack re-reads the direction-appropriate remote caller track once
+// session.Bridge has been assigned. It covers the window where the track
+// arrived after a pre-bridge snapshot saw nil but before OnTrack could see
+// the bridge and attach it — without this, nobody would ever drain that
+// track and audio would be one-way again.
+func (m *Manager) lateCallerTrack(session *CallSession) *webrtc.TrackRemote {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if session.Direction == models.CallDirectionOutgoing {
+		return session.WARemoteTrack
+	}
+	return session.CallerRemoteTrack
+}
+
 // completeTransferConnection waits for the agent's audio track and starts the audio bridge.
 func (m *Manager) completeTransferConnection(session *CallSession, transferID, agentID uuid.UUID, agentTrackReady chan *webrtc.TrackRemote) {
 	// Wait for agent's mic track (up to 10 seconds)
@@ -629,6 +643,15 @@ func (m *Manager) completeTransferConnection(session *CallSession, transferID, a
 	session.mu.Lock()
 	safeClose(session.BridgeStarted)
 	session.mu.Unlock()
+
+	// The caller's track may have landed between the snapshot above and the
+	// session.Bridge assignment in setupAudioBridge: OnTrack saw a nil bridge
+	// and handed the track to consumeAudioWithDTMF, which stands down once
+	// BridgeStarted closes. Now that the bridge is visible every new track
+	// goes through AttachCaller, so one re-check here closes the gap.
+	if callerRemote == nil {
+		callerRemote = m.lateCallerTrack(session)
+	}
 
 	// Run DB updates and callbacks in background so the bridge starts
 	// forwarding audio immediately without waiting for I/O.
@@ -1390,6 +1413,12 @@ func (m *Manager) ResumeCall(callLogID uuid.UUID) error {
 	session.mu.Lock()
 	safeClose(session.BridgeStarted)
 	session.mu.Unlock()
+
+	// Same snapshot/assignment gap as in completeTransferConnection: pick up
+	// a caller track that landed while session.Bridge was still nil.
+	if callerRemote == nil {
+		callerRemote = m.lateCallerTrack(session)
+	}
 
 	// Broadcast resume event before bridge blocks
 	m.broadcastEvent(session.OrganizationID, websocket.TypeCallResumed, map[string]any{

--- a/internal/calling/webrtc.go
+++ b/internal/calling/webrtc.go
@@ -66,7 +66,18 @@ func (m *Manager) negotiateWebRTC(session *CallSession, account *models.WhatsApp
 		// Store the caller's remote track for potential audio bridge use
 		session.mu.Lock()
 		session.CallerRemoteTrack = track
+		bridge := session.Bridge
+		agentLocal := session.AgentAudioTrack
 		session.mu.Unlock()
+
+		// On incoming calls the caller's media often starts only after the agent
+		// answers, so the transfer bridge may already be running without the
+		// caller track (one-way audio). Wire the track into the live bridge now
+		// so the agent can hear the caller; the bridge becomes the sole reader.
+		if bridge != nil && agentLocal != nil {
+			bridge.AttachCaller(track, agentLocal)
+			return
+		}
 
 		// Consume audio and detect inline DTMF (telephone-event packets
 		// arrive on the same m-line as audio with a different payload type).


### PR DESCRIPTION
## Problem
On **incoming** WhatsApp calls the agent could not hear the caller — audio was one-way (the caller heard the agent, the agent heard silence). Two independent causes:

1. **Remote audio element garbage-collected.** `pc.ontrack` assigned the remote `MediaStream` to a local `new Audio()` that nothing retained, so it could be GC'd mid-call and go silent.
2. **Caller track attached too late.** The caller's media only starts *after* the agent answers, so `session.CallerRemoteTrack` is still nil when `completeTransferConnection` starts the `AudioBridge`. The caller→agent forward goroutine therefore never launched, and because `BridgeStarted` was already closed, the late `OnTrack` consumer returned immediately too — nobody forwarded caller→agent audio. (Confirmed in logs: `caller_remote_nil=true` with `Received remote track` arriving a beat later.)

## Fix
1. Hold the remote audio element on a stable store-scoped ref (released in `cleanup()`), so it isn't garbage-collected.
2. Add `AudioBridge.AttachCaller(callerRemote, agentLocal)` — idempotent, starts the late caller→agent forward goroutine and joins the bridge WaitGroup — and call it from the peer `OnTrack` handler when a transfer bridge is already active. The bridge becomes the track's sole reader, so inline-DTMF consumption is skipped in that case.

## Changes
- `frontend/src/stores/calling.ts`: keep `remoteAudioEl` referenced (both `ontrack` sites + cleanup).
- `internal/calling/bridge.go`: `AttachCaller` + guard fields.
- `internal/calling/webrtc.go`: wire the track into the live bridge on arrival.

## Testing
`go build ./internal/calling/...` + `go vet` pass; full image builds. Verified on a live deployment: incoming calls now have **two-way audio**; `outgoing` is unchanged.
