### PR TITLE
fix(business-hours): send the out-of-hours notice once per conversation, not per message

### DIFF
--- a/internal/handlers/agent_transfers.go
+++ b/internal/handlers/agent_transfers.go
@@ -1231,9 +1231,7 @@ func (a *App) createTransferToQueue(account *models.WhatsAppAccount, contact *mo
 	if settings != nil && settings.BusinessHours.Enabled && len(settings.BusinessHours.Hours) > 0 {
 		if !a.isWithinBusinessHours(settings.BusinessHours.Hours) {
 			a.Log.Info("Outside business hours, sending out-of-hours message instead of queue transfer", "contact_id", contact.ID, "source", source)
-			if settings.BusinessHours.OutOfHoursMessage != "" {
-				_ = a.sendAndSaveTextMessage(account, contact, settings.BusinessHours.OutOfHoursMessage)
-			}
+			a.sendOutOfHoursMessage(account, contact, settings)
 			return
 		}
 	}
@@ -1270,9 +1268,7 @@ func (a *App) createTransferFromKeyword(account *models.WhatsAppAccount, contact
 	if settings != nil && settings.BusinessHours.Enabled && len(settings.BusinessHours.Hours) > 0 {
 		if !a.isWithinBusinessHours(settings.BusinessHours.Hours) {
 			a.Log.Info("Outside business hours, sending out of hours message instead of transfer", "contact_id", contact.ID)
-			if settings.BusinessHours.OutOfHoursMessage != "" {
-				_ = a.sendAndSaveTextMessage(account, contact, settings.BusinessHours.OutOfHoursMessage)
-			}
+			a.sendOutOfHoursMessage(account, contact, settings)
 			return
 		}
 	}
@@ -1328,9 +1324,7 @@ func (a *App) createTransferToTeam(account *models.WhatsAppAccount, contact *mod
 	if settings != nil && settings.BusinessHours.Enabled && len(settings.BusinessHours.Hours) > 0 {
 		if !a.isWithinBusinessHours(settings.BusinessHours.Hours) {
 			a.Log.Info("Outside business hours, sending out-of-hours message instead of team transfer", "contact_id", contact.ID, "team_id", teamID, "source", source)
-			if settings.BusinessHours.OutOfHoursMessage != "" {
-				_ = a.sendAndSaveTextMessage(account, contact, settings.BusinessHours.OutOfHoursMessage)
-			}
+			a.sendOutOfHoursMessage(account, contact, settings)
 			return
 		}
 	}

--- a/internal/handlers/chatbot_processor.go
+++ b/internal/handlers/chatbot_processor.go
@@ -224,11 +224,7 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 			// If automated responses are not allowed outside hours, send out-of-hours message and stop
 			if !settings.BusinessHours.AllowAutomatedOutside {
 				a.Log.Info("Outside business hours, sending out of hours message")
-				if settings.BusinessHours.OutOfHoursMessage != "" {
-					if err := a.sendAndSaveTextMessage(account, contact, settings.BusinessHours.OutOfHoursMessage); err != nil {
-						a.Log.Error("Failed to send out of hours message", "error", err, "contact", contact.PhoneNumber)
-					}
-				}
+				a.sendOutOfHoursMessage(account, contact, settings)
 				return
 			}
 			// AllowAutomatedOutsideHours is true, continue processing flows/keywords/AI
@@ -258,11 +254,7 @@ func (a *App) processIncomingMessageFull(phoneNumberID string, msg IncomingTextM
 		if settings.BusinessHours.Enabled && len(settings.BusinessHours.Hours) > 0 {
 			if !a.isWithinBusinessHours(settings.BusinessHours.Hours) {
 				a.Log.Info("Outside business hours, sending out of hours message instead of transfer")
-				if settings.BusinessHours.OutOfHoursMessage != "" {
-					if err := a.sendAndSaveTextMessage(account, contact, settings.BusinessHours.OutOfHoursMessage); err != nil {
-						a.Log.Error("Failed to send out of hours message", "error", err, "contact", contact.PhoneNumber)
-					}
-				}
+				a.sendOutOfHoursMessage(account, contact, settings)
 				return
 			}
 		}
@@ -1624,6 +1616,44 @@ func (a *App) saveIncomingMessage(account *models.WhatsAppAccount, contact *mode
 		WhatsAppAccount: account.Name,
 		Direction:       models.DirectionIncoming,
 	})
+}
+
+// sendOutOfHoursMessage sends the configured out-of-hours notice, at most once
+// per conversation.
+//
+// It is reached from every path that declines to serve a contact outside
+// business hours, and those paths run per inbound message: without this guard a
+// customer who sends "hi", "are you open?", "I need a quote" back to back gets
+// the same notice three times, which reads as a broken bot rather than an
+// answer. The repeat window mirrors the chatbot session timeout, so a contact
+// coming back after a real gap is notified again.
+func (a *App) sendOutOfHoursMessage(account *models.WhatsAppAccount, contact *models.Contact, settings *models.ChatbotSettings) {
+	if settings == nil || settings.BusinessHours.OutOfHoursMessage == "" {
+		return
+	}
+
+	window := time.Duration(settings.SessionTimeoutMins) * time.Minute
+	if window <= 0 {
+		window = 30 * time.Minute
+	}
+	if contact.OutOfHoursNotifiedAt != nil && time.Since(*contact.OutOfHoursNotifiedAt) < window {
+		a.Log.Debug("Out-of-hours message already sent for this conversation, skipping",
+			"contact_id", contact.ID, "last_sent", contact.OutOfHoursNotifiedAt)
+		return
+	}
+
+	if err := a.sendAndSaveTextMessage(account, contact, settings.BusinessHours.OutOfHoursMessage); err != nil {
+		// Leave the timestamp untouched so the next inbound message retries.
+		a.Log.Error("Failed to send out of hours message", "error", err, "contact", contact.PhoneNumber)
+		return
+	}
+
+	now := time.Now()
+	if err := a.DB.Model(contact).Update("out_of_hours_notified_at", now).Error; err != nil {
+		a.Log.Error("Failed to record out-of-hours notification", "error", err, "contact_id", contact.ID)
+		return
+	}
+	contact.OutOfHoursNotifiedAt = &now
 }
 
 // isWithinBusinessHours checks if current time is within configured business hours

--- a/internal/handlers/chatbot_processor_test.go
+++ b/internal/handlers/chatbot_processor_test.go
@@ -682,6 +682,86 @@ func TestProcessTemplateSessionData_MissingVariable(t *testing.T) {
 }
 
 // =============================================================================
+// sendOutOfHoursMessage
+// =============================================================================
+
+func outOfHoursTestSettings(notice string) *models.ChatbotSettings {
+	settings := &models.ChatbotSettings{SessionTimeoutMins: 30}
+	settings.BusinessHours.Enabled = true
+	settings.BusinessHours.OutOfHoursMessage = notice
+	return settings
+}
+
+// TestSendOutOfHoursMessage_OncePerConversation covers an impatient customer
+// sending several messages after closing time: they should be told once, not
+// once per message.
+func TestSendOutOfHoursMessage_OncePerConversation(t *testing.T) {
+	app := newProcessorTestApp(t)
+	org, account := createProcessorTestOrg(t, app)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+	settings := outOfHoursTestSettings("We are closed. Try our assistant meanwhile.")
+
+	app.sendOutOfHoursMessage(account, contact, settings)
+	app.sendOutOfHoursMessage(account, contact, settings)
+	app.sendOutOfHoursMessage(account, contact, settings)
+
+	var sent int64
+	require.NoError(t, app.DB.Model(&models.Message{}).
+		Where("contact_id = ? AND direction = ?", contact.ID, models.DirectionOutgoing).
+		Count(&sent).Error)
+	assert.Equal(t, int64(1), sent, "out-of-hours notice must not repeat on every inbound message")
+
+	var reloaded models.Contact
+	require.NoError(t, app.DB.First(&reloaded, contact.ID).Error)
+	require.NotNil(t, reloaded.OutOfHoursNotifiedAt, "sending must record when the notice went out")
+}
+
+// TestSendOutOfHoursMessage_ResendsAfterWindow checks the other side of the
+// guard: a contact coming back after a real gap is notified again rather than
+// being silenced forever.
+func TestSendOutOfHoursMessage_ResendsAfterWindow(t *testing.T) {
+	app := newProcessorTestApp(t)
+	org, account := createProcessorTestOrg(t, app)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+	settings := outOfHoursTestSettings("We are closed. Try our assistant meanwhile.")
+
+	app.sendOutOfHoursMessage(account, contact, settings)
+
+	// Backdate the notification well beyond SessionTimeoutMins.
+	past := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, app.DB.Model(contact).Update("out_of_hours_notified_at", past).Error)
+	contact.OutOfHoursNotifiedAt = &past
+
+	app.sendOutOfHoursMessage(account, contact, settings)
+
+	var sent int64
+	require.NoError(t, app.DB.Model(&models.Message{}).
+		Where("contact_id = ? AND direction = ?", contact.ID, models.DirectionOutgoing).
+		Count(&sent).Error)
+	assert.Equal(t, int64(2), sent, "a contact returning after the session window should be notified again")
+}
+
+// TestSendOutOfHoursMessage_NoMessageConfigured guards the no-op path: with no
+// notice configured nothing is sent and nothing is recorded.
+func TestSendOutOfHoursMessage_NoMessageConfigured(t *testing.T) {
+	app := newProcessorTestApp(t)
+	org, account := createProcessorTestOrg(t, app)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+
+	app.sendOutOfHoursMessage(account, contact, outOfHoursTestSettings(""))
+
+	var sent int64
+	require.NoError(t, app.DB.Model(&models.Message{}).
+		Where("contact_id = ? AND direction = ?", contact.ID, models.DirectionOutgoing).
+		Count(&sent).Error)
+	assert.Zero(t, sent)
+
+	var reloaded models.Contact
+	require.NoError(t, app.DB.First(&reloaded, contact.ID).Error)
+	assert.Nil(t, reloaded.OutOfHoursNotifiedAt)
+}
+
+// =============================================================================
 // logSessionMessage
 // =============================================================================
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -366,6 +366,10 @@ type Contact struct {
 	ChatbotLastMessageAt *time.Time `json:"chatbot_last_message_at,omitempty"` // When chatbot last sent a message
 	ChatbotReminderSent  bool       `gorm:"default:false" json:"chatbot_reminder_sent"`
 
+	// OutOfHoursNotifiedAt is when the out-of-hours notice was last sent, so it
+	// goes out once per conversation instead of once per inbound message.
+	OutOfHoursNotifiedAt *time.Time `json:"out_of_hours_notified_at,omitempty"`
+
 	// Relations
 	Organization *Organization `gorm:"foreignKey:OrganizationID" json:"organization,omitempty"`
 	AssignedUser *User         `gorm:"foreignKey:AssignedUserID" json:"assigned_user,omitempty"`


### PR DESCRIPTION
## Problem

Outside business hours, the out-of-hours notice is sent **once per inbound message**, not once per conversation. A customer who writes

> Hola
> ¿están abiertos?
> necesito un repuesto

after closing time receives the same canned notice three times in a row. It reads as a broken bot rather than an answer — and it is the one message a closed business has no chance to follow up on, because nobody is there to smooth it over.

The message is sent from six places, none of which tracks whether the contact has already been told:

- `chatbot_processor.go` — the business-hours gate, and the transfer-keyword branch
- `agent_transfers.go` — `createTransferToQueue`, `createTransferFromKeyword`, `createTransferToTeam`

Every one of those runs per inbound message.

## Fix

Route all six through a single `sendOutOfHoursMessage` helper that records `Contact.OutOfHoursNotifiedAt` and skips the send when the contact was already notified within the chatbot session window (`SessionTimeoutMins`).

Reusing the session window rather than inventing a new setting keeps this consistent with the greeting, which is already once-per-session — and it means a contact returning after a real gap is notified again instead of being silenced permanently. If the send fails the timestamp is left untouched, so the next message retries.

This also collapses the six copies of the same `if OutOfHoursMessage != "" { send }` block into one place.

## Tests

`internal/handlers/chatbot_processor_test.go`:

- `TestSendOutOfHoursMessage_OncePerConversation` — three back-to-back sends produce one outgoing message.
- `TestSendOutOfHoursMessage_ResendsAfterWindow` — backdating the timestamp past the session window lets the next notice through.
- `TestSendOutOfHoursMessage_NoMessageConfigured` — no notice configured sends nothing and records nothing.

## Unrelated observation, for whoever configures business hours

`isWithinBusinessHours` uses `time.Now()`, and there is no timezone conversion anywhere in the repo (no `time.LoadLocation` call exists). The organization `timezone` setting is stored and returned by the API but never read by the scheduler, so hours are evaluated in the **server's** local time. A deployment whose container runs UTC while the business is at UTC-5 sees its configured 09:00–18:00 apply as 04:00–13:00 local.

Setting `TZ` on the process works around it. I left that out of this PR to keep it focused, but it seemed worth flagging — the same applies to `evaluateTimingSchedule` in the graph runner's `timing` node.
