### PR TITLE
fix(chat): use i18n key for the unsupported-message bubble

### DIFF
--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -2180,7 +2180,7 @@ async function sendMediaMessage() {
                 <div v-else-if="message.message_type === 'unsupported'" class="mb-2">
                   <div class="flex items-center gap-2 px-3 py-2 bg-muted/50 rounded-lg text-muted-foreground">
                     <AlertCircle class="h-4 w-4 shrink-0" />
-                    <span class="text-sm italic">This message type is not supported</span>
+                    <span class="text-sm italic">{{ $t('chat.unsupportedMessage') }}</span>
                   </div>
                 </div>
                 <!-- Button reply - WhatsApp style -->


### PR DESCRIPTION
The "unsupported message" bubble in the chat hardcodes the English string:

```vue
<span class="text-sm italic">This message type is not supported</span>
```

even though `chat.unsupportedMessage` already exists — translated — in all five locales. This switches it to `{{ $t('chat.unsupportedMessage') }}`. English output is unchanged; the other locales stop showing English.

(Context where this shows up a lot: view-once photos/videos arrive through the Cloud API webhook as `unsupported`, since Meta never delivers their media to the API.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
