### PR TITLE
feat(chat): forward messages to another contact

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -652,6 +652,7 @@ func setupRoutes(g *fastglue.Fastglue, app *handlers.App, lo logf.Logger, basePa
 	g.POST("/api/messages/template", app.SendTemplateMessage)
 	g.POST("/api/messages/media", app.SendMediaMessage)
 	g.PUT("/api/messages/{id}/read", app.MarkMessageRead)
+	g.POST("/api/messages/{id}/forward", app.ForwardMessage)
 
 	// Conversation Notes
 	g.GET("/api/contacts/{id}/notes", app.ListConversationNotes)

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -428,7 +428,12 @@
     "urlButtonParamPlaceholder": "أدخل قيمة الرابط المتغيرة",
     "preview": "معاينة",
     "serviceWindowExpired": "انتهت نافذة المراسلة لمدة 24 ساعة. لا يمكن إرسال سوى رسائل القوالب حتى يرد العميل.",
-    "sendTemplateAction": "إرسال قالب"
+    "sendTemplateAction": "إرسال قالب",
+    "forward": "Forward",
+    "forwardTo": "Forward to...",
+    "forwardDesc": "Send this message to another contact",
+    "forwarded": "Message forwarded",
+    "forwardFailed": "Failed to forward message"
   },
   "contacts": {
     "title": "جهات الاتصال",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -428,7 +428,12 @@
     "urlButtonParamPlaceholder": "Enter dynamic URL value",
     "preview": "Preview",
     "serviceWindowExpired": "The 24-hour messaging window has expired. Only template messages can be sent until the customer replies.",
-    "sendTemplateAction": "Send Template"
+    "sendTemplateAction": "Send Template",
+    "forward": "Forward",
+    "forwardTo": "Forward to...",
+    "forwardDesc": "Send this message to another contact",
+    "forwarded": "Message forwarded",
+    "forwardFailed": "Failed to forward message"
   },
   "contacts": {
     "title": "Contacts",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -385,7 +385,12 @@
     "urlButtonParamPlaceholder": "Ingrese el valor dinámico de la URL",
     "preview": "Vista previa",
     "serviceWindowExpired": "La ventana de mensajería de 24 horas ha expirado. Solo se pueden enviar mensajes de plantilla hasta que el cliente responda.",
-    "sendTemplateAction": "Enviar plantilla"
+    "sendTemplateAction": "Enviar plantilla",
+    "forward": "Reenviar",
+    "forwardTo": "Reenviar a...",
+    "forwardDesc": "Enviar este mensaje a otro contacto",
+    "forwarded": "Mensaje reenviado",
+    "forwardFailed": "No se pudo reenviar el mensaje"
   },
   "contacts": {
     "title": "Contactos",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -385,7 +385,12 @@
     "urlButtonParamPlaceholder": "गतिशील URL मान दर्ज करें",
     "preview": "पूर्वावलोकन",
     "serviceWindowExpired": "24-घंटे की संदेश सेवा विंडो समाप्त हो गई है। ग्राहक के जवाब देने तक केवल टेम्पलेट संदेश भेजे जा सकते हैं।",
-    "sendTemplateAction": "टेम्पलेट भेजें"
+    "sendTemplateAction": "टेम्पलेट भेजें",
+    "forward": "Forward",
+    "forwardTo": "Forward to...",
+    "forwardDesc": "Send this message to another contact",
+    "forwarded": "Message forwarded",
+    "forwardFailed": "Failed to forward message"
   },
   "contacts": {
     "title": "संपर्क",

--- a/frontend/src/i18n/locales/ta.json
+++ b/frontend/src/i18n/locales/ta.json
@@ -385,7 +385,12 @@
     "urlButtonParamPlaceholder": "மாறும் URL மதிப்பை உள்ளிடவும்",
     "preview": "முன்னோட்டம்",
     "serviceWindowExpired": "24 மணிநேர செய்தியிடல் சாளரம் காலாவதியானது. வாடிக்கையாளர் பதிலளிக்கும் வரை வார்ப்புரு செய்திகளை மட்டுமே அனுப்ப முடியும்.",
-    "sendTemplateAction": "வார்ப்புருவை அனுப்பு"
+    "sendTemplateAction": "வார்ப்புருவை அனுப்பு",
+    "forward": "Forward",
+    "forwardTo": "Forward to...",
+    "forwardDesc": "Send this message to another contact",
+    "forwarded": "Message forwarded",
+    "forwardFailed": "Failed to forward message"
   },
   "contacts": {
     "title": "தொடர்புகள்",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -289,6 +289,8 @@ export const messagesService = {
       }
     },
   ) => api.post(`/contacts/${contactId}/messages`, data),
+  forward: (messageId: string, contactId: string, whatsappAccount?: string) =>
+    api.post(`/messages/${messageId}/forward`, { contact_id: contactId, whatsapp_account: whatsappAccount }),
   sendTemplate: (contactId: string, data: { template_name: string; template_params?: Record<string, string>; header_params?: Record<string, string>; button_params?: Record<string, string>; account_name?: string }, headerFile?: File) => {
     if (headerFile) {
       const formData = new FormData()

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -87,7 +87,8 @@ import {
   Code,
   RotateCw,
   Filter,
-  StickyNote
+  StickyNote,
+  Forward
 } from 'lucide-vue-next'
 import { getInitials, getAvatarGradient } from '@/lib/utils'
 import { useColorMode } from '@/composables/useColorMode'
@@ -1179,6 +1180,67 @@ function replyToMessage(message: Message) {
   nextTick(() => {
     messageInputRef.value?.focus()
   })
+}
+
+// Forward message: the Cloud API has no native forward, so the backend
+// re-sends the content to the chosen contact as a new message.
+const isForwardDialogOpen = ref(false)
+const forwardingMessage = ref<Message | null>(null)
+const forwardSearchQuery = ref('')
+const forwardResults = ref<any[]>([])
+const isSearchingForward = ref(false)
+const forwardSendingId = ref<string | null>(null)
+let forwardSearchTimer: number | undefined
+
+const forwardableTypes = ['text', 'image', 'video', 'audio', 'document']
+function canForward(message: Message): boolean {
+  return forwardableTypes.includes(message.message_type)
+}
+
+function openForwardDialog(message: Message) {
+  forwardingMessage.value = message
+  forwardSearchQuery.value = ''
+  isForwardDialogOpen.value = true
+  searchForwardContacts()
+}
+
+async function searchForwardContacts() {
+  isSearchingForward.value = true
+  try {
+    const response = await contactsService.list({
+      search: forwardSearchQuery.value.trim() || undefined,
+      limit: 20
+    })
+    const data = response.data.data || response.data
+    forwardResults.value = (data.contacts || []).filter(
+      (c: any) => c.id !== contactsStore.currentContact?.id
+    )
+  } catch {
+    forwardResults.value = []
+  } finally {
+    isSearchingForward.value = false
+  }
+}
+
+watch(forwardSearchQuery, () => {
+  if (!isForwardDialogOpen.value) return
+  window.clearTimeout(forwardSearchTimer)
+  forwardSearchTimer = window.setTimeout(searchForwardContacts, 300)
+})
+
+async function forwardToContact(contact: any) {
+  if (!forwardingMessage.value || forwardSendingId.value) return
+  forwardSendingId.value = contact.id
+  try {
+    await messagesService.forward(forwardingMessage.value.id, contact.id)
+    toast.success(t('chat.forwarded'))
+    isForwardDialogOpen.value = false
+    forwardingMessage.value = null
+  } catch (error: any) {
+    toast.error(error?.response?.data?.message || t('chat.forwardFailed'))
+  } finally {
+    forwardSendingId.value = null
+  }
 }
 
 // Watch for slash commands in message input
@@ -2317,6 +2379,16 @@ async function sendMediaMessage() {
                 >
                   <Reply class="h-3 w-3" />
                 </Button>
+                <Button
+                  v-if="canForward(message)"
+                  variant="ghost"
+                  size="icon"
+                  class="h-6 w-6"
+                  :title="$t('chat.forward')"
+                  @click="openForwardDialog(message)"
+                >
+                  <Forward class="h-3 w-3" />
+                </Button>
               </div>
               <!-- Reply button for outgoing messages (shown on hover) -->
               <div v-if="message.direction === 'outgoing'" class="flex flex-col gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity self-center ml-1">
@@ -2346,6 +2418,16 @@ async function sendMediaMessage() {
                   @click="replyToMessage(message)"
                 >
                   <Reply class="h-3 w-3" />
+                </Button>
+                <Button
+                  v-if="canForward(message)"
+                  variant="ghost"
+                  size="icon"
+                  class="h-6 w-6"
+                  :title="$t('chat.forward')"
+                  @click="openForwardDialog(message)"
+                >
+                  <Forward class="h-3 w-3" />
                 </Button>
                 <Button
                   v-if="message.status === 'failed' && message.message_type !== 'template'"
@@ -2671,6 +2753,51 @@ async function sendMediaMessage() {
               </Button>
               <p v-if="filteredAssignableUsers.length === 0" class="text-sm text-muted-foreground text-center py-4">
                 {{ $t('chat.noUsersFound') }}
+              </p>
+            </div>
+          </ScrollArea>
+        </div>
+      </DialogContent>
+    </Dialog>
+
+    <!-- Forward Message Dialog -->
+    <Dialog v-model:open="isForwardDialogOpen" @update:open="(open) => !open && (forwardSearchQuery = '', forwardingMessage = null)">
+      <DialogContent class="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{{ $t('chat.forwardTo') }}</DialogTitle>
+          <DialogDescription>
+            {{ $t('chat.forwardDesc') }}
+          </DialogDescription>
+        </DialogHeader>
+        <div class="py-4 space-y-3">
+          <div class="relative">
+            <Search class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              v-model="forwardSearchQuery"
+              :placeholder="$t('chat.searchContacts') + '...'"
+              class="pl-9 h-9"
+            />
+          </div>
+          <ScrollArea class="max-h-[280px]">
+            <div class="space-y-1">
+              <Button
+                v-for="contact in forwardResults"
+                :key="contact.id"
+                variant="ghost"
+                class="w-full justify-start"
+                :disabled="forwardSendingId !== null"
+                @click="forwardToContact(contact)"
+              >
+                <Loader2 v-if="forwardSendingId === contact.id" class="mr-2 h-4 w-4 animate-spin" />
+                <User v-else class="mr-2 h-4 w-4" />
+                <span class="truncate">{{ contact.profile_name || contact.name || contact.phone_number }}</span>
+                <span class="ml-auto text-xs text-muted-foreground">{{ contact.phone_number }}</span>
+              </Button>
+              <div v-if="isSearchingForward && forwardResults.length === 0" class="text-center py-4">
+                <Loader2 class="h-4 w-4 mx-auto animate-spin text-muted-foreground" />
+              </div>
+              <p v-else-if="forwardResults.length === 0" class="text-sm text-muted-foreground text-center py-4">
+                {{ $t('chat.noContacts') }}
               </p>
             </div>
           </ScrollArea>

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -497,6 +497,7 @@ onUnmounted(() => {
   notesStore.clearNotes()
   // Clear sticky date timeout
   if (stickyDateTimeout) clearTimeout(stickyDateTimeout)
+  window.clearTimeout(forwardSearchTimer)
   document.removeEventListener('visibilitychange', onUserActive)
   window.removeEventListener('focus', onUserActive)
 })
@@ -1191,6 +1192,7 @@ const forwardResults = ref<any[]>([])
 const isSearchingForward = ref(false)
 const forwardSendingId = ref<string | null>(null)
 let forwardSearchTimer: number | undefined
+let forwardSearchSeq = 0
 
 const forwardableTypes = ['text', 'image', 'video', 'audio', 'document']
 function canForward(message: Message): boolean {
@@ -1200,25 +1202,30 @@ function canForward(message: Message): boolean {
 function openForwardDialog(message: Message) {
   forwardingMessage.value = message
   forwardSearchQuery.value = ''
+  forwardResults.value = []
   isForwardDialogOpen.value = true
   searchForwardContacts()
 }
 
 async function searchForwardContacts() {
+  const seq = ++forwardSearchSeq
   isSearchingForward.value = true
   try {
     const response = await contactsService.list({
       search: forwardSearchQuery.value.trim() || undefined,
       limit: 20
     })
+    // Drop stale responses: a slow fetch for "a" must not overwrite "ab".
+    if (seq !== forwardSearchSeq) return
     const data = response.data.data || response.data
     forwardResults.value = (data.contacts || []).filter(
       (c: any) => c.id !== contactsStore.currentContact?.id
     )
   } catch {
+    if (seq !== forwardSearchSeq) return
     forwardResults.value = []
   } finally {
-    isSearchingForward.value = false
+    if (seq === forwardSearchSeq) isSearchingForward.value = false
   }
 }
 
@@ -1226,6 +1233,15 @@ watch(forwardSearchQuery, () => {
   if (!isForwardDialogOpen.value) return
   window.clearTimeout(forwardSearchTimer)
   forwardSearchTimer = window.setTimeout(searchForwardContacts, 300)
+})
+
+watch(isForwardDialogOpen, (open) => {
+  if (!open) {
+    window.clearTimeout(forwardSearchTimer)
+    forwardSearchQuery.value = ''
+    forwardResults.value = []
+    forwardingMessage.value = null
+  }
 })
 
 async function forwardToContact(contact: any) {
@@ -2761,7 +2777,7 @@ async function sendMediaMessage() {
     </Dialog>
 
     <!-- Forward Message Dialog -->
-    <Dialog v-model:open="isForwardDialogOpen" @update:open="(open) => !open && (forwardSearchQuery = '', forwardingMessage = null)">
+    <Dialog v-model:open="isForwardDialogOpen">
       <DialogContent class="max-w-sm">
         <DialogHeader>
           <DialogTitle>{{ $t('chat.forwardTo') }}</DialogTitle>
@@ -2778,7 +2794,7 @@ async function sendMediaMessage() {
               class="pl-9 h-9"
             />
           </div>
-          <ScrollArea class="max-h-[280px]">
+          <ScrollArea class="h-[280px]">
             <div class="space-y-1">
               <Button
                 v-for="contact in forwardResults"

--- a/internal/handlers/messages_forward.go
+++ b/internal/handlers/messages_forward.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/shridarpatil/whatomate/internal/models"
+	"github.com/valyala/fasthttp"
+	"github.com/zerodha/fastglue"
+)
+
+// ForwardMessageRequest identifies the destination of a forward.
+type ForwardMessageRequest struct {
+	ContactID       string `json:"contact_id"`
+	WhatsAppAccount string `json:"whatsapp_account"` // optional account-name override
+}
+
+// ForwardMessage re-sends the content of an existing message to another
+// contact as a NEW outgoing message. The WhatsApp Cloud API has no native
+// forward (the "Forwarded" label is consumer-app only), so this mirrors what
+// business inboxes do: text is re-sent as text, media is re-read from local
+// storage and re-uploaded (inbound Meta media IDs are not reusable for
+// sending). Subject to the destination contact's 24h service window like any
+// free-form message.
+func (a *App) ForwardMessage(r *fastglue.Request) error {
+	orgID, userID, err := a.getOrgAndUserID(r)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
+	}
+
+	messageID, err := parsePathUUID(r, "id", "message")
+	if err != nil {
+		return nil
+	}
+
+	var req ForwardMessageRequest
+	if err := json.Unmarshal(r.RequestCtx.PostBody(), &req); err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid request body", nil, "")
+	}
+	destContactID, err := uuid.Parse(req.ContactID)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid contact_id", nil, "")
+	}
+
+	// Source message, org-guarded.
+	message, err := findByIDAndOrg[models.Message](a.DB, r, messageID, orgID, "Message")
+	if err != nil {
+		return nil
+	}
+
+	// The agent must be able to see the source conversation (same assignment
+	// scoping as the rest of the chat surface).
+	var sourceContact models.Contact
+	srcQuery := a.DB.Where("id = ? AND organization_id = ?", message.ContactID, orgID)
+	srcQuery = a.scopeAssignedContact(srcQuery, userID, orgID)
+	if err := srcQuery.First(&sourceContact).Error; err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Access denied", nil, "")
+	}
+
+	// ...and be allowed to message the destination contact (agents can only
+	// send to their assigned contacts, mirroring SendMessage).
+	var destContact models.Contact
+	destQuery := a.DB.Where("id = ? AND organization_id = ?", destContactID, orgID)
+	destQuery = a.scopeAssignedContact(destQuery, userID, orgID)
+	if err := destQuery.First(&destContact).Error; err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Contact not found", nil, "")
+	}
+	if destContact.ID == message.ContactID {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Cannot forward to the same conversation", nil, "")
+	}
+
+	// Outgoing account: explicit override > destination contact's account > org default.
+	accountName := destContact.WhatsAppAccount
+	if req.WhatsAppAccount != "" {
+		accountName = req.WhatsAppAccount
+	}
+	account, err := a.resolveWhatsAppAccount(orgID, accountName)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Failed to resolve WhatsApp account", nil, "")
+	}
+
+	msgReq := OutgoingMessageRequest{
+		Account: account,
+		Contact: &destContact,
+	}
+
+	switch message.MessageType {
+	case models.MessageTypeText:
+		msgReq.Type = models.MessageTypeText
+		msgReq.Content = message.Content
+
+	case models.MessageTypeImage, models.MessageTypeVideo, models.MessageTypeAudio, models.MessageTypeDocument:
+		if message.MediaURL == "" {
+			return r.SendErrorEnvelope(fasthttp.StatusNotFound, "No media found for this message", nil, "")
+		}
+		data, errResp := a.readLocalMedia(r, message.MediaURL)
+		if data == nil {
+			return errResp
+		}
+		msgReq.Type = message.MessageType
+		msgReq.MediaData = data
+		msgReq.MediaURL = message.MediaURL // reuse the stored file for the new message record
+		msgReq.MediaMimeType = message.MediaMimeType
+		msgReq.MediaFilename = message.MediaFilename
+		msgReq.Caption = message.Content
+		msgReq.Content = message.Content
+
+	default:
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "This message type cannot be forwarded", nil, "")
+	}
+
+	opts := DefaultSendOptions()
+	opts.SentByUserID = &userID
+
+	sent, err := a.SendOutgoingMessage(context.Background(), msgReq, opts)
+	if err != nil {
+		a.Log.Error("Failed to forward message", "error", err, "source_message_id", messageID)
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to forward message", nil, "")
+	}
+
+	return r.SendEnvelope(map[string]any{
+		"id":         sent.ID,
+		"contact_id": sent.ContactID,
+		"status":     sent.Status,
+	})
+}
+
+// readLocalMedia safely reads a stored media file by its relative MediaURL,
+// applying the same traversal/symlink guards as ServeMedia. On failure it
+// writes the error envelope and returns nil data.
+func (a *App) readLocalMedia(r *fastglue.Request, mediaURL string) ([]byte, error) {
+	filePath := filepath.Clean(mediaURL)
+	baseDir, err := filepath.Abs(a.getMediaStoragePath())
+	if err != nil {
+		a.Log.Error("Storage configuration error", "error", err)
+		return nil, r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Storage configuration error", nil, "")
+	}
+	fullPath, err := filepath.Abs(filepath.Join(baseDir, filePath))
+	if err != nil || !strings.HasPrefix(fullPath, baseDir+string(os.PathSeparator)) {
+		return nil, r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid file path", nil, "")
+	}
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		return nil, r.SendErrorEnvelope(fasthttp.StatusNotFound, "Media file not found", nil, "")
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, r.SendErrorEnvelope(fasthttp.StatusBadRequest, "Invalid file path", nil, "")
+	}
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		a.Log.Error("Failed to read media file", "path", fullPath, "error", err)
+		return nil, r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to read file", nil, "")
+	}
+	return data, nil
+}

--- a/internal/handlers/messages_forward.go
+++ b/internal/handlers/messages_forward.go
@@ -105,7 +105,15 @@ func (a *App) ForwardMessage(r *fastglue.Request) error {
 		msgReq.MediaData = data
 		msgReq.MediaURL = message.MediaURL // reuse the stored file for the new message record
 		msgReq.MediaMimeType = message.MediaMimeType
-		msgReq.MediaFilename = message.MediaFilename
+		// Inbound images/videos/audio/stickers are stored without a filename
+		// (only documents carry one). The Cloud API media upload rejects an
+		// empty multipart filename with "(#100) The parameter file is
+		// required", so synthesize one from the mime type when it's missing.
+		filename := message.MediaFilename
+		if filename == "" {
+			filename = "forwarded" + getExtensionFromMimeType(message.MediaMimeType)
+		}
+		msgReq.MediaFilename = filename
 		msgReq.Caption = message.Content
 		msgReq.Content = message.Content
 

--- a/internal/handlers/messages_forward.go
+++ b/internal/handlers/messages_forward.go
@@ -101,6 +101,9 @@ func (a *App) ForwardMessage(r *fastglue.Request) error {
 		if data == nil {
 			return errResp
 		}
+		if len(data) == 0 {
+			return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Media file is empty", nil, "")
+		}
 		msgReq.Type = message.MessageType
 		msgReq.MediaData = data
 		msgReq.MediaURL = message.MediaURL // reuse the stored file for the new message record

--- a/pkg/whatsapp/client.go
+++ b/pkg/whatsapp/client.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"strings"
 	"time"
 
 	"github.com/zerodha/logf"
@@ -311,22 +314,45 @@ func (c *Client) UploadMedia(ctx context.Context, account *Account, data []byte,
 		filename = "file"
 	}
 
-	// Create multipart form body
+	// Sanitize filename for the multipart header — forwarding is the first
+	// path that routes a remote-contact-controlled filename (stored from
+	// msg.Document.Filename) into this body. Use mime/multipart.Writer so
+	// quoting/escaping is handled, and strip CR/LF which would corrupt the
+	// header. mimeType is also stripped of CR/LF as defense-in-depth.
+	filename = strings.ReplaceAll(filename, "\r", "")
+	filename = strings.ReplaceAll(filename, "\n", "")
+	mimeType = strings.ReplaceAll(mimeType, "\r", "")
+	mimeType = strings.ReplaceAll(mimeType, "\n", "")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
 	body := &bytes.Buffer{}
-	boundary := "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+	writer := multipart.NewWriter(body)
 
-	// Build multipart body manually
-	fmt.Fprintf(body, "--%s\r\n", boundary)
-	body.WriteString("Content-Disposition: form-data; name=\"messaging_product\"\r\n\r\n")
-	body.WriteString("whatsapp\r\n")
+	if err := writer.WriteField("messaging_product", "whatsapp"); err != nil {
+		return "", fmt.Errorf("failed to write multipart field: %w", err)
+	}
 
-	fmt.Fprintf(body, "--%s\r\n", boundary)
-	fmt.Fprintf(body, "Content-Disposition: form-data; name=\"file\"; filename=\"%s\"\r\n", filename)
-	fmt.Fprintf(body, "Content-Type: %s\r\n\r\n", mimeType)
-	body.Write(data)
-	body.WriteString("\r\n")
-
-	fmt.Fprintf(body, "--%s--\r\n", boundary)
+	// Use CreatePart with an explicit header so we can set the real MIME
+	// type while still getting the escaping that multipart.Writer provides
+	// via escapeQuotes (backslash and double-quote). The header values are
+	// already stripped of CR/LF above.
+	h := make(textproto.MIMEHeader)
+	// Escape backslash and quote the same way mime/multipart does.
+	escapedFilename := strings.ReplaceAll(strings.ReplaceAll(filename, "\\", "\\\\"), `"`, `\"`)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, "file", escapedFilename))
+	h.Set("Content-Type", mimeType)
+	part, err := writer.CreatePart(h)
+	if err != nil {
+		return "", fmt.Errorf("failed to create multipart file part: %w", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		return "", fmt.Errorf("failed to write media data: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("failed to close multipart writer: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
@@ -334,7 +360,7 @@ func (c *Client) UploadMedia(ctx context.Context, account *Account, data []byte,
 	}
 
 	req.Header.Set("Authorization", "Bearer "+account.AccessToken)
-	req.Header.Set("Content-Type", fmt.Sprintf("multipart/form-data; boundary=%s", boundary))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/pkg/whatsapp/client.go
+++ b/pkg/whatsapp/client.go
@@ -303,6 +303,14 @@ type UploadMediaResponse struct {
 func (c *Client) UploadMedia(ctx context.Context, account *Account, data []byte, mimeType, filename string) (string, error) {
 	url := fmt.Sprintf("%s/%s/%s/media", c.getBaseURL(), account.APIVersion, account.PhoneID)
 
+	// An empty multipart filename makes Meta treat the part as a plain field
+	// rather than a file upload, failing with "(#100) The parameter file is
+	// required". Guarantee a non-empty name for any caller (e.g. forwarding
+	// inbound images, which carry no filename).
+	if filename == "" {
+		filename = "file"
+	}
+
 	// Create multipart form body
 	body := &bytes.Buffer{}
 	boundary := "----WebKitFormBoundary7MA4YWxkTrZu0gW"


### PR DESCRIPTION
## Why

The Cloud API has no native forward endpoint — the `forwarded` flag exists only as inbound metadata, and the "Forwarded" label is consumer-app only. Agents coming from other inboxes expect to forward a message (an address, a photo, a document) to another contact without re-typing or re-downloading it, so this implements the same approach commercial inboxes use: **re-send the content as a new message**.

## What

**Backend** — `POST /api/messages/{id}/forward` with `{contact_id, whatsapp_account?}` (new `internal/handlers/messages_forward.go`):
- The agent must have access to **both** conversations (same assignment scoping as the rest of the chat handlers); forwarding to the same conversation is rejected.
- Outgoing account resolution: request override → destination contact's account → default account.
- `text` copies the content; `image/video/audio/document` re-read the file from local storage (reusing `ServeMedia`'s path-traversal/symlink guards) and re-upload it, since inbound Meta media IDs are **not reusable for sending**. Captions are preserved. Other types → 400.
- Delivery goes through `SendOutgoingMessage`, so status tracking, WS broadcast and webhooks behave like any outgoing message — a closed 24h service window on the destination surfaces as a normal failed message with its `error_message`.

**Frontend** — a Forward button on message hover next to Reply (both directions, only for forwardable types) opening a dialog with debounced server-side contact search (300 ms, excludes the current contact). i18n: en/es translated; ar/hi/ta get English placeholders (same pattern as the existing locales).

## Limitations (platform, not implementation)

- The recipient sees a normal message — no "Forwarded" label is possible through the Cloud API.
- View-once messages can't be forwarded (WhatsApp blocks this by design across the platform).

## Testing

- `go build ./...` + `go vet`, frontend build pass.
- Verified on our production deployment: forwarding text, images and documents between real conversations (media re-uploads correctly, captions preserved); non-forwardable types don't show the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
