### PR TITLE
feat(chat): responsive one-pane-at-a-time layout on phones

### DIFF
--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -103,7 +103,10 @@ const handleLogout = async () => {
 </script>
 
 <template>
-  <div class="flex h-screen bg-[#0a0a0b] light:bg-gray-50">
+  <!-- h-dvh (dynamic viewport height): on Android, 100vh includes the area
+       behind the system bars, cutting off the bottom row (composer/send).
+       dvh tracks the real visible height; h-screen stays as the fallback. -->
+  <div class="flex h-screen supports-[height:100dvh]:h-dvh bg-[#0a0a0b] light:bg-gray-50">
     <!-- Skip link for accessibility -->
     <a href="#main-content" class="skip-link">{{ $t('nav.skipToMain') }}</a>
 

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -87,7 +87,8 @@ import {
   Code,
   RotateCw,
   Filter,
-  StickyNote
+  StickyNote,
+  ArrowLeft
 } from 'lucide-vue-next'
 import { getInitials, getAvatarGradient } from '@/lib/utils'
 import { useColorMode } from '@/composables/useColorMode'
@@ -1654,8 +1655,11 @@ async function sendMediaMessage() {
 
 <template>
   <div class="flex h-full bg-[#0a0a0b] light:bg-gray-50">
-    <!-- Contacts List -->
-    <div class="w-80 border-r border-white/[0.08] light:border-gray-200 flex flex-col bg-[#0a0a0b] light:bg-white">
+    <!-- Contacts List (on phones: full width, hidden while a chat is open) -->
+    <div
+      class="w-full md:w-80 border-r border-white/[0.08] light:border-gray-200 flex-col bg-[#0a0a0b] light:bg-white"
+      :class="contactsStore.currentContact ? 'hidden md:flex' : 'flex'"
+    >
       <!-- Search Header -->
       <div class="p-2 border-b border-white/[0.08] light:border-gray-200">
         <div class="flex items-center gap-2">
@@ -1804,8 +1808,11 @@ async function sendMediaMessage() {
       </ScrollArea>
     </div>
 
-    <!-- Chat Area -->
-    <div class="flex-1 flex flex-col bg-[#0f0f10] light:bg-gray-50">
+    <!-- Chat Area (on phones: full screen only while a chat is open) -->
+    <div
+      class="flex-1 flex-col bg-[#0f0f10] light:bg-gray-50"
+      :class="contactsStore.currentContact ? 'flex' : 'hidden md:flex'"
+    >
       <!-- No Contact Selected -->
       <div
         v-if="!contactsStore.currentContact"
@@ -1825,6 +1832,15 @@ async function sendMediaMessage() {
         <!-- Chat Header -->
         <div class="h-14 flex-shrink-0 px-4 border-b border-white/[0.08] light:border-gray-200 flex items-center justify-between bg-[#0f0f10] light:bg-white">
           <div class="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8 -ml-1 md:hidden"
+              :title="$t('common.back')"
+              @click="router.push('/chat')"
+            >
+              <ArrowLeft class="h-4 w-4" />
+            </Button>
             <Avatar class="h-8 w-8 ring-2 ring-white/[0.1] light:ring-gray-200">
               <AvatarImage :src="contactsStore.currentContact.avatar_url" />
               <AvatarFallback :class="'text-xs bg-gradient-to-br text-white ' + getAvatarGradient(contactsStore.currentContact.name || contactsStore.currentContact.phone_number)">
@@ -2478,18 +2494,20 @@ async function sendMediaMessage() {
       </template>
     </div>
 
-    <!-- Notes Side Panel -->
+    <!-- Notes Side Panel (on phones: full-screen overlay) -->
     <ConversationNotes
       v-if="contactsStore.currentContact && isNotesPanelOpen"
       :contact-id="contactsStore.currentContact.id"
+      class="max-md:fixed max-md:inset-0 max-md:z-50 max-md:!w-full"
       @close="isNotesPanelOpen = false"
     />
 
-    <!-- Contact Info Panel -->
+    <!-- Contact Info Panel (on phones: full-screen overlay) -->
     <ContactInfoPanel
       v-if="contactsStore.currentContact && isInfoPanelOpen"
       :contact="contactsStore.currentContact"
       :session-data="contactSessionData"
+      class="max-md:fixed max-md:inset-0 max-md:z-50 max-md:!w-full"
       @close="isInfoPanelOpen = false"
       @tags-updated="(tags) => contactsStore.updateContactTags(contactsStore.currentContact!.id, tags)"
     />

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -1808,9 +1808,12 @@ async function sendMediaMessage() {
       </ScrollArea>
     </div>
 
-    <!-- Chat Area (on phones: full screen only while a chat is open) -->
+    <!-- Chat Area (on phones: full screen only while a chat is open).
+         min-w-0 lets this flex child shrink to the viewport: without it the
+         composer's intrinsic width (textarea + buttons) forces the panel wider
+         than a phone screen, pushing bubbles and the send button off-screen. -->
     <div
-      class="flex-1 flex-col bg-[#0f0f10] light:bg-gray-50"
+      class="flex-1 min-w-0 flex-col bg-[#0f0f10] light:bg-gray-50"
       :class="contactsStore.currentContact ? 'flex' : 'hidden md:flex'"
     >
       <!-- No Contact Selected -->
@@ -2482,11 +2485,11 @@ async function sendMediaMessage() {
               v-model="messageInput"
               :placeholder="$t('chat.typeMessage') + '...'"
               rows="1"
-              class="flex-1 bg-transparent text-[14px] text-white light:text-gray-900 placeholder:text-white/30 light:placeholder:text-gray-400 focus:outline-none resize-none min-h-[36px] max-h-[120px] py-2 overflow-y-auto"
+              class="flex-1 min-w-0 bg-transparent text-[14px] text-white light:text-gray-900 placeholder:text-white/30 light:placeholder:text-gray-400 focus:outline-none resize-none min-h-[36px] max-h-[120px] py-2 overflow-y-auto"
               @keydown.enter.exact.prevent="sendMessage"
               @input="autoResizeTextarea"
             />
-            <button type="submit" class="w-9 h-9 rounded-lg bg-emerald-600 hover:bg-emerald-500 light:bg-emerald-500 light:hover:bg-emerald-600 flex items-center justify-center transition-colors disabled:opacity-50" :disabled="!messageInput.trim() || isSending">
+            <button type="submit" class="w-9 h-9 shrink-0 rounded-lg bg-emerald-600 hover:bg-emerald-500 light:bg-emerald-500 light:hover:bg-emerald-600 flex items-center justify-center transition-colors disabled:opacity-50" :disabled="!messageInput.trim() || isSending">
               <Send class="w-4 h-4 text-white" />
             </button>
           </form>


### PR DESCRIPTION
## Problem

`ChatView` is a fixed three-pane desktop layout: a 320px contact list (`w-80`) plus the conversation pane. On a phone (~360-400px) the panes can't fit side by side, and the conversation pane can't even shrink to the viewport (the composer's intrinsic width — textarea default size + four fixed buttons — exceeds a phone screen because of flexbox's `min-width: auto`), so message bubbles and the send button render past the right edge. The app is effectively unusable on mobile, which matters now that agents open it from a phone (PWA or browser).

## Fix (template-only, desktop unchanged)

One pane at a time below `md` (768px), driven by the existing `/chat/:contactId` route:

- **Contact list**: `w-full md:w-80`, hidden while a chat is open (`hidden md:flex`). Full-screen list on phones.
- **Conversation pane**: shown only while a chat is open (inverse condition) + **`min-w-0`** so it can actually shrink to the viewport (also on the textarea; `shrink-0` on the send button).
- **Back button** (`md:hidden`, `ArrowLeft`) in the chat header → `router.push('/chat')`, which the existing route watcher already handles. Since chat selection is route-based, **Android's back gesture works for free**.
- **Notes / contact info side panels** become full-screen overlays on phones (`max-md:fixed max-md:inset-0 max-md:z-50 max-md:!w-full`); both already have close buttons.
- **App shell**: `h-screen` → `100dvh` where supported (`supports-[height:100dvh]:h-dvh`) — on Android, `100vh` includes the area behind the system bars, cutting off the composer's bottom half.

At `>=768px` the conditional classes reproduce today's classes exactly — desktop is pixel-identical.

## Testing

- Phone (Android, 360-412px wide): list ↔ conversation full-screen navigation, back button and Android back gesture, side panels as overlays, composer and send button fully visible, bubbles inside the viewport.
- Desktop: no visual change.
- Verified in production with agents on both desktop and Android (installed PWA).
