### PR TITLE
fix(chat): compress images client-side to fit the 5 MB image limit

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -368,6 +368,8 @@
     "cannedResponses": "Canned Responses",
     "fileTooLarge": "File too large",
     "fileTooLargeDesc": "Maximum file size is 16MB",
+    "fileTooLargeImage": "Images must be 5 MB or smaller",
+    "fileTooLargeMedia": "The file exceeds the 15 MB limit",
     "unsupportedFileType": "Unsupported file type",
     "unsupportedFileTypeDesc": "Please select an image, video, audio, or document file",
     "audioFile": "Audio file",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -330,6 +330,8 @@
     "cannedResponses": "Respuestas predefinidas",
     "fileTooLarge": "Archivo demasiado grande",
     "fileTooLargeDesc": "El tamaño máximo del archivo es 16MB",
+    "fileTooLargeImage": "La imagen supera el límite de 5 MB de WhatsApp",
+    "fileTooLargeMedia": "El archivo supera el límite de 15 MB",
     "unsupportedFileType": "Tipo de archivo no compatible",
     "unsupportedFileTypeDesc": "Seleccione un archivo de imagen, video, audio o documento",
     "audioFile": "Archivo de audio",

--- a/frontend/src/lib/imageCompression.ts
+++ b/frontend/src/lib/imageCompression.ts
@@ -1,0 +1,87 @@
+// Client-side image downscale/recompress so photos fit WhatsApp Cloud API's
+// 5 MB image limit (Meta accepts only image/jpeg & image/png for `image`
+// messages). Canvas-only, no dependencies. Non-images, animated GIFs and
+// decode failures are returned untouched so the caller's per-type size gate
+// stays authoritative.
+
+export interface CompressOptions {
+  maxDimension?: number   // longest edge cap, px (default 2048)
+  targetBytes?: number    // stay under this (default 4.5 MB, margin below Meta's 5 MB)
+  minQuality?: number     // JPEG quality floor before shrinking dimensions (default 0.5)
+  skipBelowBytes?: number // leave already-small jpeg/png untouched (default 4.5 MB)
+}
+
+const MB = 1024 * 1024
+const DEFAULTS: Required<CompressOptions> = {
+  maxDimension: 2048,
+  targetBytes: 4.5 * MB,
+  minQuality: 0.5,
+  skipBelowBytes: 4.5 * MB,
+}
+
+/**
+ * Returns a compressed JPEG File when the input is an image that needs it,
+ * otherwise returns the original File unchanged.
+ */
+export async function compressImage(file: File, opts: CompressOptions = {}): Promise<File> {
+  const o = { ...DEFAULTS, ...opts }
+
+  if (!file.type.startsWith('image/')) return file           // only images
+  if (file.type === 'image/gif') return file                 // canvas flattens animation -> skip
+
+  const isJpegOrPng = file.type === 'image/jpeg' || file.type === 'image/png'
+  if (isJpegOrPng && file.size <= o.skipBelowBytes) return file // already fine, keep pristine
+
+  let bitmap: ImageBitmap
+  try {
+    // imageOrientation:'from-image' bakes EXIF rotation into pixels (iPhone photos)
+    bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
+  } catch {
+    return file                                              // HEIC / undecodable -> original, size gate rejects
+  }
+
+  try {
+    let width = bitmap.width
+    let height = bitmap.height
+    const scale = Math.min(1, o.maxDimension / Math.max(width, height))
+    width = Math.round(width * scale)
+    height = Math.round(height * scale)
+
+    let quality = 0.9
+    let blob = await encode(bitmap, width, height, quality)
+    if (!blob) return file                                   // toBlob null -> keep original
+
+    while (blob.size > o.targetBytes) {
+      if (quality > o.minQuality) {
+        quality = Math.max(o.minQuality, quality - 0.1)
+      } else if (Math.max(width, height) > 640) {
+        width = Math.round(width * 0.85)
+        height = Math.round(height * 0.85)
+        quality = 0.8                                        // reset quality after a dimension cut
+      } else {
+        break                                                // best effort; size gate is the final arbiter
+      }
+      const next = await encode(bitmap, width, height, quality)
+      if (!next) break
+      blob = next
+    }
+
+    if (blob.size >= file.size) return file                  // never adopt a bigger result
+    const name = file.name.replace(/\.[^.]+$/, '') + '.jpg'
+    return new File([blob], name, { type: 'image/jpeg', lastModified: Date.now() })
+  } finally {
+    bitmap.close()
+  }
+}
+
+function encode(bitmap: ImageBitmap, w: number, h: number, q: number): Promise<Blob | null> {
+  const canvas = document.createElement('canvas')
+  canvas.width = w
+  canvas.height = h
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return Promise.resolve(null)
+  ctx.fillStyle = '#ffffff'                                  // flatten alpha -> white (transparent PNG -> JPEG)
+  ctx.fillRect(0, 0, w, h)
+  ctx.drawImage(bitmap, 0, 0, w, h)
+  return new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', q))
+}

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -12,6 +12,7 @@ import { useTagsStore } from '@/stores/tags'
 import { TagBadge } from '@/components/ui/tag-badge'
 import { getTagColorClass } from '@/lib/constants'
 import { getErrorMessage } from '@/lib/api-utils'
+import { compressImage } from '@/lib/imageCompression'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -1546,9 +1547,10 @@ function openFilePicker() {
   fileInputRef.value?.click()
 }
 
-function handleFileSelect(event: Event) {
+async function handleFileSelect(event: Event) {
   const input = event.target as HTMLInputElement
   const file = input.files?.[0]
+  input.value = '' // reset so the same file can be selected again
   if (!file) return
 
   // Validate file type
@@ -1561,29 +1563,39 @@ function handleFileSelect(event: Event) {
     return
   }
 
-  // Validate file size (16MB limit for WhatsApp)
-  const maxSize = 16 * 1024 * 1024
-  if (file.size > maxSize) {
+  // Compress images client-side so they fit the Cloud API's 5 MB image limit
+  // (Meta accepts only jpeg/png for `image` messages). No-op for non-images.
+  let outFile = file
+  if (file.type.startsWith('image/')) {
+    try {
+      outFile = await compressImage(file)
+    } catch {
+      outFile = file
+    }
+  }
+
+  // Per-type size validation: images 5 MB (Meta's limit), other media 14.5 MB
+  // (under the 15 MB fasthttp request body cap).
+  const type = getMediaType(outFile.type)
+  const maxSize = type === 'image' ? 5 * 1024 * 1024 : 14.5 * 1024 * 1024
+  if (outFile.size > maxSize) {
     toast.error(t('chat.fileTooLarge'), {
-      description: t('chat.fileTooLargeDesc')
+      description: type === 'image' ? t('chat.fileTooLargeImage') : t('chat.fileTooLargeMedia')
     })
     return
   }
 
-  selectedFile.value = file
+  selectedFile.value = outFile
   mediaCaption.value = ''
 
   // Create preview URL for images and videos
-  if (file.type.startsWith('image/') || file.type.startsWith('video/')) {
-    filePreviewUrl.value = URL.createObjectURL(file)
+  if (outFile.type.startsWith('image/') || outFile.type.startsWith('video/')) {
+    filePreviewUrl.value = URL.createObjectURL(outFile)
   } else {
     filePreviewUrl.value = null
   }
 
   isMediaDialogOpen.value = true
-
-  // Reset input so same file can be selected again
-  input.value = ''
 }
 
 function closeMediaDialog() {


### PR DESCRIPTION
## Problem

Sending a photo between **5 and 16 MB** fails with a Meta 400:

```
media upload failed with status 400: {"error":{"message":"(#100) Invalid parameter",...
"details":"File Too Large: The file you uploaded is too large."}}
```

The WhatsApp Cloud API caps **images at 5 MB** (and accepts only `image/jpeg` / `image/png` for `image` messages — see [Meta media reference](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media)), but `handleFileSelect` validated a flat **16 MB** for every type and the backend forwards the bytes to Meta untouched, so anything 5–16 MB is rejected.

## Fix

Add a **zero-dependency, canvas-only** helper `frontend/src/lib/imageCompression.ts` (`compressImage`) that downscales + re-encodes images to JPEG under ~4.5 MB (margin below Meta's 5 MB) before upload:

- leaves already-small `jpeg`/`png` untouched — no needless recompression / quality loss;
- caps the longest edge at 2048 px, then loops JPEG quality (and shrinks dimensions if still over);
- bakes in **EXIF orientation** (`createImageBitmap(..., { imageOrientation: 'from-image' })`) so rotated iPhone photos stay upright;
- flattens alpha to white (transparent PNG → JPEG);
- re-encodes `image/webp` and other odd image types to JPEG (Meta only accepts jpeg/png for `image` messages — this also fixes those being rejected);
- returns the original on decode failure (e.g. HEIC on desktop Chrome) or if the result would be larger, so the size gate stays authoritative.

`handleFileSelect` becomes `async`, compresses images, and validates **per media type** — image **5 MB** (Meta's limit), other media **14.5 MB** (just under the server's 15 MB `MaxRequestBodySize`) — instead of the flat 16 MB gate. Two new i18n keys (`chat.fileTooLargeImage`, `chat.fileTooLargeMedia`) in `en` and `es`.

## Scope / notes

- **Frontend only, no backend change, no new dependency.**
- Non-images pass through untouched; the per-type gate is unchanged in spirit, just corrected.
- Known limitation: **HEIC/HEIF** (iPhone default) can't be decoded by desktop Chrome/Firefox → the original is sent and the 5 MB gate rejects it with a clear message; Safari (which decodes HEIC) works.
- `npm run build` passes; `npm run typecheck` is clean apart from a pre-existing unrelated error in `AccountDetailView.vue`.
