### PR TITLE
fix(reply): resolve quoted context for replies to business-sent messages

### DIFF
--- a/internal/handlers/chatbot_processor.go
+++ b/internal/handlers/chatbot_processor.go
@@ -1278,6 +1278,28 @@ type Reaction struct {
 	FromUser  string `json:"from_user,omitempty"`  // User ID if from agent
 }
 
+// resolveMessageByWAMID looks up a stored message by its WhatsApp message ID.
+// WhatsApp encodes the peer's phone number into the WAMID prefix, so the same
+// message carries a different WAMID from the sender's vs the recipient's
+// perspective. When the exact match fails (e.g. a customer replies to or
+// reacts to a message the business sent, whose stored WAMID is the sender-side
+// value), fall back to matching on the unique suffix after "FQIA" + a 4-char
+// type indicator (e.g. "ERgS", "EhgU"), which is stable across perspectives.
+func (a *App) resolveMessageByWAMID(wamid string) (*models.Message, bool) {
+	var m models.Message
+	if err := a.DB.Where("whats_app_message_id = ?", wamid).First(&m).Error; err == nil {
+		return &m, true
+	}
+	if idx := strings.Index(wamid, "FQIA"); idx != -1 {
+		if start := idx + 8; start < len(wamid) {
+			if err := a.DB.Where("whats_app_message_id LIKE ?", "%"+wamid[start:]).First(&m).Error; err == nil {
+				return &m, true
+			}
+		}
+	}
+	return nil, false
+}
+
 // handleIncomingReaction handles incoming reaction messages from WhatsApp
 func (a *App) handleIncomingReaction(account *models.WhatsAppAccount, fromPhone, messageWAMID, emoji, profileName string) {
 	a.Log.Info("Handling incoming reaction",
@@ -1286,30 +1308,12 @@ func (a *App) handleIncomingReaction(account *models.WhatsAppAccount, fromPhone,
 		"emoji", emoji,
 	)
 
-	// Find the message being reacted to
-	// WhatsApp encodes phone numbers in the WAMID prefix, so the same message
-	// has different WAMIDs from sender vs recipient perspective.
-	// We match on the suffix after "FQIA" + 4 chars (type indicator like "ERgS" or "EhgU")
-	var message models.Message
-	if err := a.DB.Where("whats_app_message_id = ?", messageWAMID).First(&message).Error; err != nil {
-		// Try matching on WAMID suffix (the unique message ID part)
-		if idx := strings.Index(messageWAMID, "FQIA"); idx != -1 {
-			// Extract suffix after "FQIA" + 4 char type indicator (e.g., "ERgS", "EhgU")
-			suffixStart := idx + 8
-			if suffixStart < len(messageWAMID) {
-				suffix := messageWAMID[suffixStart:]
-				if err := a.DB.Where("whats_app_message_id LIKE ?", "%"+suffix).First(&message).Error; err != nil {
-					a.Log.Warn("Message not found for reaction", "wamid", messageWAMID, "suffix", suffix)
-					return
-				}
-			} else {
-				a.Log.Warn("Message not found for reaction - invalid WAMID format", "wamid", messageWAMID)
-				return
-			}
-		} else {
-			a.Log.Warn("Message not found for reaction - no FQIA pattern", "wamid", messageWAMID)
-			return
-		}
+	// Find the message being reacted to (exact match, with the cross-perspective
+	// WAMID fallback — see resolveMessageByWAMID).
+	message, ok := a.resolveMessageByWAMID(messageWAMID)
+	if !ok {
+		a.Log.Warn("Message not found for reaction", "wamid", messageWAMID)
+		return
 	}
 
 	// Get or create contact
@@ -1360,7 +1364,7 @@ func (a *App) handleIncomingReaction(account *models.WhatsAppAccount, fromPhone,
 	metadata["reactions"] = newReactions
 
 	// Save to database
-	if err := a.DB.Model(&message).Update("metadata", metadata).Error; err != nil {
+	if err := a.DB.Model(message).Update("metadata", metadata).Error; err != nil {
 		a.Log.Error("Failed to update message reactions", "error", err)
 		return
 	}
@@ -1558,10 +1562,12 @@ func (a *App) saveIncomingMessage(account *models.WhatsAppAccount, contact *mode
 		Status:            models.MessageStatusReceived,
 	}
 
-	// Handle reply context - look up the original message by WhatsApp message ID
+	// Handle reply context - look up the original message by WhatsApp message ID.
+	// Uses the cross-perspective WAMID fallback so replies to messages the
+	// business sent (whose stored WAMID differs from the context.id Meta sends
+	// on the inbound reply) still resolve. See resolveMessageByWAMID.
 	if replyToWAMID != "" {
-		var replyToMsg models.Message
-		if err := a.DB.Where("whats_app_message_id = ?", replyToWAMID).First(&replyToMsg).Error; err == nil {
+		if replyToMsg, ok := a.resolveMessageByWAMID(replyToWAMID); ok {
 			message.IsReply = true
 			message.ReplyToMessageID = &replyToMsg.ID
 		} else {

--- a/internal/handlers/chatbot_processor_test.go
+++ b/internal/handlers/chatbot_processor_test.go
@@ -637,6 +637,50 @@ func TestSaveIncomingMessage_WithReplyContext(t *testing.T) {
 	assert.Equal(t, originalMsg.ID, *replyMsg.ReplyToMessageID)
 }
 
+// TestSaveIncomingMessage_ReplyToBusinessSentMessage exercises the
+// cross-perspective WAMID fallback: when a customer replies to a message the
+// business SENT, Meta's inbound context.id carries the recipient-perspective
+// WAMID, which differs (in the phone-encoded prefix + type indicator) from the
+// sender-perspective WAMID stored on the outbound row. Only the unique suffix
+// after "FQIA" + 4 chars is stable, so the reply must still resolve via the
+// LIKE-suffix fallback rather than the exact match.
+func TestSaveIncomingMessage_ReplyToBusinessSentMessage(t *testing.T) {
+	app := newProcessorTestApp(t)
+	org, account := createProcessorTestOrg(t, app)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+
+	// The unique message-id suffix is identical from both perspectives.
+	suffix := "gBBy" + uuid.New().String()[:12]
+	// Outbound (business-sent) message stores the sender-perspective WAMID.
+	sentWAMID := "wamid.HBgLc2VuZGVyUGhvbmU" + "FQIA" + "EhgS" + suffix
+	// The inbound reply's context.id is the recipient-perspective WAMID:
+	// different prefix + type indicator, same suffix. Exact match must miss.
+	replyContextWAMID := "wamid.HBgLcmVjaXBpZW50Tm8" + "FQIA" + "ERgU" + suffix
+	require.NotEqual(t, sentWAMID, replyContextWAMID)
+
+	sentMsg := models.Message{
+		BaseModel:         models.BaseModel{ID: uuid.New()},
+		OrganizationID:    org.ID,
+		WhatsAppAccount:   account.Name,
+		ContactID:         contact.ID,
+		WhatsAppMessageID: sentWAMID,
+		Direction:         models.DirectionOutgoing,
+		MessageType:       models.MessageTypeText,
+		Content:           "Message the business sent",
+		Status:            models.MessageStatusSent,
+	}
+	require.NoError(t, app.DB.Create(&sentMsg).Error)
+
+	replyWAMID := "wamid.reply_" + uuid.New().String()[:8]
+	app.saveIncomingMessage(account, contact, replyWAMID, "text", "Replying to your message", nil, replyContextWAMID)
+
+	var replyMsg models.Message
+	require.NoError(t, app.DB.Where("whats_app_message_id = ?", replyWAMID).First(&replyMsg).Error)
+	assert.True(t, replyMsg.IsReply, "reply to a business-sent message should resolve via the WAMID suffix fallback")
+	require.NotNil(t, replyMsg.ReplyToMessageID)
+	assert.Equal(t, sentMsg.ID, *replyMsg.ReplyToMessageID)
+}
+
 func TestSaveIncomingMessage_LongContent(t *testing.T) {
 	app := newProcessorTestApp(t)
 	org, account := createProcessorTestOrg(t, app)


### PR DESCRIPTION
## Problem

When a customer **replies to a message the business sent** (WhatsApp reply/quote), the quoted context never renders — the reply shows up as a plain message with no quoted preview. Replies to the customer's *own* earlier inbound message do render correctly.

## Root cause

WhatsApp encodes the peer's phone number into the WAMID prefix, so the **same message has a different WAMID from the sender's vs the recipient's perspective**.

- An outbound message stores the **sender-perspective** WAMID (the `id` Meta returns from the send call).
- When the customer replies to it, the inbound webhook's `context.id` is the **recipient-perspective** WAMID.

`saveIncomingMessage` resolves the quoted message with an **exact match only**:

```go
a.DB.Where("whats_app_message_id = ?", replyToWAMID).First(&replyToMsg)
```

The two WAMIDs never match, so it logs `"Reply-to message not found"`, `IsReply` stays `false`, and the frontend has nothing to render.

This is the *same* asymmetry that `handleIncomingReaction` already handles — it falls back to matching on the unique suffix after `"FQIA"` + a 4-char type indicator, which is stable across perspectives. The reaction path had the fallback; the reply path never got it.

## Fix

- Extract the exact-then-`FQIA`-suffix lookup into a shared helper `resolveMessageByWAMID(wamid) (*models.Message, bool)`.
- Use it on the reply path in `saveIncomingMessage`.
- Refactor `handleIncomingReaction` to use the same helper, removing the duplicated `FQIA` magic-constant logic.

No schema change — `IsReply` / `ReplyToMessageID` / the preloaded `ReplyToMessage` relation and the API/DTO already exist; this only fixes resolution.

## Tests

Added `TestSaveIncomingMessage_ReplyToBusinessSentMessage`: seeds an **outbound** message with a sender-perspective WAMID, processes an inbound reply whose `context.id` is the recipient-perspective WAMID (different prefix + type indicator, same suffix), and asserts the reply resolves (`IsReply == true`, `ReplyToMessageID` points at the outbound message). The existing exact-match reply test and the reaction tests continue to cover their paths.

`go build ./...`, `go vet ./...` clean.
