### PR TITLE
feat(chat): alert on new messages with sound and browser notifications

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "test:e2e": "playwright test",
     "test:ui": "BASE_URL=http://localhost:8080 playwright test --ui",
     "test:debug": "BASE_URL=http://localhost:8080 playwright test --debug",
-    "test:report": "playwright show-report"
+    "test:report": "playwright show-report",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@radix-icons/vue": "^1.0.0",

--- a/frontend/src/services/notifications.spec.ts
+++ b/frontend/src/services/notifications.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { shouldNotifyIncoming } from '@/services/notifications'
+
+const ME = 'user-1'
+const OTHER = 'user-2'
+
+describe('shouldNotifyIncoming', () => {
+  it('alerts on an incoming message assigned to the current user', () => {
+    expect(
+      shouldNotifyIncoming({ direction: 'incoming', assigned_user_id: ME }, ME, {}, false)
+    ).toBe(true)
+  })
+
+  it('alerts on an incoming message that is unassigned', () => {
+    expect(
+      shouldNotifyIncoming({ direction: 'incoming', assigned_user_id: null }, ME, {}, false)
+    ).toBe(true)
+    expect(
+      shouldNotifyIncoming({ direction: 'incoming' }, ME, {}, false)
+    ).toBe(true)
+  })
+
+  it('stays quiet on chats assigned to another agent', () => {
+    expect(
+      shouldNotifyIncoming({ direction: 'incoming', assigned_user_id: OTHER }, ME, {}, false)
+    ).toBe(false)
+  })
+
+  it('does not alert for outgoing messages', () => {
+    expect(
+      shouldNotifyIncoming({ direction: 'outgoing', assigned_user_id: ME }, ME, {}, false)
+    ).toBe(false)
+  })
+
+  it('does not alert while the user is viewing the chat', () => {
+    expect(
+      shouldNotifyIncoming({ direction: 'incoming', assigned_user_id: ME }, ME, {}, true)
+    ).toBe(false)
+  })
+
+  it('respects the new_message_alerts opt-out', () => {
+    expect(
+      shouldNotifyIncoming(
+        { direction: 'incoming', assigned_user_id: ME },
+        ME,
+        { new_message_alerts: false },
+        false
+      )
+    ).toBe(false)
+  })
+
+  it('defaults to alerting when new_message_alerts is unset', () => {
+    expect(
+      shouldNotifyIncoming(
+        { direction: 'incoming', assigned_user_id: ME },
+        ME,
+        { new_message_alerts: undefined },
+        false
+      )
+    ).toBe(true)
+  })
+})

--- a/frontend/src/services/notifications.ts
+++ b/frontend/src/services/notifications.ts
@@ -1,0 +1,33 @@
+// Pure notification-policy helpers, split out from websocket.ts so they can be
+// unit tested without pulling in the router/store/DOM graph.
+
+export interface IncomingMessagePayload {
+  direction?: string
+  assigned_user_id?: string | null
+}
+
+export interface AlertSettings {
+  new_message_alerts?: boolean
+}
+
+// Decide whether an incoming message should alert the current user.
+// Alert when the chat is assigned to this user or unassigned, and the user has
+// new-message alerts enabled — stay quiet on chats another agent owns, and when
+// the user is already viewing the chat.
+export function shouldNotifyIncoming(
+  payload: IncomingMessagePayload,
+  currentUserId: string | undefined,
+  settings: AlertSettings,
+  isViewingThisContact: boolean | null | undefined
+): boolean {
+  if (payload.direction !== 'incoming' || isViewingThisContact) return false
+
+  const isAssignedToUser = payload.assigned_user_id === currentUserId
+  const isUnassigned = !payload.assigned_user_id
+  const shouldAlert = isAssignedToUser || isUnassigned
+
+  // Default to true when the setting is unset
+  const alertsEnabled = settings.new_message_alerts !== false
+
+  return shouldAlert && alertsEnabled
+}

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -4,25 +4,86 @@ import { useCallingStore } from '@/stores/calling'
 import { useAuthStore } from '@/stores/auth'
 import { useNotesStore } from '@/stores/notes'
 import { contactsService } from '@/services/api'
+import { shouldNotifyIncoming } from '@/services/notifications'
 import { toast } from 'vue-sonner'
 import router from '@/router'
 
 // Notification sound
 let notificationSound: HTMLAudioElement | null = null
+let audioUnlocked = false
 
-function playNotificationSound() {
+function getSound(): HTMLAudioElement {
   if (!notificationSound) {
     notificationSound = new Audio('/notification.mp3')
     notificationSound.volume = 0.5
   }
-  notificationSound.currentTime = 0
-  notificationSound.play().catch(() => {
+  return notificationSound
+}
+
+// Browsers block Audio.play() until the user interacts with the page, so the
+// first incoming-message sound is silently rejected. Prime the element inside
+// the first user gesture (play muted, then reset) so later alerts are audible.
+// Also request OS notification permission here — same gesture requirement.
+function unlockNotifications() {
+  if (audioUnlocked) return
+  audioUnlocked = true
+
+  const el = getSound()
+  el.muted = true
+  el.play().then(() => {
+    el.pause()
+    el.currentTime = 0
+    el.muted = false
+  }).catch(() => {
+    el.muted = false
+  })
+
+  if (typeof window !== 'undefined' && 'Notification' in window
+      && Notification.permission === 'default') {
+    Notification.requestPermission().catch(() => { /* denied/unsupported */ })
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('pointerdown', unlockNotifications, { once: true })
+  window.addEventListener('keydown', unlockNotifications, { once: true })
+}
+
+function playNotificationSound() {
+  const el = getSound()
+  el.currentTime = 0
+  el.play().catch(() => {
     // Ignore autoplay errors (browser may block until user interaction)
   })
 }
 
-// Show toast notification with click handler
+// Show a notification for an incoming message. When the tab is backgrounded or
+// unfocused and the user granted permission, fire an OS-level browser
+// notification (visible outside the app); otherwise fall back to an in-app toast.
 function showNotification(title: string, body: string, contactId: string) {
+  const pageActive = typeof document !== 'undefined'
+    && document.visibilityState === 'visible'
+    && document.hasFocus()
+
+  if (!pageActive && typeof window !== 'undefined' && 'Notification' in window
+      && Notification.permission === 'granted') {
+    try {
+      const notification = new Notification(title, {
+        body,
+        icon: '/favicon.svg',
+        tag: `contact-${contactId}`
+      })
+      notification.onclick = () => {
+        window.focus()
+        router.push(`/chat/${contactId}`)
+        notification.close()
+      }
+      return
+    } catch {
+      // Notification construction can throw on some platforms — fall back to toast
+    }
+  }
+
   toast.info(title, {
     description: body,
     duration: 5000,
@@ -278,23 +339,14 @@ class WebSocketService {
       })
     }
 
-    // Show toast notification for incoming messages if:
-    // 1. Message is incoming (from customer, not chatbot/agent)
-    // 2. Current user is assigned to this contact
-    // 3. User has new_message_alerts enabled
-    // 4. User is not currently viewing this contact
-    if (payload.direction === 'incoming' && !isViewingThisContact) {
+    // Alert for incoming messages assigned to me or unassigned (see
+    // shouldNotifyIncoming), unless I'm already viewing the chat.
+    {
       const authStore = useAuthStore()
       const currentUserId = authStore.user?.id
       const settings = authStore.userSettings
 
-      // Check if user is assigned to this contact
-      const isAssignedToUser = payload.assigned_user_id === currentUserId
-
-      // Check if new message alerts are enabled (default to true if not set)
-      const alertsEnabled = settings.new_message_alerts !== false
-
-      if (isAssignedToUser && alertsEnabled) {
+      if (shouldNotifyIncoming(payload, currentUserId, settings, isViewingThisContact)) {
         const senderName = payload.profile_name || 'Unknown'
         const messagePreview = payload.content?.body || 'New message'
         const preview = messagePreview.length > 50

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts']
+  }
+})


### PR DESCRIPTION
## What

Incoming WhatsApp messages now proactively alert the assigned agent with a sound and — when the tab is backgrounded — a native browser notification, instead of only silently incrementing the sidebar unread badge.

## Why

Today an incoming message only shows up as a small unread count in the contact list, so an agent has to actively watch the screen to notice a new chat. Three separate gaps caused this:

1. **Assignment gate too narrow** — the toast + sound only fired when the chat was assigned to the current user. Unassigned chats bumped the badge with no alert at all.
2. **Autoplay-blocked sound** — the notification audio was created and played without any prior user gesture, so the browser autoplay policy rejected the very first `play()` and the sound was dropped.
3. **No out-of-tab signal** — alerts were in-app toasts only, invisible when the browser tab was backgrounded or minimized.

## How

- **Broaden the alert rule**: an incoming message now alerts when the chat is assigned to you **or** unassigned; chats owned by another agent stay quiet to avoid cross-agent noise. The decision is extracted into a pure `shouldNotifyIncoming()` helper (`frontend/src/services/notifications.ts`).
- **Prime the audio**: the sound element is unlocked on the first `pointerdown`/`keydown` (played muted once, then reset) so later alerts play reliably. Browser notification permission is requested in the same gesture.
- **Native notifications**: when the tab is not visible/focused and permission is granted, fire a `window.Notification` (click focuses the window and routes to the chat); otherwise fall back to the existing in-app toast.

## Tests

- New `shouldNotifyIncoming` unit tests cover assigned / unassigned / other-agent / outgoing / already-viewing / alerts-disabled / default-on cases.
- Adds a minimal **Vitest** setup (`vitest.config.ts` + `test:unit` script); the repo previously had only Playwright e2e. `npm run test:unit` → 7 passing.
- `npm run typecheck` and `eslint` clean on changed files.

## Notes

- Browser notifications require the user to grant permission (prompted on first interaction). If previously denied, it must be re-enabled in the browser's site settings.
- No backend changes.