### PR TITLE
fix(messages): DOCUMENT header filename still missing on campaign sends (foll...

### DIFF
--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -942,6 +944,14 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 	if headerMediaFilename == "" {
 		headerMediaFilename = headerFileFilename
 	}
+	if headerMediaFilename == "" && req.HeaderMediaURL != "" {
+		if mediaURL, err := url.Parse(req.HeaderMediaURL); err == nil {
+			headerMediaFilename = path.Base(mediaURL.Path)
+			if headerMediaFilename == "." || headerMediaFilename == "/" {
+				headerMediaFilename = ""
+			}
+		}
+	}
 
 	// Send using unified message sender
 	msgReq := OutgoingMessageRequest{
@@ -976,6 +986,9 @@ func (a *App) SendTemplateMessage(r *fastglue.Request) error {
 		MessageType:     message.MessageType,
 		Content:         map[string]string{"body": message.Content},
 		InteractiveData: message.InteractiveData,
+		MediaURL:        message.MediaURL,
+		MediaMimeType:   message.MediaMimeType,
+		MediaFilename:   message.MediaFilename,
 		Status:          message.Status,
 		IsReply:         message.IsReply,
 		WhatsAppAccount: message.WhatsAppAccount,

--- a/internal/handlers/messages_test.go
+++ b/internal/handlers/messages_test.go
@@ -550,11 +550,14 @@ func TestApp_SendOutgoingMessage_TemplateMessage(t *testing.T) {
 	ctx := testutil.TestContext(t)
 
 	req := handlers.OutgoingMessageRequest{
-		Account:    account,
-		Contact:    contact,
-		Type:       models.MessageTypeTemplate,
-		Template:   template,
-		BodyParams: map[string]string{"1": "John", "2": "ORD-123"},
+		Account:             account,
+		Contact:             contact,
+		Type:                models.MessageTypeTemplate,
+		Template:            template,
+		BodyParams:          map[string]string{"1": "John", "2": "ORD-123"},
+		MediaURL:            "/media/documents/invoice.pdf",
+		MediaMimeType:       "application/pdf",
+		HeaderMediaFilename: "invoice.pdf",
 	}
 
 	opts := handlers.ChatbotSendOptions()
@@ -567,6 +570,9 @@ func TestApp_SendOutgoingMessage_TemplateMessage(t *testing.T) {
 	// Verify template message was saved with rendered content
 	assert.Equal(t, models.MessageTypeTemplate, msg.MessageType)
 	assert.Equal(t, "Hello John! Your order ORD-123 is ready.", msg.Content)
+	assert.Equal(t, "/media/documents/invoice.pdf", msg.MediaURL)
+	assert.Equal(t, "application/pdf", msg.MediaMimeType)
+	assert.Equal(t, "invoice.pdf", msg.MediaFilename)
 
 	// Verify template metadata
 	assert.NotNil(t, msg.Metadata)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -140,6 +140,7 @@ func (w *Worker) HandleRecipientJob(ctx context.Context, job *queue.RecipientJob
 		if campaign.HeaderMediaLocalPath != "" {
 			message.MediaURL = campaign.HeaderMediaLocalPath
 			message.MediaMimeType = campaign.HeaderMediaMimeType
+			message.MediaFilename = campaign.HeaderMediaFilename
 		}
 	}
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -673,6 +673,12 @@ func TestWorker_HandleRecipientJob_Success(t *testing.T) {
 	w := testWorker(t)
 	org, account, template, campaign, recipient := createTestCampaignData(t, w)
 
+	campaign.HeaderMediaID = "media-123"
+	campaign.HeaderMediaLocalPath = "/media/documents/invoice.pdf"
+	campaign.HeaderMediaMimeType = "application/pdf"
+	campaign.HeaderMediaFilename = "invoice.pdf"
+	require.NoError(t, w.DB.Save(campaign).Error)
+
 	// Create mock server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Content-Type", "application/json")
@@ -718,6 +724,9 @@ func TestWorker_HandleRecipientJob_Success(t *testing.T) {
 	assert.Equal(t, models.MessageStatusSent, message.Status)
 	assert.Equal(t, models.DirectionOutgoing, message.Direction)
 	assert.Equal(t, models.MessageTypeTemplate, message.MessageType)
+	assert.Equal(t, "/media/documents/invoice.pdf", message.MediaURL)
+	assert.Equal(t, "application/pdf", message.MediaMimeType)
+	assert.Equal(t, "invoice.pdf", message.MediaFilename)
 }
 
 func TestWorker_HandleRecipientJob_WhatsAppError(t *testing.T) {


### PR DESCRIPTION
Fixes #523.

## Summary

fix(messages): DOCUMENT header filename still missing on campaign sends (follow-ups to #518)

## Validation

- Mechanical gate: +34/-5, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->