### PR TITLE
fix(contacts): stop incoming messages from reverting manually set contact names

### DIFF
--- a/internal/contactutil/contactutil.go
+++ b/internal/contactutil/contactutil.go
@@ -10,7 +10,8 @@ import (
 // Merges behaviors from both handler and worker implementations:
 //   - Normalizes phone (strips leading "+")
 //   - Tries both normalized and +prefix forms
-//   - Updates profile name if changed
+//   - Refreshes the profile name from WhatsApp, unless a user set it manually
+//     (Contact.NameManuallySet)
 //   - Handles race conditions on create by re-fetching
 //   - Restores soft-deleted contacts if found
 //
@@ -30,10 +31,7 @@ func GetOrCreateContact(db *gorm.DB, orgID uuid.UUID, phoneNumber, profileName s
 			db.Unscoped().Model(&contact).Update("deleted_at", nil)
 			contact.DeletedAt.Valid = false
 		}
-		// Update profile name if changed
-		if profileName != "" && contact.ProfileName != profileName {
-			db.Model(&contact).Update("profile_name", profileName)
-		}
+		refreshProfileName(db, &contact, profileName)
 		return &contact, false, nil
 	}
 
@@ -44,9 +42,7 @@ func GetOrCreateContact(db *gorm.DB, orgID uuid.UUID, phoneNumber, profileName s
 			db.Unscoped().Model(&contact).Update("deleted_at", nil)
 			contact.DeletedAt.Valid = false
 		}
-		if profileName != "" && contact.ProfileName != profileName {
-			db.Model(&contact).Update("profile_name", profileName)
-		}
+		refreshProfileName(db, &contact, profileName)
 		return &contact, false, nil
 	}
 
@@ -70,6 +66,21 @@ func GetOrCreateContact(db *gorm.DB, orgID uuid.UUID, phoneNumber, profileName s
 		return nil, false, err
 	}
 	return &contact, true, nil
+}
+
+// refreshProfileName syncs the stored profile name with the one WhatsApp reports.
+//
+// It is a no-op when the name was set manually (via the UI or an import): the
+// contact list is a place users curate, and GetOrCreateContact runs on every
+// inbound message, so without this guard a single reply from the contact would
+// silently revert any name a user had typed.
+func refreshProfileName(db *gorm.DB, contact *models.Contact, profileName string) {
+	if contact.NameManuallySet || profileName == "" || contact.ProfileName == profileName {
+		return
+	}
+	if err := db.Model(contact).Update("profile_name", profileName).Error; err == nil {
+		contact.ProfileName = profileName
+	}
 }
 
 // FindContact finds a contact for the given phone number with both forms (normalized and +prefix).

--- a/internal/contactutil/contactutil_test.go
+++ b/internal/contactutil/contactutil_test.go
@@ -105,3 +105,58 @@ func TestGetOrCreateContact_UpdatesProfileName(t *testing.T) {
 	require.NoError(t, db.First(&reloaded, contact.ID).Error)
 	assert.Equal(t, "New Name", reloaded.ProfileName)
 }
+
+// TestGetOrCreateContact_PreservesManuallySetName guards the case where a user
+// renames a contact in the UI: GetOrCreateContact runs on every inbound message,
+// so without the NameManuallySet check the next reply from that contact would
+// silently restore the name reported by WhatsApp.
+func TestGetOrCreateContact_PreservesManuallySetName(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	uid := uuid.New().String()[:8]
+	org := models.Organization{BaseModel: models.BaseModel{ID: uuid.New()}, Name: "test-" + uid, Slug: "test-" + uid}
+	require.NoError(t, db.Create(&org).Error)
+
+	existing := models.Contact{
+		BaseModel:       models.BaseModel{ID: uuid.New()},
+		OrganizationID:  org.ID,
+		PhoneNumber:     "1234567890",
+		ProfileName:     "Ferretería Ruiz",
+		NameManuallySet: true,
+	}
+	require.NoError(t, db.Create(&existing).Error)
+
+	contact, isNew, err := GetOrCreateContact(db, org.ID, "1234567890", "Juanito 🔥")
+	require.NoError(t, err)
+	assert.False(t, isNew)
+	assert.Equal(t, "Ferretería Ruiz", contact.ProfileName)
+
+	var reloaded models.Contact
+	require.NoError(t, db.First(&reloaded, contact.ID).Error)
+	assert.Equal(t, "Ferretería Ruiz", reloaded.ProfileName, "a manually set name must survive incoming messages")
+}
+
+// TestGetOrCreateContact_PreservesManuallySetNamePlusPrefix covers the same
+// guard on the +prefix lookup branch, which duplicates the update logic.
+func TestGetOrCreateContact_PreservesManuallySetNamePlusPrefix(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	uid := uuid.New().String()[:8]
+	org := models.Organization{BaseModel: models.BaseModel{ID: uuid.New()}, Name: "test-" + uid, Slug: "test-" + uid}
+	require.NoError(t, db.Create(&org).Error)
+
+	existing := models.Contact{
+		BaseModel:       models.BaseModel{ID: uuid.New()},
+		OrganizationID:  org.ID,
+		PhoneNumber:     "+1234567890",
+		ProfileName:     "Ferretería Ruiz",
+		NameManuallySet: true,
+	}
+	require.NoError(t, db.Create(&existing).Error)
+
+	contact, isNew, err := GetOrCreateContact(db, org.ID, "1234567890", "Juanito 🔥")
+	require.NoError(t, err)
+	assert.False(t, isNew)
+
+	var reloaded models.Contact
+	require.NoError(t, db.First(&reloaded, contact.ID).Error)
+	assert.Equal(t, "Ferretería Ruiz", reloaded.ProfileName)
+}

--- a/internal/handlers/contacts.go
+++ b/internal/handlers/contacts.go
@@ -1365,6 +1365,7 @@ func (a *App) CreateContact(r *fastglue.Request) error {
 			updates := map[string]any{}
 			if req.ProfileName != "" {
 				updates["profile_name"] = req.ProfileName
+				updates["name_manually_set"] = true
 			}
 			if req.WhatsAppAccount != "" {
 				updates["whats_app_account"] = req.WhatsAppAccount
@@ -1395,6 +1396,7 @@ func (a *App) CreateContact(r *fastglue.Request) error {
 		OrganizationID:  orgID,
 		PhoneNumber:     normalizedPhone,
 		ProfileName:     req.ProfileName,
+		NameManuallySet: req.ProfileName != "",
 		WhatsAppAccount: req.WhatsAppAccount,
 	}
 
@@ -1467,6 +1469,10 @@ func (a *App) UpdateContact(r *fastglue.Request) error {
 
 	if req.ProfileName != nil {
 		updates["profile_name"] = *req.ProfileName
+		// Flag the name as user-owned so incoming webhooks stop overwriting it
+		// with the WhatsApp profile name. Clearing the name hands control back
+		// to WhatsApp.
+		updates["name_manually_set"] = *req.ProfileName != ""
 	}
 	if req.WhatsAppAccount != nil {
 		updates["whats_app_account"] = *req.WhatsAppAccount

--- a/internal/handlers/import_export.go
+++ b/internal/handlers/import_export.go
@@ -36,6 +36,9 @@ type ImportConfig struct {
 	ColumnTransform map[string]func(string) (any, error)
 	UniqueColumn    string // Column to check for duplicates (e.g., "phone_number")
 	BeforeCreate    func(db *gorm.DB, orgID uuid.UUID, record map[string]any) error
+	// NormalizeRecord may add or adjust columns after a row is parsed, for both
+	// newly created and updated records.
+	NormalizeRecord func(record map[string]any)
 }
 
 // Supported export/import configurations
@@ -127,6 +130,13 @@ var importConfigs = map[string]ImportConfig{
 		RequiredColumns: []string{"phone_number"},
 		OptionalColumns: []string{"profile_name", "whats_app_account", "tags", "assigned_user_id"},
 		UniqueColumn:    "phone_number",
+		NormalizeRecord: func(record map[string]any) {
+			// An imported name is a deliberate choice by the user; protect it
+			// from being overwritten by the contact's WhatsApp profile name.
+			if name, ok := record["profile_name"].(string); ok && name != "" {
+				record["name_manually_set"] = true
+			}
+		},
 		ColumnTransform: map[string]func(string) (any, error){
 			"phone_number": func(s string) (any, error) {
 				// Normalize phone number - remove + prefix
@@ -542,6 +552,12 @@ func (a *App) ImportData(r *fastglue.Request) error {
 		if hasError {
 			errors++
 			continue
+		}
+
+		// Let the resource derive extra columns from the parsed row. Runs for
+		// both the create and the update-on-duplicate paths.
+		if config.NormalizeRecord != nil {
+			config.NormalizeRecord(recordMap)
 		}
 
 		// Check for duplicate based on unique column

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -344,9 +344,13 @@ func (a *WhatsAppAccount) DecryptSecrets(encryptionKey string) {
 // Contact represents a WhatsApp contact/profile
 type Contact struct {
 	BaseModel
-	OrganizationID     uuid.UUID  `gorm:"type:uuid;index;not null" json:"organization_id"`
-	PhoneNumber        string     `gorm:"size:50;not null" json:"phone_number"`
-	ProfileName        string     `gorm:"size:255" json:"profile_name"`
+	OrganizationID uuid.UUID `gorm:"type:uuid;index;not null" json:"organization_id"`
+	PhoneNumber    string    `gorm:"size:50;not null" json:"phone_number"`
+	ProfileName    string    `gorm:"size:255" json:"profile_name"`
+	// NameManuallySet marks ProfileName as edited by a user (via the UI or an
+	// import) rather than taken from the WhatsApp profile. When true, incoming
+	// webhooks must not overwrite it with the name WhatsApp reports.
+	NameManuallySet    bool       `gorm:"default:false" json:"name_manually_set"`
 	WhatsAppAccount    string     `gorm:"size:100;index" json:"whatsapp_account"` // References WhatsAppAccount.Name
 	AssignedUserID     *uuid.UUID `gorm:"type:uuid;index" json:"assigned_user_id,omitempty"`
 	LastMessageAt      *time.Time `json:"last_message_at,omitempty"`


### PR DESCRIPTION
## Problem

Renaming a contact in the UI does not stick. The new name survives until that contact sends their next message, then silently reverts to the name from their WhatsApp profile. Reproduced repeatedly on a live deployment.

`Contact.ProfileName` serves double duty: it is both the name WhatsApp reports and the name users edit. `GetOrCreateContact` runs on **every** inbound message and refreshes it:

```go
// Update profile name if changed
if profileName != "" && contact.ProfileName != profileName {
    db.Model(&contact).Update("profile_name", profileName)
}
```

The condition `contact.ProfileName != profileName` is true exactly when someone has renamed the contact, so the rename is what triggers its own reversion. The same path is reached from incoming messages (`chatbot_processor.go`), reactions, coexistence contact sync (`webhook.go`) and campaign jobs (`worker.go`), so a single emoji reaction is enough to undo an edit.

This also quietly affects CSV imports: names imported from a CRM are overwritten as soon as each contact writes in.

## Fix

Add `Contact.NameManuallySet` and use it to distinguish a name WhatsApp supplied from one a user chose:

- set to `true` where a name is written deliberately — `UpdateContact`, `CreateContact`, and CSV import when the row carries `profile_name`;
- `GetOrCreateContact` skips the refresh when it is `true`.

Contacts that were never renamed keep syncing their name from WhatsApp exactly as before. Clearing the name field in the UI sets the flag back to `false`, handing control to WhatsApp again — an intentional escape hatch rather than a one-way door.

The refresh logic was copy-pasted across the normalized and `+prefix` lookup branches; it is now a single `refreshProfileName` helper, so the guard cannot drift between the two.

The importer gained a small `NormalizeRecord` hook, called for both the create and update-on-duplicate paths, since the existing `BeforeCreate` hook only runs on create.

## Tests

`internal/contactutil/contactutil_test.go`:

- `TestGetOrCreateContact_PreservesManuallySetName` — a renamed contact keeps its name when a message arrives under a different WhatsApp profile name.
- `TestGetOrCreateContact_PreservesManuallySetNamePlusPrefix` — same guard on the `+prefix` branch.

The existing `TestGetOrCreateContact_UpdatesProfileName` is unchanged and still passes, pinning the auto-sync behaviour for contacts nobody has renamed.

The new column is additive with a `false` default, so existing rows keep the current behaviour until a name is edited. Deployments that already imported names from a CRM can opt those rows in with a one-off `UPDATE contacts SET name_manually_set = true WHERE ...` if they want the imported names protected retroactively.
