### PR TITLE
feat(flows): add Flow Submission Responses detail view

### DIFF
--- a/cmd/whatomate/main.go
+++ b/cmd/whatomate/main.go
@@ -684,6 +684,9 @@ func setupRoutes(g *fastglue.Fastglue, app *handlers.App, lo logf.Logger, basePa
 	g.POST("/api/flows/{id}/duplicate", app.DuplicateFlow)
 	g.POST("/api/flows/sync", app.SyncFlows)
 
+	// WhatsApp Flow Submissions
+	g.GET("/api/flow-submissions/{id}", app.GetFlowSubmissions)
+
 	// Bulk Campaigns
 	g.GET("/api/campaigns", app.ListCampaigns)
 	g.POST("/api/campaigns", app.CreateCampaign)

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -249,6 +249,7 @@
     "overview": "Overview",
     "keywords": "Keywords",
     "flows": "Flows",
+    "flowResponses": "Flow Responses",
     "aiContexts": "AI Contexts",
     "transfers": "Transfers",
     "agentAnalytics": "Agent Analytics",
@@ -1550,7 +1551,23 @@
     "saveToMetaConfirmTitle": "Save Flow to Meta",
     "saveToMetaConfirmDescription": "This will push the current version of \"{name}\" to Meta. Are you sure you want to continue?",
     "fetchErrorTitle": "Failed to load flows",
-    "fetchErrorDescription": "Something went wrong while loading flows. Please try again."
+    "fetchErrorDescription": "Something went wrong while loading flows. Please try again.",
+    "responses": "Responses"
+  },
+  "flowResponses": {
+    "title": "{name} Responses",
+    "submissionsCollected": "{count} submissions collected",
+    "responsesCollected": "{count} responses collected",
+    "backToFlows": "Back to Flows",
+    "refresh": "Refresh",
+    "liveUpdating": "Live Updating",
+    "live": "Live",
+    "loading": "Loading...",
+    "exportCsv": "Export CSV",
+    "phoneNumber": "Phone Number",
+    "submittedAt": "Submitted At",
+    "noResponsesYet": "No responses yet",
+    "noResponsesDesc": "When users complete this flow on WhatsApp, their responses will appear here in real-time."
   },
   "businessProfile": {
     "title": "Business Profile",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -77,6 +77,12 @@ const router = createRouter({
           meta: { permission: 'flows.whatsapp' }
         },
         {
+          path: 'flow-responses/:flowId',
+          name: 'flow-responses-detail',
+          component: () => import('@/views/settings/FlowResponsesView.vue'),
+          meta: { permission: 'flows.whatsapp' }
+        },
+        {
           path: 'campaigns',
           name: 'campaigns',
           component: () => import('@/views/settings/CampaignsView.vue'),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -343,6 +343,11 @@ export const flowsService = {
   sync: (whatsappAccount: string) => api.post('/flows/sync', { whatsapp_account: whatsappAccount })
 }
 
+export const flowSubmissionsService = {
+  getSubmissions: (flowId: string) =>
+    api.get<{ flow: any; submissions: any[]; total: number }>(`/flow-submissions/${flowId}`),
+}
+
 export const campaignsService = {
   list: (params?: { status?: string; from?: string; to?: string; search?: string; page?: number; limit?: number }) =>
     api.get('/campaigns', { params }),

--- a/frontend/src/views/settings/FlowResponsesView.vue
+++ b/frontend/src/views/settings/FlowResponsesView.vue
@@ -1,0 +1,276 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { PageHeader } from '@/components/shared'
+import { ArrowLeft, ClipboardList, RefreshCw, Clock, Download, Phone } from 'lucide-vue-next'
+import { flowSubmissionsService } from '@/services/api'
+
+const route = useRoute()
+const router = useRouter()
+const { t } = useI18n()
+
+
+interface Submission {
+  id: string
+  phone_number: string
+  response_data: Record<string, any>
+  created_at: string
+  created_at_display: string
+}
+
+const submissions = ref<Submission[]>([])
+const selectedFlowId = ref<string | null>(null)
+const selectedFlowName = ref('')
+const isLoading = ref(true)
+const isRefreshing = ref(false)
+const pollingInterval = ref<ReturnType<typeof setInterval> | null>(null)
+
+onMounted(async () => {
+  selectedFlowId.value = route.params.flowId as string
+  await fetchSubmissions()
+  pollingInterval.value = setInterval(() => {
+    fetchSubmissions()
+  }, 10000)
+})
+
+onUnmounted(() => {
+  if (pollingInterval.value) {
+    clearInterval(pollingInterval.value)
+    pollingInterval.value = null
+  }
+})
+
+
+
+async function fetchSubmissions() {
+  if (!selectedFlowId.value) return
+  try {
+    const resp = await flowSubmissionsService.getSubmissions(selectedFlowId.value)
+    const data = (resp.data as any).data
+
+    if (data) {
+      selectedFlowName.value = data.flow?.name || ''
+      const rawSubmissions = data.submissions || []
+      submissions.value = rawSubmissions.map((sub: any) => {
+        const d = new Date(sub.created_at)
+        const dateStr = d.toLocaleString(undefined, {
+          month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit'
+        })
+        return {
+          id: sub.id,
+          phone_number: sub.phone_number,
+          response_data: sub.response_data || {},
+          created_at: sub.created_at,
+          created_at_display: dateStr
+        }
+      })
+    }
+  } catch (e) {
+    console.error('Failed to fetch submissions:', e)
+  } finally {
+    isLoading.value = false
+    isRefreshing.value = false
+  }
+}
+
+function goBack() {
+  router.push('/flows')
+}
+
+async function refreshData() {
+  isRefreshing.value = true
+  await fetchSubmissions()
+  isRefreshing.value = false
+}
+
+function formatKey(key: string): string {
+  return key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+}
+
+
+
+// Dynamic column headers from all submission response data
+const responseColumns = computed(() => {
+  const cols = new Set<string>()
+  for (const sub of submissions.value) {
+    if (sub.response_data) {
+      for (const key of Object.keys(sub.response_data)) {
+        if (key !== 'flow_token') cols.add(key)
+      }
+    }
+  }
+  return Array.from(cols)
+})
+
+
+function exportToCsv() {
+  if (submissions.value.length === 0) return
+  const allKeys = new Set<string>()
+  submissions.value.forEach(sub => { Object.keys(sub.response_data).forEach(k => { if (k !== 'flow_token') allKeys.add(k) }) })
+
+  const headers = [t('flowResponses.phoneNumber'), t('flowResponses.submittedAt'), ...Array.from(allKeys).map(k => formatKey(k))]
+  const rows = submissions.value.map(sub => {
+    const row = [
+      sub.phone_number,
+      sub.created_at_display,
+      ...Array.from(allKeys).map(k => {
+        const val = sub.response_data[k]
+        return Array.isArray(val) ? val.join(', ') : (val || '')
+      })
+    ]
+    return row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(',')
+  })
+
+  const csv = [headers.join(','), ...rows].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv' })
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${selectedFlowName.value.replace(/\s+/g, '_')}_submissions.csv`
+  a.click()
+  window.URL.revokeObjectURL(url)
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full bg-[#0a0a0b] light:bg-gray-50">
+    <PageHeader
+      :title="t('flowResponses.title', { name: selectedFlowName })"
+      :subtitle="t('flowResponses.submissionsCollected', { count: submissions.length })"
+      :icon="ClipboardList"
+      icon-gradient="bg-gradient-to-br from-emerald-500 to-teal-600 shadow-emerald-500/20"
+    >
+      <template #actions>
+        <Button variant="outline" size="sm" @click="goBack">
+          <ArrowLeft class="h-4 w-4 mr-2" /> {{ t('flowResponses.backToFlows') }}
+        </Button>
+        <Button variant="outline" size="sm" @click="refreshData" :disabled="isRefreshing">
+          <RefreshCw class="h-4 w-4 mr-2" :class="{ 'animate-spin': isRefreshing }" />
+          {{ t('flowResponses.refresh') }}
+        </Button>
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <div class="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
+          {{ t('flowResponses.liveUpdating') }}
+        </div>
+      </template>
+    </PageHeader>
+
+    <ScrollArea class="flex-1">
+      <div class="p-6">
+        <div class="max-w-6xl mx-auto">
+          <!-- Loading State -->
+          <div v-if="isLoading" class="flex items-center justify-center py-20">
+            <div class="flex flex-col items-center gap-4">
+              <div class="h-8 w-8 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+              <p class="text-sm text-muted-foreground">{{ t('flowResponses.loading') }}</p>
+            </div>
+          </div>
+
+          <!-- Submissions View -->
+          <template v-if="!isLoading">
+            <!-- Table -->
+            <Card>
+              <CardHeader class="pb-4 border-b">
+                <div class="flex items-center justify-between">
+                  <div>
+                    <CardTitle class="text-xl flex items-center gap-2">
+                      <ClipboardList class="h-5 w-5 text-emerald-500" />
+                      {{ t('flowResponses.title', { name: selectedFlowName }) }}
+                    </CardTitle>
+                    <CardDescription class="mt-1">{{ t('flowResponses.responsesCollected', { count: submissions.length }) }}</CardDescription>
+                  </div>
+                  <div class="flex items-center gap-4">
+                    <div class="flex items-center gap-2 px-3 py-1 bg-emerald-500/10 text-emerald-500 rounded-full text-xs font-medium">
+                      <div class="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
+                      {{ t('flowResponses.live') }}
+                    </div>
+                    <Button variant="outline" size="sm" @click="exportToCsv" :disabled="submissions.length === 0" class="shadow-sm">
+                      <Download class="h-4 w-4 mr-2 text-muted-foreground" />
+                      {{ t('flowResponses.exportCsv') }}
+                    </Button>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent class="p-0">
+                <div class="overflow-x-auto">
+                  <table class="w-full">
+                    <thead>
+                      <tr class="border-b">
+                        <th class="text-left p-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('flowResponses.phoneNumber') }}</th>
+                        <th class="text-left p-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('flowResponses.submittedAt') }}</th>
+                        <th
+                          v-for="col in responseColumns"
+                          :key="col"
+                          class="text-left p-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider"
+                        >
+                          {{ formatKey(col) }}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr
+                        v-for="sub in submissions"
+                        :key="sub.id"
+                        class="border-b last:border-0 hover:bg-muted/30 transition-colors"
+                      >
+                        <td class="p-4 align-top">
+                          <div class="flex items-center gap-2">
+                            <div class="p-1.5 rounded bg-blue-500/10">
+                              <Phone class="h-3.5 w-3.5 text-blue-500" />
+                            </div>
+                            <span class="font-medium text-sm">{{ sub.phone_number }}</span>
+                          </div>
+                        </td>
+                        <td class="p-4 align-top text-sm text-muted-foreground">
+                          <div class="flex items-center gap-1.5">
+                            <Clock class="h-3.5 w-3.5 opacity-70" />
+                            {{ sub.created_at_display }}
+                          </div>
+                        </td>
+                        <td
+                          v-for="col in responseColumns"
+                          :key="col"
+                          class="p-4 align-top"
+                        >
+                          <template v-if="Array.isArray(sub.response_data[col])">
+                            <div class="flex flex-wrap gap-1">
+                              <Badge v-for="(v, i) in sub.response_data[col]" :key="i" variant="outline" class="bg-indigo-500/10 text-indigo-400 border-indigo-500/20">
+                                {{ v }}
+                              </Badge>
+                            </div>
+                          </template>
+                          <Badge v-else-if="sub.response_data[col] != null" variant="outline" class="bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
+                            {{ sub.response_data[col] }}
+                          </Badge>
+                          <span v-else class="text-muted-foreground text-xs">—</span>
+                        </td>
+                      </tr>
+                      <tr v-if="submissions.length === 0">
+                        <td :colspan="2 + responseColumns.length" class="p-12 text-center">
+                          <div class="flex flex-col items-center justify-center">
+                            <div class="p-4 rounded-full bg-muted mb-4">
+                              <ClipboardList class="h-8 w-8 text-muted-foreground/50" />
+                            </div>
+                            <h3 class="text-lg font-medium">{{ t('flowResponses.noResponsesYet') }}</h3>
+                            <p class="text-sm text-muted-foreground max-w-sm mx-auto mt-1">
+                              {{ t('flowResponses.noResponsesDesc') }}
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          </template>
+        </div>
+      </div>
+    </ScrollArea>
+  </div>
+</template>

--- a/frontend/src/views/settings/FlowsView.vue
+++ b/frontend/src/views/settings/FlowsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -13,12 +14,13 @@ import { PageHeader, DeleteConfirmDialog, ConfirmDialog, DataTable, SearchInput,
 import FlowBuilder from '@/components/flow-builder/FlowBuilder.vue'
 import { flowsService, accountsService } from '@/services/api'
 import { toast } from 'vue-sonner'
-import { Plus, Pencil, Trash2, Workflow, Play, ExternalLink, Loader2, Archive, RefreshCw, Upload, Copy } from 'lucide-vue-next'
+import { Plus, Pencil, Trash2, Workflow, Play, ExternalLink, Loader2, Archive, RefreshCw, Upload, Copy, ClipboardList } from 'lucide-vue-next'
 import { getErrorMessage } from '@/lib/api-utils'
 import { formatDate } from '@/lib/utils'
 import { useSearchPagination } from '@/composables/useSearchPagination'
 
 const { t } = useI18n()
+const router = useRouter()
 
 interface WhatsAppFlow {
   id: string; whatsapp_account: string; meta_flow_id: string; name: string; status: 'DRAFT' | 'PUBLISHED' | 'DEPRECATED'
@@ -192,9 +194,24 @@ async function duplicateFlow(flow: WhatsAppFlow) {
 }
 
 async function syncFlows() {
-  if (!selectedAccount.value || selectedAccount.value === 'all') { toast.error(t('flows.selectAccountToSync')); return }
   isSyncing.value = true
-  try { const response = await flowsService.sync(selectedAccount.value); const data = response.data.data; toast.success(t('flows.syncSuccess', { synced: data.synced, created: data.created, updated: data.updated })); await fetchFlows() }
+  try {
+    // When "All Accounts" is selected, sync every account one-by-one
+    const accountsToSync = selectedAccount.value === 'all'
+      ? accounts.value.map(a => a.name)
+      : [selectedAccount.value]
+
+    let totalSynced = 0, totalCreated = 0, totalUpdated = 0
+    for (const name of accountsToSync) {
+      const response = await flowsService.sync(name)
+      const data = response.data.data
+      totalSynced += data.synced ?? 0
+      totalCreated += data.created ?? 0
+      totalUpdated += data.updated ?? 0
+    }
+    toast.success(t('flows.syncSuccess', { synced: totalSynced, created: totalCreated, updated: totalUpdated }))
+    await fetchFlows()
+  }
   catch (e) { toast.error(getErrorMessage(e, t('flows.syncFailed'))) }
   finally { isSyncing.value = false }
 }
@@ -216,7 +233,7 @@ function sanitizeScreensForMeta(screens: any[]): any[] {
   <div class="flex flex-col h-full bg-[#0a0a0b] light:bg-gray-50">
     <PageHeader :title="$t('flows.title')" :subtitle="$t('flows.subtitle')" :icon="Workflow" icon-gradient="bg-gradient-to-br from-violet-500 to-purple-600 shadow-violet-500/20">
       <template #actions>
-        <Button variant="outline" size="sm" @click="syncFlows" :disabled="isSyncing || !selectedAccount || selectedAccount === 'all'"><RefreshCw :class="['h-4 w-4 mr-2', isSyncing && 'animate-spin']" />{{ $t('flows.syncFromMeta') }}</Button>
+        <Button variant="outline" size="sm" @click="syncFlows" :disabled="isSyncing"><RefreshCw :class="['h-4 w-4 mr-2', isSyncing && 'animate-spin']" />{{ $t('flows.syncFromMeta') }}</Button>
         <Button variant="outline" size="sm" @click="openCreateDialog"><Plus class="h-4 w-4 mr-2" />{{ $t('flows.createFlow') }}</Button>
       </template>
     </PageHeader>
@@ -288,6 +305,10 @@ function sanitizeScreensForMeta(screens: any[]): any[] {
                 </template>
                 <template #cell-actions="{ item: flow }">
                   <div class="flex items-center justify-end gap-1">
+                    <Button v-if="flow.status?.toUpperCase() === 'PUBLISHED'" variant="outline" size="sm" class="mr-2" @click="router.push(`/flow-responses/${flow.id}`)">
+                      <ClipboardList class="h-4 w-4 mr-2" />
+                      {{ $t('flows.responses') }}
+                    </Button>
                     <IconButton :icon="Pencil" :label="$t('flows.editTooltip')" class="h-8 w-8" @click="openEditDialog(flow)" />
                     <IconButton :icon="duplicatingFlowId === flow.id ? Loader2 : Copy" :label="$t('flows.duplicateTooltip')" class="h-8 w-8" :disabled="duplicatingFlowId === flow.id" @click="duplicateFlow(flow)" />
                     <IconButton v-if="flow.preview_url" :icon="ExternalLink" :label="$t('flows.previewTooltip')" class="h-8 w-8" @click="openPreviewUrl(flow.preview_url!)" />

--- a/internal/handlers/flow_submissions.go
+++ b/internal/handlers/flow_submissions.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shridarpatil/whatomate/internal/models"
+	"github.com/valyala/fasthttp"
+	"github.com/zerodha/fastglue"
+)
+
+
+// GetFlowSubmissions returns all submissions for a specific WhatsApp flow.
+func (a *App) GetFlowSubmissions(r *fastglue.Request) error {
+	orgID, err := a.getOrgID(r)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusUnauthorized, "Unauthorized", nil, "")
+	}
+
+	flowID, err := parsePathUUID(r, "id", "flow")
+	if err != nil {
+		return nil
+	}
+
+	// Verify the flow belongs to this org
+	var flow models.WhatsAppFlow
+	if err := a.DB.Where("id = ? AND organization_id = ?", flowID, orgID).First(&flow).Error; err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Flow not found", nil, "")
+	}
+
+	// Fetch submissions
+	type submissionRow struct {
+		ID           uuid.UUID  `gorm:"column:id" json:"id"`
+		PhoneNumber  string     `gorm:"column:phone_number" json:"phone_number"`
+		ResponseData string     `gorm:"column:response_data" json:"-"`
+		CreatedAt    time.Time  `gorm:"column:created_at" json:"created_at"`
+	}
+
+	var rows []submissionRow
+	if err := a.DB.Raw(`
+		SELECT id, phone_number, response_data, created_at
+		FROM whatsapp_flow_submissions
+		WHERE flow_id = ? AND organization_id = ?
+		ORDER BY created_at DESC
+	`, flowID, orgID).Scan(&rows).Error; err != nil {
+		a.Log.Error("Failed to fetch flow submissions", "error", err, "flow_id", flowID)
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to fetch submissions", nil, "")
+	}
+
+	submissions := make([]map[string]any, len(rows))
+	for i, row := range rows {
+		// Parse response_data from JSON string
+		var respData models.JSONB
+		if row.ResponseData != "" {
+			if err := json.Unmarshal([]byte(row.ResponseData), &respData); err != nil {
+				respData = models.JSONB{}
+			}
+		}
+		if respData == nil {
+			respData = models.JSONB{}
+		}
+
+		submissions[i] = map[string]any{
+			"id":            row.ID,
+			"phone_number":  row.PhoneNumber,
+			"response_data": respData,
+			"created_at":    row.CreatedAt,
+		}
+	}
+
+	return r.SendEnvelope(map[string]any{
+		"flow": map[string]any{
+			"id":     flow.ID,
+			"name":   flow.Name,
+			"status": flow.Status,
+		},
+		"submissions": submissions,
+		"total":       len(submissions),
+	})
+}

--- a/internal/handlers/flows.go
+++ b/internal/handlers/flows.go
@@ -304,7 +304,7 @@ func (a *App) SaveFlowToMeta(r *fastglue.Request) error {
 		metaFlowID, err = waClient.CreateFlow(ctx, waAccount, flow.Name, categories)
 		if err != nil {
 			a.Log.Error("Failed to create flow in Meta", "error", err, "flow_id", id, "business_id", account.BusinessID)
-			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to create flow in Meta", nil, "")
+			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create flow in Meta: %s", err.Error()), nil, "")
 		}
 	} else {
 		metaFlowID = flow.MetaFlowID
@@ -331,7 +331,7 @@ func (a *App) SaveFlowToMeta(r *fastglue.Request) error {
 			a.DB.Model(flow).Updates(map[string]any{
 				"meta_flow_id": metaFlowID,
 			})
-			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to update flow JSON", nil, "")
+			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update flow JSON: %s", err.Error()), nil, "")
 		}
 	}
 
@@ -399,7 +399,7 @@ func (a *App) PublishFlow(r *fastglue.Request) error {
 	// Publish the flow
 	if err := waClient.PublishFlow(ctx, waAccount, flow.MetaFlowID); err != nil {
 		a.Log.Error("Failed to publish flow in Meta", "error", err, "flow_id", id, "meta_flow_id", flow.MetaFlowID)
-		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "Failed to publish flow", nil, "")
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to publish flow: %s", err.Error()), nil, "")
 	}
 
 	// Get the flow details including preview URL
@@ -656,17 +656,16 @@ func (a *App) SyncFlows(r *fastglue.Request) error {
 	})
 }
 
-// validateFlowStructure validates the flow structure before sending to Meta
-// - Ensures at least one screen has a Footer with "complete" action
-// - If multiple screens, only the last screen should have "complete" action
+// validateFlowStructure validates the flow structure before sending to Meta.
+// If no screen has a Footer with "complete" action, one is auto-injected on
+// the last screen so the user doesn't have to manually add it.
 func validateFlowStructure(screens []any) error {
 	if len(screens) == 0 {
 		return fmt.Errorf("flow must have at least one screen")
 	}
 
-	// Find which screens have complete action
-	screensWithComplete := []int{}
-	for i, screen := range screens {
+	// Check if any screen already has a complete action
+	for _, screen := range screens {
 		screenMap, ok := screen.(map[string]any)
 		if !ok {
 			continue
@@ -683,24 +682,37 @@ func validateFlowStructure(screens []any) error {
 		}
 
 		if hasCompleteAction(children) {
-			screensWithComplete = append(screensWithComplete, i)
+			return nil // Already has a complete action — nothing to do
 		}
 	}
 
-	// Check if any screen has a complete action
-	if len(screensWithComplete) == 0 {
-		return fmt.Errorf("flow must have a Footer button with 'Complete Flow' action: add a Footer component to your last screen and set its action to 'Complete Flow'")
+	// No screen has a complete action — auto-inject a Footer on the last screen
+	lastScreen, ok := screens[len(screens)-1].(map[string]any)
+	if !ok {
+		return fmt.Errorf("last screen has invalid structure")
 	}
 
-	// If multiple screens, complete action should only be on the last screen
-	if len(screens) > 1 {
-		lastScreenIndex := len(screens) - 1
-		for _, idx := range screensWithComplete {
-			if idx != lastScreenIndex {
-				return fmt.Errorf("'Complete Flow' action should only be on the last screen. Screen %d has a complete action but it's not the last screen. Use 'Navigate to Screen' action for intermediate screens", idx+1)
-			}
-		}
+	layout, ok := lastScreen["layout"].(map[string]any)
+	if !ok {
+		layout = map[string]any{"type": "SingleColumnLayout", "children": []any{}}
+		lastScreen["layout"] = layout
 	}
+
+	children, ok := layout["children"].([]any)
+	if !ok {
+		children = []any{}
+	}
+
+	footer := map[string]any{
+		"type":  "Footer",
+		"label": "Complete",
+		"on-click-action": map[string]any{
+			"name":    "complete",
+			"payload": map[string]any{},
+		},
+	}
+
+	layout["children"] = append(children, footer)
 
 	return nil
 }
@@ -725,15 +737,134 @@ var componentsWithoutID = map[string]bool{
 // - Removes 'id' property from components that don't support it
 // - Marks screens with 'complete' action as terminal screens
 // - Auto-populates the complete action's payload with all form field values
+// - Correctly handles branching flows (If/Else navigation) by tracing the navigation graph
 func sanitizeScreensForMeta(screens []any) []any {
-	// First pass: collect form field names per screen
-	screenFields := collectFormFieldsPerScreen(screens)
-	allFieldNames := collectFormFieldNames(screens)
+	// First pass: collect form field names per screen (by sanitized screen ID)
+	screenFieldsByID := make(map[string][]string) // screenID -> field names on that screen
+	screenIDOrder := make([]string, 0, len(screens))
+	screenByID := make(map[string]int) // screenID -> index
 
+	for i, screen := range screens {
+		screenMap, ok := screen.(map[string]any)
+		if !ok {
+			continue
+		}
+		screenID := ""
+		if id, ok := screenMap["id"].(string); ok {
+			screenID = sanitizeID(id)
+		}
+		screenIDOrder = append(screenIDOrder, screenID)
+		screenByID[screenID] = i
+
+		layout, ok := screenMap["layout"].(map[string]any)
+		if !ok {
+			continue
+		}
+		children, ok := layout["children"].([]any)
+		if !ok {
+			continue
+		}
+		fields := collectFormFieldNamesFromChildren(children)
+		// Sanitize the field names
+		for j, f := range fields {
+			fields[j] = sanitizeID(f)
+		}
+		screenFieldsByID[screenID] = fields
+	}
+
+	// Second pass: build navigation graph (which screens navigate TO which screens)
+	// incomingFields[screenID] = fields that should be in its data model (from screens that navigate to it)
+	incomingFields := make(map[string]map[string]bool) // screenID -> set of field names
+
+	for _, screen := range screens {
+		screenMap, ok := screen.(map[string]any)
+		if !ok {
+			continue
+		}
+		sourceID := ""
+		if id, ok := screenMap["id"].(string); ok {
+			sourceID = sanitizeID(id)
+		}
+
+		layout, ok := screenMap["layout"].(map[string]any)
+		if !ok {
+			continue
+		}
+		children, ok := layout["children"].([]any)
+		if !ok {
+			continue
+		}
+
+		// Find all navigate targets from this screen (including inside If/Else)
+		targets := collectNavigateTargets(children)
+		sourceFields := screenFieldsByID[sourceID]
+
+		for _, targetID := range targets {
+			targetID = sanitizeID(targetID)
+			if _, exists := incomingFields[targetID]; !exists {
+				incomingFields[targetID] = make(map[string]bool)
+			}
+			// The target screen needs all fields from the source screen in its data model
+			for _, f := range sourceFields {
+				incomingFields[targetID][f] = true
+			}
+		}
+	}
+
+	// Propagate: if screen A navigates to screen B, and screen B navigates to screen C,
+	// then C needs fields from both A and B. We already have B's own fields.
+	// But also need to propagate A's fields through B to C.
+	// Do a simple BFS/propagation pass
+	changed := true
+	for changed {
+		changed = false
+		for _, screen := range screens {
+			screenMap, ok := screen.(map[string]any)
+			if !ok {
+				continue
+			}
+			sourceID := ""
+			if id, ok := screenMap["id"].(string); ok {
+				sourceID = sanitizeID(id)
+			}
+			layout, ok := screenMap["layout"].(map[string]any)
+			if !ok {
+				continue
+			}
+			children, ok := layout["children"].([]any)
+			if !ok {
+				continue
+			}
+			targets := collectNavigateTargets(children)
+
+			// Fields available at this screen = its own fields + fields in its data model (from incoming)
+			allAvailable := make(map[string]bool)
+			for _, f := range screenFieldsByID[sourceID] {
+				allAvailable[f] = true
+			}
+			if incoming, ok := incomingFields[sourceID]; ok {
+				for f := range incoming {
+					allAvailable[f] = true
+				}
+			}
+
+			for _, targetID := range targets {
+				targetID = sanitizeID(targetID)
+				if _, exists := incomingFields[targetID]; !exists {
+					incomingFields[targetID] = make(map[string]bool)
+				}
+				for f := range allAvailable {
+					if !incomingFields[targetID][f] {
+						incomingFields[targetID][f] = true
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	// Third pass: build the result
 	result := make([]any, len(screens))
-
-	// Track cumulative fields from previous screens
-	var fieldsFromPreviousScreens []string
 
 	for i, screen := range screens {
 		screenMap, ok := screen.(map[string]any)
@@ -749,12 +880,14 @@ func sanitizeScreensForMeta(screens []any) []any {
 		}
 
 		// Fix screen ID if it contains numbers
+		screenID := ""
 		if id, ok := newScreen["id"].(string); ok {
-			newScreen["id"] = sanitizeID(id)
+			screenID = sanitizeID(id)
+			newScreen["id"] = screenID
 		}
 
-		// Add data model for fields from previous screens (required for multi-screen flows)
-		if i > 0 && len(fieldsFromPreviousScreens) > 0 {
+		// Set data model based on navigation graph (not sequential order)
+		if i > 0 {
 			dataModel := make(map[string]any)
 			// Copy existing data model if present
 			if existingData, ok := newScreen["data"].(map[string]any); ok {
@@ -762,15 +895,32 @@ func sanitizeScreensForMeta(screens []any) []any {
 					dataModel[k] = v
 				}
 			}
-			// Add entries for fields from previous screens
-			for _, fieldName := range fieldsFromPreviousScreens {
-				dataModel[fieldName] = map[string]any{
-					"type":        "string",
-					"__example__": "",
+			// Add entries for fields coming from navigating screens
+			if incoming, ok := incomingFields[screenID]; ok {
+				for fieldName := range incoming {
+					if _, exists := dataModel[fieldName]; !exists {
+						dataModel[fieldName] = map[string]any{
+							"type":        "string",
+							"__example__": "",
+						}
+					}
 				}
 			}
-			newScreen["data"] = dataModel
+			if len(dataModel) > 0 {
+				newScreen["data"] = dataModel
+			}
 		}
+
+		// Get the fields that are actually in this screen's data model
+		dataModelFields := make(map[string]bool)
+		if dm, ok := newScreen["data"].(map[string]any); ok {
+			for k := range dm {
+				dataModelFields[k] = true
+			}
+		}
+
+		// Get this screen's own form fields
+		thisScreenFields := screenFieldsByID[screenID]
 
 		// Sanitize layout children and check for terminal action
 		isTerminal := false
@@ -781,8 +931,8 @@ func sanitizeScreensForMeta(screens []any) []any {
 			}
 
 			if children, ok := layout["children"].([]any); ok {
-				// Sanitize and auto-populate action payloads
-				sanitizedChildren := sanitizeComponentsWithPayload(children, allFieldNames, fieldsFromPreviousScreens)
+				// Sanitize and auto-populate action payloads using ONLY known fields
+				sanitizedChildren := sanitizeComponentsWithPayloadV2(children, thisScreenFields, dataModelFields)
 				newLayout["children"] = sanitizedChildren
 
 				// Check if any child has on-click-action with name "complete"
@@ -798,100 +948,14 @@ func sanitizeScreensForMeta(screens []any) []any {
 		}
 
 		result[i] = newScreen
-
-		// Add this screen's fields to cumulative list for next screens
-		if fields, ok := screenFields[i]; ok {
-			fieldsFromPreviousScreens = append(fieldsFromPreviousScreens, fields...)
-		}
 	}
 
 	return result
 }
 
-// collectFormFieldNames collects all form field names from all screens
-// These are components that have a "name" attribute (TextInput, TextArea, Dropdown, etc.)
-func collectFormFieldNames(screens []any) []string {
-	var fieldNames []string
-
-	for _, screen := range screens {
-		screenMap, ok := screen.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		layout, ok := screenMap["layout"].(map[string]any)
-		if !ok {
-			continue
-		}
-
-		children, ok := layout["children"].([]any)
-		if !ok {
-			continue
-		}
-
-		for _, child := range children {
-			compMap, ok := child.(map[string]any)
-			if !ok {
-				continue
-			}
-
-			// Check if component has a "name" attribute (form field)
-			if name, ok := compMap["name"].(string); ok && name != "" {
-				// Sanitize the name to match what will be sent to Meta
-				sanitizedName := sanitizeID(name)
-				fieldNames = append(fieldNames, sanitizedName)
-			}
-		}
-	}
-
-	return fieldNames
-}
-
-// collectFormFieldsPerScreen collects form field names for each screen by index
-func collectFormFieldsPerScreen(screens []any) map[int][]string {
-	result := make(map[int][]string)
-
-	for i, screen := range screens {
-		screenMap, ok := screen.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		layout, ok := screenMap["layout"].(map[string]any)
-		if !ok {
-			continue
-		}
-
-		children, ok := layout["children"].([]any)
-		if !ok {
-			continue
-		}
-
-		var fieldNames []string
-		for _, child := range children {
-			compMap, ok := child.(map[string]any)
-			if !ok {
-				continue
-			}
-
-			// Check if component has a "name" attribute (form field)
-			if name, ok := compMap["name"].(string); ok && name != "" {
-				// Sanitize the name to match what will be sent to Meta
-				sanitizedName := sanitizeID(name)
-				fieldNames = append(fieldNames, sanitizedName)
-			}
-		}
-
-		if len(fieldNames) > 0 {
-			result[i] = fieldNames
-		}
-	}
-
-	return result
-}
-
-// hasCompleteAction checks if any component has an on-click-action with name "complete"
-func hasCompleteAction(children []any) bool {
+// collectNavigateTargets extracts all screen IDs that are navigation targets in children (including If/Else)
+func collectNavigateTargets(children []any) []string {
+	var targets []string
 	for _, child := range children {
 		compMap, ok := child.(map[string]any)
 		if !ok {
@@ -899,67 +963,41 @@ func hasCompleteAction(children []any) bool {
 		}
 
 		if action, ok := compMap["on-click-action"].(map[string]any); ok {
-			if name, ok := action["name"].(string); ok && name == "complete" {
-				return true
+			if name, ok := action["name"].(string); ok && name == "navigate" {
+				if next, ok := action["next"].(map[string]any); ok {
+					if screenName, ok := next["name"].(string); ok {
+						targets = append(targets, screenName)
+					}
+				}
+			}
+		}
+
+		if compMap["type"] == "If" {
+			if thenBlock, ok := compMap["then"].([]any); ok {
+				targets = append(targets, collectNavigateTargets(thenBlock)...)
+			}
+			if elseBlock, ok := compMap["else"].([]any); ok {
+				targets = append(targets, collectNavigateTargets(elseBlock)...)
 			}
 		}
 	}
-	return false
+	return targets
 }
 
-// sanitizeID converts an ID to use only alphabets and underscores
-// e.g., "SCREEN_1" -> "SCREEN_A", "id_1234_abc" -> "id_abcd_abc"
-func sanitizeID(id string) string {
-	// Check if ID already only contains valid characters
-	valid := true
-	for _, c := range id {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') { //nolint:staticcheck // More readable than De Morgan's law
-			valid = false
-			break
-		}
-	}
-	if valid {
-		return id
-	}
-
-	// Replace numbers with letters
-	result := make([]byte, 0, len(id))
-	for _, c := range id {
-		if c >= '0' && c <= '9' {
-			// Convert 0-9 to A-J
-			result = append(result, byte('A'+c-'0'))
-		} else if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' {
-			result = append(result, byte(c))
-		}
-		// Skip other characters
-	}
-
-	return string(result)
-}
-
-// sanitizeComponentsWithPayload sanitizes components and auto-populates action payloads
-// - For navigate actions: passes current screen's form fields using ${form.fieldName}
-// - For complete actions: uses ${data.fieldName} for previous screens, ${form.fieldName} for current
-func sanitizeComponentsWithPayload(children []any, allFieldNames []string, fieldsFromPreviousScreens []string) []any {
-	result := make([]any, len(children))
-
-	// Collect this screen's field names
-	var thisScreenFields []string
-	for _, child := range children {
-		compMap, ok := child.(map[string]any)
-		if !ok {
-			continue
-		}
-		if name, ok := compMap["name"].(string); ok && name != "" {
-			thisScreenFields = append(thisScreenFields, sanitizeID(name))
-		}
-	}
-
-	// Create a set for quick lookup of this screen's fields
+// sanitizeComponentsWithPayloadV2 sanitizes components using only the known fields
+// - For navigate actions: passes current screen's form fields and data model fields
+// - For complete actions: uses ${data.fieldName} for data model fields, ${form.fieldName} for current screen
+func sanitizeComponentsWithPayloadV2(children []any, thisScreenFields []string, dataModelFields map[string]bool) []any {
 	thisScreenFieldSet := make(map[string]bool)
 	for _, f := range thisScreenFields {
 		thisScreenFieldSet[f] = true
 	}
+
+	return sanitizeComponentsRecursiveV2(children, thisScreenFields, dataModelFields, thisScreenFieldSet)
+}
+
+func sanitizeComponentsRecursiveV2(children []any, thisScreenFields []string, dataModelFields map[string]bool, thisScreenFieldSet map[string]bool) []any {
+	result := make([]any, len(children))
 
 	for i, child := range children {
 		compMap, ok := child.(map[string]any)
@@ -1016,38 +1054,348 @@ func sanitizeComponentsWithPayload(children []any, allFieldNames []string, field
 
 			switch actionName {
 			case "complete":
-				// Complete action: include all form fields from all screens
-				// - Fields from previous screens: use ${data.fieldName} (passed via data model)
-				// - Fields on current screen: use ${form.fieldName} (form input)
 				payload := make(map[string]any)
-				for _, fieldName := range allFieldNames {
-					if thisScreenFieldSet[fieldName] {
-						// Current screen's field - use form reference
-						payload[fieldName] = "${form." + fieldName + "}"
-					} else {
-						// Previous screen's field - use data reference
+
+				// Preserve existing payload
+				if existingPayload, ok := newAction["payload"].(map[string]any); ok {
+					for k, v := range existingPayload {
+						payload[k] = v
+					}
+				}
+
+				// Add data model fields (from previous screens) using ${data.xxx}
+				for fieldName := range dataModelFields {
+					if _, exists := payload[fieldName]; !exists {
 						payload[fieldName] = "${data." + fieldName + "}"
 					}
 				}
-				newAction["payload"] = payload
-			case "navigate":
-				// Navigate action: pass current screen's form fields to next screen
-				// Use ${form.fieldName} for current screen's fields
-				if len(thisScreenFields) > 0 {
-					payload := make(map[string]any)
-					// Pass previous screen data through
-					for _, fieldName := range fieldsFromPreviousScreens {
-						payload[fieldName] = "${data." + fieldName + "}"
-					}
-					// Add current screen's form fields
-					for _, fieldName := range thisScreenFields {
+				// Add this screen's own fields using ${form.xxx}
+				for _, fieldName := range thisScreenFields {
+					if _, exists := payload[fieldName]; !exists {
 						payload[fieldName] = "${form." + fieldName + "}"
 					}
+				}
+
+				newAction["payload"] = payload
+			case "navigate":
+				if len(thisScreenFields) > 0 || len(dataModelFields) > 0 {
+					payload := make(map[string]any)
+
+					// Preserve existing payload
+					if existingPayload, ok := newAction["payload"].(map[string]any); ok {
+						for k, v := range existingPayload {
+							payload[k] = v
+						}
+					}
+
+					// Pass data model fields forward
+					for fieldName := range dataModelFields {
+						if _, exists := payload[fieldName]; !exists {
+							payload[fieldName] = "${data." + fieldName + "}"
+						}
+					}
+					// Pass this screen's form fields
+					for _, fieldName := range thisScreenFields {
+						if _, exists := payload[fieldName]; !exists {
+							payload[fieldName] = "${form." + fieldName + "}"
+						}
+					}
+
 					newAction["payload"] = payload
 				}
 			}
 
 			newComp["on-click-action"] = newAction
+		}
+
+		if compType == "If" {
+			if thenBlock, ok := newComp["then"].([]any); ok {
+				newComp["then"] = sanitizeComponentsRecursiveV2(thenBlock, thisScreenFields, dataModelFields, thisScreenFieldSet)
+			}
+			if elseBlock, ok := newComp["else"].([]any); ok {
+				newComp["else"] = sanitizeComponentsRecursiveV2(elseBlock, thisScreenFields, dataModelFields, thisScreenFieldSet)
+			}
+		}
+
+		result[i] = newComp
+	}
+
+	return result
+}
+
+func collectFormFieldNamesFromChildren(children []any) []string {
+	var fieldNames []string
+	for _, child := range children {
+		compMap, ok := child.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if name, ok := compMap["name"].(string); ok && name != "" {
+			sanitizedName := sanitizeID(name)
+			fieldNames = append(fieldNames, sanitizedName)
+		}
+
+		if compMap["type"] == "If" {
+			if thenBlock, ok := compMap["then"].([]any); ok {
+				fieldNames = append(fieldNames, collectFormFieldNamesFromChildren(thenBlock)...)
+			}
+			if elseBlock, ok := compMap["else"].([]any); ok {
+				fieldNames = append(fieldNames, collectFormFieldNamesFromChildren(elseBlock)...)
+			}
+		}
+	}
+	return fieldNames
+}
+
+// collectFormFieldNames collects all form field names from all screens
+// These are components that have a "name" attribute (TextInput, TextArea, Dropdown, etc.)
+func collectFormFieldNames(screens []any) []string {
+	var fieldNames []string
+
+	for _, screen := range screens {
+		screenMap, ok := screen.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		layout, ok := screenMap["layout"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		children, ok := layout["children"].([]any)
+		if !ok {
+			continue
+		}
+
+		fieldNames = append(fieldNames, collectFormFieldNamesFromChildren(children)...)
+	}
+
+	return fieldNames
+}
+
+// collectFormFieldsPerScreen collects form field names for each screen by index
+func collectFormFieldsPerScreen(screens []any) map[int][]string {
+	result := make(map[int][]string)
+
+	for i, screen := range screens {
+		screenMap, ok := screen.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		layout, ok := screenMap["layout"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		children, ok := layout["children"].([]any)
+		if !ok {
+			continue
+		}
+
+		fieldNames := collectFormFieldNamesFromChildren(children)
+
+		if len(fieldNames) > 0 {
+			result[i] = fieldNames
+		}
+	}
+
+	return result
+}
+
+// hasCompleteAction checks if any component has an on-click-action with name "complete"
+func hasCompleteAction(children []any) bool {
+	for _, child := range children {
+		compMap, ok := child.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if action, ok := compMap["on-click-action"].(map[string]any); ok {
+			if name, ok := action["name"].(string); ok && name == "complete" {
+				return true
+			}
+		}
+
+		if compMap["type"] == "If" {
+			if thenBlock, ok := compMap["then"].([]any); ok {
+				if hasCompleteAction(thenBlock) {
+					return true
+				}
+			}
+			if elseBlock, ok := compMap["else"].([]any); ok {
+				if hasCompleteAction(elseBlock) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// sanitizeID converts an ID to use only alphabets and underscores
+// e.g., "SCREEN_1" -> "SCREEN_A", "id_1234_abc" -> "id_abcd_abc"
+func sanitizeID(id string) string {
+	// Check if ID already only contains valid characters
+	valid := true
+	for _, c := range id {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') { //nolint:staticcheck // More readable than De Morgan's law
+			valid = false
+			break
+		}
+	}
+	if valid {
+		return id
+	}
+
+	// Replace numbers with letters
+	result := make([]byte, 0, len(id))
+	for _, c := range id {
+		if c >= '0' && c <= '9' {
+			// Convert 0-9 to A-J
+			result = append(result, byte('A'+c-'0'))
+		} else if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' {
+			result = append(result, byte(c))
+		}
+		// Skip other characters
+	}
+
+	return string(result)
+}
+
+// sanitizeComponentsWithPayload sanitizes components and auto-populates action payloads
+// - For navigate actions: passes current screen's form fields using ${form.fieldName}
+// - For complete actions: uses ${data.fieldName} for previous screens, ${form.fieldName} for current
+func sanitizeComponentsWithPayload(children []any, allFieldNames []string, fieldsFromPreviousScreens []string) []any {
+	// Collect this screen's field names
+	thisScreenFields := collectFormFieldNamesFromChildren(children)
+
+	// Create a set for quick lookup of this screen's fields
+	thisScreenFieldSet := make(map[string]bool)
+	for _, f := range thisScreenFields {
+		thisScreenFieldSet[f] = true
+	}
+
+	return sanitizeComponentsRecursive(children, allFieldNames, fieldsFromPreviousScreens, thisScreenFieldSet, thisScreenFields)
+}
+
+func sanitizeComponentsRecursive(children []any, allFieldNames []string, fieldsFromPreviousScreens []string, thisScreenFieldSet map[string]bool, thisScreenFields []string) []any {
+	result := make([]any, len(children))
+
+	for i, child := range children {
+		compMap, ok := child.(map[string]any)
+		if !ok {
+			result[i] = child
+			continue
+		}
+
+		// Create a new component map
+		newComp := make(map[string]any)
+		for k, v := range compMap {
+			newComp[k] = v
+		}
+
+		// Check if this component type should not have an id
+		compType, _ := newComp["type"].(string)
+		if componentsWithoutID[compType] {
+			delete(newComp, "id")
+		}
+
+		// Sanitize name field if it contains numbers
+		if name, ok := newComp["name"].(string); ok {
+			newComp["name"] = sanitizeID(name)
+		}
+
+		// Sanitize data-source option IDs
+		if dataSource, ok := newComp["data-source"].([]any); ok {
+			newDataSource := make([]any, len(dataSource))
+			for j, opt := range dataSource {
+				if optMap, ok := opt.(map[string]any); ok {
+					newOpt := make(map[string]any)
+					for k, v := range optMap {
+						newOpt[k] = v
+					}
+					if optID, ok := newOpt["id"].(string); ok {
+						newOpt["id"] = sanitizeID(optID)
+					}
+					newDataSource[j] = newOpt
+				} else {
+					newDataSource[j] = opt
+				}
+			}
+			newComp["data-source"] = newDataSource
+		}
+
+		// Auto-populate action payloads
+		if action, ok := newComp["on-click-action"].(map[string]any); ok {
+			actionName, _ := action["name"].(string)
+
+			newAction := make(map[string]any)
+			for k, v := range action {
+				newAction[k] = v
+			}
+
+			switch actionName {
+			case "complete":
+				payload := make(map[string]any)
+				
+				// Preserve existing payload
+				if existingPayload, ok := newAction["payload"].(map[string]any); ok {
+					for k, v := range existingPayload {
+						payload[k] = v
+					}
+				}
+
+				for _, fieldName := range fieldsFromPreviousScreens {
+					if _, exists := payload[fieldName]; !exists {
+						payload[fieldName] = "${data." + fieldName + "}"
+					}
+				}
+				for _, fieldName := range thisScreenFields {
+					if _, exists := payload[fieldName]; !exists {
+						payload[fieldName] = "${form." + fieldName + "}"
+					}
+				}
+				
+				newAction["payload"] = payload
+			case "navigate":
+				if len(thisScreenFields) > 0 || len(fieldsFromPreviousScreens) > 0 {
+					payload := make(map[string]any)
+					
+					// Preserve existing payload
+					if existingPayload, ok := newAction["payload"].(map[string]any); ok {
+						for k, v := range existingPayload {
+							payload[k] = v
+						}
+					}
+					
+					for _, fieldName := range fieldsFromPreviousScreens {
+						if _, exists := payload[fieldName]; !exists {
+							payload[fieldName] = "${data." + fieldName + "}"
+						}
+					}
+					for _, fieldName := range thisScreenFields {
+						if _, exists := payload[fieldName]; !exists {
+							payload[fieldName] = "${form." + fieldName + "}"
+						}
+					}
+					
+					newAction["payload"] = payload
+				}
+			}
+
+			newComp["on-click-action"] = newAction
+		}
+
+		if compType == "If" {
+			if thenBlock, ok := newComp["then"].([]any); ok {
+				newComp["then"] = sanitizeComponentsRecursive(thenBlock, allFieldNames, fieldsFromPreviousScreens, thisScreenFieldSet, thisScreenFields)
+			}
+			if elseBlock, ok := newComp["else"].([]any); ok {
+				newComp["else"] = sanitizeComponentsRecursive(elseBlock, allFieldNames, fieldsFromPreviousScreens, thisScreenFieldSet, thisScreenFields)
+			}
 		}
 
 		result[i] = newComp


### PR DESCRIPTION
Add a per-flow submission responses view accessible from the 'Responses' button on published flows in the Flows page.

Backend:
- New GET /api/flow-submissions/:id endpoint returning per-flow submissions
- Register route in main.go

Frontend:
- New FlowResponsesView.vue showing submissions table with dynamic columns, CSV export, live polling, and 'Back to Flows' navigation
- Add 'Responses' button on published flows in FlowsView
- Add route and API service method
- Add i18n translation key for Flow Responses nav item