### PR TITLE
fix(sla): stamp SLA deadlines on transfers that predate the configuration

### DIFF
--- a/internal/handlers/sla_processor.go
+++ b/internal/handlers/sla_processor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shridarpatil/whatomate/internal/models"
 	"github.com/shridarpatil/whatomate/internal/websocket"
+	"gorm.io/gorm"
 )
 
 // SLAProcessor handles periodic SLA checks and escalations
@@ -71,9 +72,51 @@ func (p *SLAProcessor) processStaleTransfers() {
 	}
 }
 
+// backfillMissingDeadlines stamps SLA deadlines on active transfers that have
+// none.
+//
+// Deadlines are assigned when a transfer is created, and only while SLA is
+// already enabled. Every SLA task then filters on "deadline IS NOT NULL", so
+// enabling SLA in a deployment that already has open conversations leaves all of
+// them permanently invisible to auto-close, escalation and breach marking — and
+// silently, since nothing reports transfers it never selected. Raising a window
+// from zero later has the same effect.
+//
+// Deriving the deadlines from created_at applies the policy as if it had been
+// configured all along, which is what an operator enabling SLA expects. Already
+// stamped transfers are skipped, so this is idempotent and cannot pull in a
+// deadline that agent activity has extended.
+func (p *SLAProcessor) backfillMissingDeadlines(orgID uuid.UUID, settings models.ChatbotSettings) {
+	backfill := func(column, interval string, window int) {
+		if window <= 0 {
+			return
+		}
+		res := p.app.DB.Model(&models.AgentTransfer{}).
+			Where("organization_id = ? AND status = ? AND "+column+" IS NULL",
+				orgID, models.TransferStatusActive).
+			Update(column, gorm.Expr("created_at + "+interval, window))
+		if res.Error != nil {
+			p.app.Log.Error("Failed to backfill SLA deadline", "error", res.Error, "column", column, "org_id", orgID)
+			return
+		}
+		if res.RowsAffected > 0 {
+			p.app.Log.Info("Backfilled SLA deadline on pre-existing transfers",
+				"column", column, "count", res.RowsAffected, "org_id", orgID)
+		}
+	}
+
+	backfill("expires_at", "make_interval(hours => ?)", settings.SLA.AutoCloseHours)
+	backfill("sla_escalation_at", "make_interval(mins => ?)", settings.SLA.EscalationMinutes)
+	backfill("sla_response_deadline", "make_interval(mins => ?)", settings.SLA.ResponseMinutes)
+}
+
 // processOrganizationSLA processes SLA for a single organization
 func (p *SLAProcessor) processOrganizationSLA(settings models.ChatbotSettings, now time.Time) {
 	orgID := settings.OrganizationID
+
+	// Transfers opened before SLA was configured carry no deadlines, and every
+	// check below skips those. Give them the deadlines they would have had.
+	p.backfillMissingDeadlines(orgID, settings)
 
 	// 1. Auto-close expired transfers
 	if settings.SLA.AutoCloseHours > 0 {

--- a/internal/handlers/sla_processor_internal_test.go
+++ b/internal/handlers/sla_processor_internal_test.go
@@ -288,3 +288,106 @@ func TestSLAEscalationFiresWhenNoAgentResponse(t *testing.T) {
 	assert.Equal(t, 1, updated.SLA.EscalationLevel, "escalation level should increase to 1")
 	require.NotNil(t, updated.SLA.EscalatedAt)
 }
+
+// --- backfillMissingDeadlines ---
+
+// TestBackfillMissingDeadlines_StampsTransfersOpenedBeforeSLA covers enabling SLA
+// on a deployment that already has open conversations. Those transfers carry no
+// deadlines, and every SLA check filters on "deadline IS NOT NULL", so without
+// the backfill they can never be auto-closed, escalated or marked breached.
+func TestBackfillMissingDeadlines_StampsTransfersOpenedBeforeSLA(t *testing.T) {
+	app := newSLATestApp(t)
+	org := testutil.CreateTestOrganization(t, app.DB)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+	agent := testutil.CreateTestUser(t, app.DB, org.ID)
+	account := testutil.CreateTestWhatsAppAccount(t, app.DB, org.ID)
+
+	// Opened three days ago, while SLA was still off: no deadlines at all.
+	transfer := createSLATestTransfer(t, app, org.ID, contact.ID, agent.ID, account.Name, models.SLATracking{})
+	createdAt := time.Now().Add(-72 * time.Hour)
+	require.NoError(t, app.DB.Model(transfer).Update("created_at", createdAt).Error)
+
+	settings := models.ChatbotSettings{
+		OrganizationID: org.ID,
+		SLA: models.SLAConfig{
+			Enabled:           true,
+			AutoCloseHours:    24,
+			EscalationMinutes: 30,
+			ResponseMinutes:   15,
+		},
+	}
+
+	proc := NewSLAProcessor(app, time.Minute)
+	proc.backfillMissingDeadlines(org.ID, settings)
+
+	var updated models.AgentTransfer
+	require.NoError(t, app.DB.Where("id = ?", transfer.ID).First(&updated).Error)
+
+	require.NotNil(t, updated.SLA.ExpiresAt, "expires_at must be stamped or auto-close can never see this transfer")
+	assert.WithinDuration(t, createdAt.Add(24*time.Hour), *updated.SLA.ExpiresAt, time.Minute)
+	require.NotNil(t, updated.SLA.EscalationAt)
+	assert.WithinDuration(t, createdAt.Add(30*time.Minute), *updated.SLA.EscalationAt, time.Minute)
+	require.NotNil(t, updated.SLA.ResponseDeadline)
+	assert.WithinDuration(t, createdAt.Add(15*time.Minute), *updated.SLA.ResponseDeadline, time.Minute)
+
+	assert.True(t, updated.SLA.ExpiresAt.Before(time.Now()),
+		"a transfer open for three days must land past its 24h deadline, ready to be closed")
+}
+
+// TestBackfillMissingDeadlines_LeavesExistingDeadlines guards idempotency: the
+// backfill runs on every tick, so it must never pull back a deadline that agent
+// activity already extended.
+func TestBackfillMissingDeadlines_LeavesExistingDeadlines(t *testing.T) {
+	app := newSLATestApp(t)
+	org := testutil.CreateTestOrganization(t, app.DB)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+	agent := testutil.CreateTestUser(t, app.DB, org.ID)
+	account := testutil.CreateTestWhatsAppAccount(t, app.DB, org.ID)
+
+	extended := time.Now().Add(12 * time.Hour)
+	transfer := createSLATestTransfer(t, app, org.ID, contact.ID, agent.ID, account.Name, models.SLATracking{
+		ExpiresAt: &extended,
+	})
+	require.NoError(t, app.DB.Model(transfer).Update("created_at", time.Now().Add(-72*time.Hour)).Error)
+
+	settings := models.ChatbotSettings{
+		OrganizationID: org.ID,
+		SLA:            models.SLAConfig{Enabled: true, AutoCloseHours: 24},
+	}
+
+	proc := NewSLAProcessor(app, time.Minute)
+	proc.backfillMissingDeadlines(org.ID, settings)
+
+	var updated models.AgentTransfer
+	require.NoError(t, app.DB.Where("id = ?", transfer.ID).First(&updated).Error)
+	require.NotNil(t, updated.SLA.ExpiresAt)
+	assert.WithinDuration(t, extended, *updated.SLA.ExpiresAt, time.Second,
+		"an already stamped deadline must survive the backfill untouched")
+}
+
+// TestBackfillMissingDeadlines_SkipsUnconfiguredWindows checks that a window left
+// at zero stays unset rather than collapsing to the transfer's creation time.
+func TestBackfillMissingDeadlines_SkipsUnconfiguredWindows(t *testing.T) {
+	app := newSLATestApp(t)
+	org := testutil.CreateTestOrganization(t, app.DB)
+	contact := testutil.CreateTestContact(t, app.DB, org.ID)
+	agent := testutil.CreateTestUser(t, app.DB, org.ID)
+	account := testutil.CreateTestWhatsAppAccount(t, app.DB, org.ID)
+
+	transfer := createSLATestTransfer(t, app, org.ID, contact.ID, agent.ID, account.Name, models.SLATracking{})
+
+	settings := models.ChatbotSettings{
+		OrganizationID: org.ID,
+		// Auto-close only; escalation and response windows disabled.
+		SLA: models.SLAConfig{Enabled: true, AutoCloseHours: 24},
+	}
+
+	proc := NewSLAProcessor(app, time.Minute)
+	proc.backfillMissingDeadlines(org.ID, settings)
+
+	var updated models.AgentTransfer
+	require.NoError(t, app.DB.Where("id = ?", transfer.ID).First(&updated).Error)
+	assert.NotNil(t, updated.SLA.ExpiresAt)
+	assert.Nil(t, updated.SLA.EscalationAt, "a disabled window must not be backfilled")
+	assert.Nil(t, updated.SLA.ResponseDeadline, "a disabled window must not be backfilled")
+}


### PR DESCRIPTION
## Problem

Turning SLA on in a deployment that already has open conversations does nothing to those conversations, permanently.

SLA deadlines (`expires_at`, `sla_escalation_at`, `sla_response_deadline`) are stamped in `setSLADeadlines` when a transfer is **created**, and only when SLA is already enabled. All three processing tasks then filter on the deadline being present:

```go
// autoCloseExpiredTransfers
"organization_id = ? AND status = ? AND expires_at IS NOT NULL AND expires_at < ?"
// escalateTransfers
"... AND sla_escalation_at IS NOT NULL AND sla_escalation_at < ? ..."
// markSLABreached
"... AND sla_response_deadline IS NOT NULL AND sla_response_deadline < ? ..."
```

So every transfer opened before SLA was configured is invisible to all of them, forever. Raising a window from zero later on has the same effect.

What makes this expensive is that it fails **silently**. Nothing reports transfers it never selected: the operator enables SLA, sees no errors in the logs, and simply never gets a single auto-close. I hit this on a live deployment with 57 open transfers, 34 of them more than a week old — all with `expires_at IS NULL`, and none of them closable without a manual `UPDATE`.

There is a second-order effect worth noting: a transfer stuck in `active` also makes `hasActiveAgentTransfer` return true forever, so `processIncomingMessageFull` skips chatbot processing for that contact entirely. Those customers stop receiving greetings, keyword replies and out-of-hours notices — which is how I noticed in the first place.

## Fix

Backfill the missing deadlines from `created_at` at the start of each processing tick, applying the configured windows as if they had been in place all along — which is what an operator enabling SLA expects to happen.

Deliberately narrow:

- **Idempotent.** Only rows where the column `IS NULL` are touched, so a deadline that `autoCloseExpiredTransfers` extended after agent activity is never pulled back.
- **Only active transfers.** Closed history is left alone.
- **Respects disabled windows.** A window left at zero stays `NULL` instead of collapsing onto the creation time, so enabling only auto-close does not silently switch on escalation.

Doing it in the processor rather than on settings save also repairs deployments that already went through the upgrade, without requiring anyone to re-save the form.

## Tests

`internal/handlers/sla_processor_internal_test.go`:

- `TestBackfillMissingDeadlines_StampsTransfersOpenedBeforeSLA` — a transfer opened three days ago with no deadlines gets all three, derived from `created_at`, and lands past its 24h expiry ready to be closed.
- `TestBackfillMissingDeadlines_LeavesExistingDeadlines` — an already extended `expires_at` survives untouched.
- `TestBackfillMissingDeadlines_SkipsUnconfiguredWindows` — a zero window stays `NULL`.

Verified locally against Postgres 17 and Redis (not just CI): the full `./internal/...` suite passes with `-p 1`. Note that running the packages in parallel against a single shared test database produces unrelated foreign-key failures in `assignment`, `database` and `worker` — that is pre-existing cross-package interference, not a regression from this change.

`make_interval(hours => ?)` is Postgres-only, consistent with the rest of the schema (jsonb, `gen_random_uuid()`).
